### PR TITLE
chore: release v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-core"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "clap",
  "directories",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 version = "0.4.1"
 
 [workspace.package]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]

--- a/crates/redisctl-core/CHANGELOG.md
+++ b/crates/redisctl-core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/redis/redisctl/compare/redisctl-core-v0.11.1...redisctl-core-v0.12.0) - 2026-08-11
+
+### Other
+
+- *(mcp)* stabilize the library embedding API ([#1097](https://github.com/redis/redisctl/pull/1097))
+- harden project maintenance and release hygiene ([#1069](https://github.com/redis/redisctl/pull/1069))
+- *(core)* centralize API client resolution ([#1071](https://github.com/redis/redisctl/pull/1071))
+- remove dead resilience flags and modules ([#1050](https://github.com/redis/redisctl/pull/1050))
+- migrate to redis-cloud 0.11.0 (handle breaking changes) ([#1028](https://github.com/redis/redisctl/pull/1028))
+
 ## [0.11.0](https://github.com/redis-developer/redisctl/compare/redisctl-core-v0.10.1...redisctl-core-v0.11.0) - 2026-03-20
 
 ### Fixed

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/redis/redisctl/compare/redisctl-mcp-v0.11.1...redisctl-mcp-v0.12.0) - 2026-08-11
+
+### Fixed
+
+- *(enterprise)* migrate to redis-enterprise 0.10 ([#1081](https://github.com/redis/redisctl/pull/1081))
+- *(cloud)* add mock tests locking in tags/plans surfacing after 0.11 upgrade ([#1029](https://github.com/redis/redisctl/pull/1029))
+
+### Other
+
+- *(mcp)* stabilize the library embedding API ([#1097](https://github.com/redis/redisctl/pull/1097))
+- *(mcp)* establish catalog compatibility contract ([#1096](https://github.com/redis/redisctl/pull/1096))
+- correct compose file path in Docker integration test doc comments ([#1076](https://github.com/redis/redisctl/pull/1076))
+- *(mcp)* cover enterprise write lifecycles ([#1074](https://github.com/redis/redisctl/pull/1074))
+- *(mcp)* cover tolerant numeric tool inputs ([#1073](https://github.com/redis/redisctl/pull/1073))
+- harden project maintenance and release hygiene ([#1069](https://github.com/redis/redisctl/pull/1069))
+- *(core)* centralize API client resolution ([#1071](https://github.com/redis/redisctl/pull/1071))
+- remove non-functional MCP OAuth surface and dead McpError ([#1053](https://github.com/redis/redisctl/pull/1053))
+- remove dead resilience flags and modules ([#1050](https://github.com/redis/redisctl/pull/1050))
+- *(mcp)* cover fixed-plan cloud tools request shapes ([#997](https://github.com/redis/redisctl/pull/997)) ([#1032](https://github.com/redis/redisctl/pull/1032))
+- *(mcp)* cover all redis_seed data types and error paths ([#1031](https://github.com/redis/redisctl/pull/1031))
+- *(mcp)* add request-shape tests for cloud account write/destructive tools ([#1025](https://github.com/redis/redisctl/pull/1025))
+- migrate to redis-cloud 0.11.0 (handle breaking changes) ([#1028](https://github.com/redis/redisctl/pull/1028))
+
 ## [0.11.1](https://github.com/redis/redisctl/compare/redisctl-mcp-v0.11.0...redisctl-mcp-v0.11.1) - 2026-06-11
 
 ### Other

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -43,7 +43,7 @@ tower-mcp = { version = "0.8.2", features = ["http", "dynamic-tools"] }
 schemars = "1.2"
 
 # Internal crates
-redisctl-core = { version = "0.11.1", path = "../redisctl-core" }
+redisctl-core = { version = "0.12.0", path = "../redisctl-core" }
 
 # External API clients (optional, gated by features)
 redis-cloud = { workspace = true, optional = true }

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/redis/redisctl/compare/redisctl-v0.11.1...redisctl-v0.12.0) - 2026-08-11
+
+### Added
+
+- *(cli)* give failures a taxonomy exit code instead of a blanket 1 ([#1058](https://github.com/redis/redisctl/pull/1058))
+- *(cli)* emit a structured error envelope under -o json/yaml ([#1048](https://github.com/redis/redisctl/pull/1048))
+
+### Fixed
+
+- *(enterprise)* migrate to redis-enterprise 0.10 ([#1081](https://github.com/redis/redisctl/pull/1081))
+- *(cli)* standardize confirmation bypass flags ([#1070](https://github.com/redis/redisctl/pull/1070))
+- *(cli)* report a nonexistent profile as ProfileNotFound ([#1061](https://github.com/redis/redisctl/pull/1061))
+- *(cli)* make a declined confirmation exit non-zero ([#1059](https://github.com/redis/redisctl/pull/1059))
+- *(cli)* send tracing to stderr so -o json stays clean ([#1046](https://github.com/redis/redisctl/pull/1046))
+- *(cli)* stop labeling anyhow-wrapped errors "Configuration error" ([#1047](https://github.com/redis/redisctl/pull/1047))
+- *(cli)* unify confirmation prompts and fail non-interactive deletes ([#1044](https://github.com/redis/redisctl/pull/1044))
+- *(cli)* stop cm-settings import panicking on duplicate -f short ([#1043](https://github.com/redis/redisctl/pull/1043))
+
+### Other
+
+- *(mcp)* stabilize the library embedding API ([#1097](https://github.com/redis/redisctl/pull/1097))
+- define 1.0 compatibility policy ([#1094](https://github.com/redis/redisctl/pull/1094))
+- correct compose file path in Docker integration test doc comments ([#1076](https://github.com/redis/redisctl/pull/1076))
+- add TESTING.md covering test tiers, Docker suites, and CI gates ([#1075](https://github.com/redis/redisctl/pull/1075))
+- harden project maintenance and release hygiene ([#1069](https://github.com/redis/redisctl/pull/1069))
+- *(core)* centralize API client resolution ([#1071](https://github.com/redis/redisctl/pull/1071))
+- *(cli)* use the canonical dispatch pattern for alerts and license ([#1056](https://github.com/redis/redisctl/pull/1056))
+- drop the redundant redisctl lib target ([#1051](https://github.com/redis/redisctl/pull/1051))
+- remove dead resilience flags and modules ([#1050](https://github.com/redis/redisctl/pull/1050))
+- post-0.11.1 cleanup ([#1023](https://github.com/redis/redisctl/pull/1023))
+
 ## [0.11.1](https://github.com/redis/redisctl/compare/redisctl-v0.11.0...redisctl-v0.11.1) - 2026-06-11
 
 ### Other

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-redisctl-core = { version = "0.11.1", path = "../redisctl-core" }
+redisctl-core = { version = "0.12.0", path = "../redisctl-core" }
 redis-cloud = { workspace = true, features = ["tower-integration"] }
 redis-enterprise = { workspace = true, features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `redisctl-core`: 0.11.1 -> 0.12.0 (⚠ API breaking changes)
* `redisctl`: 0.11.1 -> 0.12.0
* `redisctl-mcp`: 0.11.1 -> 0.12.0 (⚠ API breaking changes)

### ⚠ `redisctl-core` breaking changes

```text
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod redisctl_core::config::resilience, previously in file /tmp/.tmptQEVJw/redisctl-core/src/config/resilience.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct redisctl_core::config::resilience::RateLimitConfig, previously in file /tmp/.tmptQEVJw/redisctl-core/src/config/resilience.rs:88
  struct redisctl_core::config::resilience::ResilienceConfig, previously in file /tmp/.tmptQEVJw/redisctl-core/src/config/resilience.rs:10
  struct redisctl_core::config::ResilienceConfig, previously in file /tmp/.tmptQEVJw/redisctl-core/src/config/resilience.rs:10
  struct redisctl_core::ResilienceConfig, previously in file /tmp/.tmptQEVJw/redisctl-core/src/config/resilience.rs:10
  struct redisctl_core::config::resilience::RetryConfig, previously in file /tmp/.tmptQEVJw/redisctl-core/src/config/resilience.rs:57
  struct redisctl_core::config::resilience::CircuitBreakerConfig, previously in file /tmp/.tmptQEVJw/redisctl-core/src/config/resilience.rs:26

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field resilience of struct Profile, previously in file /tmp/.tmptQEVJw/redisctl-core/src/config/config.rs:52
  field resilience of struct Profile, previously in file /tmp/.tmptQEVJw/redisctl-core/src/config/config.rs:52
  field resilience of struct Profile, previously in file /tmp/.tmptQEVJw/redisctl-core/src/config/config.rs:52
```

### ⚠ `redisctl-mcp` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum CredentialSource in /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/state.rs:28

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum redisctl_mcp::state::CredentialSource, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/state.rs:28
  enum redisctl_mcp::audit::AuditLevel, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/audit.rs:24
  enum redisctl_mcp::policy::ToolsetKind, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/policy.rs:227
  enum redisctl_mcp::policy::SafetyTier, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/policy.rs:22
  enum redisctl_mcp::error::McpError, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/error.rs:8
  enum redisctl_mcp::McpError, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/error.rs:8

--- failure enum_now_doc_hidden: pub enum is now #[doc(hidden)] ---

Description:
A pub enum is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_now_doc_hidden.ron

Failed in:
  enum HttpMethod in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/raw.rs:16
  enum HttpMethod in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/raw.rs:16

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant CredentialSource::OAuth, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/state.rs:33

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function redisctl_mcp::prompts::capacity_planning_prompt, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/prompts.rs:133
  function redisctl_mcp::tools::enterprise::get_database_endpoints, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/databases.rs:145
  function redisctl_mcp::resources::help_resource, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/resources.rs:69
  function redisctl_mcp::serde_helpers::string_or_u64::deserialize, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:52
  function redisctl_mcp::serde_helpers::string_or_opt_usize::deserialize, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:114
  function redisctl_mcp::tools::enterprise::validate_license, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/cluster.rs:290
  function redisctl_mcp::prompts::analyze_performance_prompt, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/prompts.rs:72
  function redisctl_mcp::resources::profiles_resource, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/resources.rs:35
  function redisctl_mcp::tools::enterprise::get_proxy_stats, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/proxy.rs:44
  function redisctl_mcp::tools::enterprise::create_debug_info, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/observability.rs:280
  function redisctl_mcp::tools::enterprise::list_debug_info_tasks, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/observability.rs:251
  function redisctl_mcp::serde_helpers::string_or_opt_i64::deserialize, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:31
  function redisctl_mcp::serde_helpers::string_or_usize::deserialize, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:92
  function redisctl_mcp::tools::enterprise::get_debug_info_status, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/observability.rs:264
  function redisctl_mcp::audit::redact_value, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/audit.rs:205
  function redisctl_mcp::prompts::troubleshoot_database_prompt, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/prompts.rs:11
  function redisctl_mcp::resources::config_path_resource, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/resources.rs:10
  function redisctl_mcp::policy::show_policy_tool, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/policy.rs:537
  function redisctl_mcp::serde_helpers::string_or_i64::deserialize, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:12
  function redisctl_mcp::serde_helpers::string_or_opt_u64::deserialize, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:71
  function redisctl_mcp::tools::enterprise::get_enterprise_builtin_roles, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/rbac.rs:308
  function redisctl_mcp::serde_helpers::string_or_f64::deserialize, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:142
  function redisctl_mcp::presets::resolve_visible_tools, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/presets.rs:146
  function redisctl_mcp::presets::list_available_tools_tool, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/presets.rs:252
  function redisctl_mcp::prompts::migration_planning_prompt, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/prompts.rs:192

--- failure function_now_doc_hidden: pub function is now #[doc(hidden)] ---

Description:
A pub function is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_now_doc_hidden.ron

Failed in:
  function append in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:796
  function create_enterprise_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:230
  function list_fixed_plans in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:179
  function upgrade_database_redis_version in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:878
  function get_subscription_maintenance_windows in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:325
  function get_cloud_account in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:736
  function get_fixed_database_upgrade_status in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:748
  function delete_acl_role in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:462
  function tool_names in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/mod.rs:66
  function mset in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:535
  function upgrade_enterprise_database_redis in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:393
  function seed in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/bulk.rs:177
  function get_tags in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:237
  function get_fixed_plans_by_subscription in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:200
  function get_active_active_regions in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:341
  function llen in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:935
  function object_encoding in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:281
  function slowlog in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:112
  function tool_names in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/profile.rs:28
  function create_cloud_account in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:752
  function config_path in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/profile.rs:293
  function get_license_usage in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:257
  function get_enterprise_user_permissions in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:177
  function lrange in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:117
  function list_database_alerts in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:145
  function list_alerts in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:28
  function ft_dictdump in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:501
  function get_aa_psc_endpoints in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:974
  function zrank in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:770
  function list_tasks in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:640
  function get_all_shards_stats in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:157
  function get_fixed_plan in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:216
  function hexpire in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1423
  function get_enterprise_cluster_services in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:527
  function json_arrappend in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:276
  function get_psc_creation_script in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:868
  function sunion in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:637
  function json_arrpop in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:411
  function update_database_tag in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:944
  function backup_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:554
  function update_license in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:302
  function acknowledge_enterprise_alert in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:41
  function import_fixed_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:533
  function pubsub_channels in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:365
  function list_profiles in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/profile.rs:51
  function get_task in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:653
  function json_objlen in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:156
  function list_shards in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:174
  function get_fixed_redis_versions in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:232
  function update_cloud_account in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:791
  function flush_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:1159
  function get_aa_tgw_attachments in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:498
  function ft_explain in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:377
  function remove_aa_private_link_principals in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1445
  function rename in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:476
  function update_subscription_maintenance_windows in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:791
  function update_proxy in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/proxy.rs:43
  function ft_list in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:131
  function credential_error in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/mod.rs:34
  function get_enterprise_ldap_config in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:444
  function update_fixed_subscription in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:125
  function get_shard in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:195
  function delete_cloud_account in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:831
  function delete_fixed_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:447
  function zrange in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:188
  function import_enterprise_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:195
  function reject_tgw_invitation in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:400
  function hdel in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1012
  function update_enterprise_ldap_config in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:457
  function json_toggle in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:341
  function delete_fixed_subscription in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:162
  function get_fixed_database_upgrade_versions in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:730
  function list_shards_by_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:211
  function dump in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:644
  function get_aa_private_link in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1354
  function xtrim in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1362
  function create_private_link in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1213
  function ft_aliasdel in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:818
  function update_enterprise_crdb in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:486
  function get_slow_log in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:216
  function create_subscription in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:631
  function get_cluster_policy in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:112
  function zremrangebyscore in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:905
  function memory_usage in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:258
  function list_shards_by_node in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:227
  function list_fixed_subscriptions in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:60
  function list_proxies in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/proxy.rs:14
  function enterprise_raw_api in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/raw.rs:43
  function update_enterprise_acl in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:361
  function delete_private_link in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1247
  function delete_enterprise_crdb in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:504
  function ft_syndump in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:474
  function update_cluster_policy in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:126
  function ft_dictadd in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:716
  function sismember in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:613
  function get_fixed_subscription in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:74
  function get_proxy in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/proxy.rs:27
  function zadd in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1208
  function cloud_raw_api in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/raw.rs:43
  function hlen in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:493
  function delete_enterprise_acl in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:390
  function list_enterprise_crdbs in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:429
  function get_session_logs in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:121
  function router in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/profile.rs:940
  function xlen in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:346
  function delete_tgw_attachment in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:476
  function lpop in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1096
  function get_enterprise_crdb in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:439
  function get_vpc_peering in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:76
  function validate_config in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/profile.rs:321
  function get_regions in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:141
  function list_roles in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:194
  function get_cluster in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:42
  function update_fixed_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:377
  function remove_private_link_principals in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1298
  function update_service in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/services.rs:80
  function ft_create in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:530
  function accept_tgw_invitation in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:382
  function get_enterprise_crdb_tasks in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:455
  function get_role in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:204
  function update_fixed_database_tags in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:689
  function copy in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:608
  function create_acl_role in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:380
  function get_private_link_endpoint_script in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1334
  function start_service in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/services.rs:97
  function json_mget in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:64
  function ft_dropindex in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:791
  function create_enterprise_crdb in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:471
  function decr in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:777
  function list_nodes in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:325
  function add_active_active_region in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:831
  function exists in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:234
  function key_summary in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/diagnostics.rs:182
  function stop_service in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/services.rs:115
  function keys in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:54
  function ft_tagvals in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:446
  function get_node in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:335
  function srem in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1180
  function list_services in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/services.rs:34
  function restart_service in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/services.rs:133
  function delete_aa_vpc_peering in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:328
  function create_fixed_database_tag in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:604
  function delete_aa_psc_endpoint in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1097
  function hmget in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:462
  function ft_search in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:174
  function get_system_logs in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:101
  function create_aa_private_link in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1372
  function delete_database_tag in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:1255
  function reject_aa_tgw_invitation in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:558
  function delete_aa_psc_service in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:956
  function xrange in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:298
  function update_account_user in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:204
  function zscore in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:742
  function update_tgw_attachment_cidrs in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:443
  function delete_psc_endpoint in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:848
  function get_service in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/services.rs:48
  function delete_vpc_peering in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:198
  function router in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/mod.rs:80
  function get_tgw_attachments in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:350
  function create_profile in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/profile.rs:798
  function delete_account_user in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:231
  function json_objkeys in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:136
  function enable_maintenance_mode in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:147
  function update_acl_user in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:336
  function delete_subscription in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:1133
  function ft_aggregate in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:307
  function get_service_status in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/services.rs:64
  function get_aa_vpc_peering in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:220
  function expire in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:446
  function update_subscription_cidr_allowlist in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:760
  function getrange in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:837
  function get_tgw_invitations in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:366
  function sub_router in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/mod.rs:99
  function get_aa_psc_deletion_script in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1151
  function delete_acl_user in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:364
  function info in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:42
  function hset in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:982
  function list_databases in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:44
  function json_arrinsert in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:307
  function set_default_cloud in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/profile.rs:595
  function incr in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:758
  function get_modules in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:158
  function json_arrtrim in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:438
  function ttl in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:212
  function flushdb in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:326
  function health_check in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/diagnostics.rs:74
  function dbsize in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:63
  function import_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:588
  function list_modules in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:247
  function list_logs in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:65
  function get_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:86
  function get_backup_status in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:191
  function client_list in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:78
  function get_module in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:260
  function update_aa_vpc_peering in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:295
  function restore_enterprise_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:369
  function get_account in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:88
  function create_aa_psc_service in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:938
  function ft_synupdate in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:684
  function scard in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:594
  function update_vpc_peering in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:144
  function cluster_info in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:95
  function update_enterprise_role in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:251
  function redis_command in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/raw.rs:91
  function hgetall in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:83
  function router in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/mod.rs:96
  function delete_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:1103
  function json_numincrby in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:251
  function rpush in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1068
  function sub_router in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/mod.rs:68
  function json_clear in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:389
  function delete_enterprise_role in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:283
  function create_database_tag in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:912
  function alias_delete in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/aliases.rs:119
  function update_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:486
  function get_fixed_database_import_status in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:515
  function list_users in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:38
  function ping in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:27
  function sub_tool_names in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/mod.rs:91
  function touch in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:732
  function update_redis_rule in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:501
  function list_acl_users in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:251
  function key_type in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:196
  function delete_fixed_database_tag in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:669
  function disable_maintenance_mode in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:164
  function get_psc_endpoints in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:741
  function get_user in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:48
  function config_set in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:302
  function backup_enterprise_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:169
  function json_get in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:40
  function zcount in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:798
  function ft_aliasupdate in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:766
  function delete_redis_rule in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:527
  function get_acl_user in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:264
  function export_enterprise_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:351
  function create_psc_endpoint in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:759
  function get_database_import_status in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:396
  function ft_profile in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:399
  function get_aa_psc_service in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:920
  function set_default_enterprise in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/profile.rs:646
  function list_account_users in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:175
  function sadd in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1152
  function delete_aa_tgw_attachment in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:665
  function setnx in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:887
  function zrangebyscore in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:823
  function bulk_load in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/bulk.rs:58
  function hvals in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:564
  function generate_cost_report in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:547
  function get_all_nodes_stats in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:115
  function alias_run in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/aliases.rs:54
  function hget in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:437
  function create_enterprise_acl in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:332
  function get_fixed_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:275
  function delete_active_active_regions in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:1215
  function accept_aa_tgw_invitation in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:534
  function get_account_user in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:188
  function zcard in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:723
  function get_psc_service in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:693
  function update_psc_endpoint in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:801
  function update_cluster_certificates in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:213
  function create_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:418
  function download_cost_report in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:600
  function alias_list in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/aliases.rs:95
  function restore in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:676
  function backup_fixed_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:487
  function hotkeys in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/diagnostics.rs:265
  function sub_router in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/mod.rs:82
  function json_arrlen in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:116
  function create_psc_service in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:709
  function hincrby in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1397
  function create_acl_user in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:310
  function show_profile in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/profile.rs:184
  function sub_tool_names in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/mod.rs:60
  function del in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:422
  function update_subscription in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:714
  function create_fixed_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:294
  function upgrade_fixed_database_redis_version in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:766
  function randomkey in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:717
  function connection_summary in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/diagnostics.rs:382
  function get in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:174
  function delete_psc_service in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:725
  function add_private_link_principals in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1263
  function add_aa_private_link_principals in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1408
  function create_aa_tgw_attachment in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:582
  function tool_names in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/mod.rs:83
  function lindex in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:954
  function create_fixed_subscription in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:91
  function unlink in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:584
  function router in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/mod.rs:183
  function flush_enterprise_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:325
  function get_database_upgrade_status in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:375
  function get_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:173
  function object_idletime in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:325
  function get_psc_deletion_script in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:892
  function update_database_tags in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:981
  function get_cluster_certificates in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:184
  function hkeys in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:536
  function alias_set in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/aliases.rs:21
  function xadd in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1299
  function wait_for_cloud_task in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:669
  function get_private_link in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1197
  function json_strlen in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:176
  function list_fixed_databases in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:252
  function create_enterprise_user in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:64
  function object_help in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:345
  function sdiff in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:693
  function latency_history in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:203
  function list_acl_roles in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:280
  function get_fixed_database_tags in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:586
  function update_aa_psc_endpoint in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1047
  function delete_profile in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/profile.rs:697
  function acl_list in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:245
  function update_crdb_local_properties in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:1020
  function update_enterprise_user in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:109
  function lpush in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1040
  function json_del in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:367
  function set in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:363
  function get_all_databases_stats in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:128
  function update_enterprise_node in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:486
  function list_subscriptions in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:127
  function sub_tool_names in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/mod.rs:74
  function scan in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:105
  function acl_whoami in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:266
  function ft_dictdel in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:836
  function get_license in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:247
  function delete_enterprise_user in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:154
  function tool_names in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/mod.rs:52
  function strlen in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:818
  function get_node_stats in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:351
  function update_enterprise_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:288
  function list_payment_methods in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:623
  function get_shard_stats in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/observability.rs:141
  function remove_enterprise_node in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:504
  function get_subscription in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:140
  function create_redis_rule in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:478
  function update_fixed_database_tag in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:634
  function get_aa_psc_creation_script in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1124
  function persist in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:558
  function module_list in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:279
  function get_database_certificate in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:255
  function enable_node_maintenance in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:398
  function delete_enterprise_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:306
  function ft_aliasadd in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:745
  function get_available_database_versions in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:357
  function list_databases in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:157
  function object_freq in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:304
  function config_get in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:155
  function zrem in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1271
  function hexists in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:512
  function validate_enterprise_acl in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:413
  function smembers in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:160
  function get_subscription_pricing in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:276
  function disable_node_maintenance in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:419
  function list_redis_acls in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:306
  function sinter in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:665
  function rpop in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1124
  function update_aa_tgw_attachment_cidrs in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:625
  function create_aa_psc_endpoint in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:998
  function memory_stats in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:190
  function setrange in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:861
  function create_aa_vpc_peering in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:236
  function get_cluster_stats in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:55
  function get_fixed_database_slow_log in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:564
  function get_redis_versions in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:292
  function pubsub_numsub in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:396
  function rebalance_node in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:440
  function get_redis_acl in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:316
  function create_vpc_peering in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:92
  function flush_crdb_database in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:1189
  function get_aa_tgw_invitations in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:516
  function get_aa_private_link_endpoint_script in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:1487
  function ft_alter in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:656
  function mget in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:498
  function ft_info in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:151
  function rotate_cluster_certificates in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:197
  function create_enterprise_role in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:220
  function update_cluster in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:96
  function get_subscription_cidr_allowlist in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:309
  function drain_node in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:461
  function list_cloud_accounts in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:722
  function update_acl_role in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:418
  function get_fixed_database_backup_status in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:469
  function xinfo_stream in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:277
  function json_type in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:96
  function list_redis_rules in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:293
  function json_set in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:200
  function create_tgw_attachment in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:418
  function get_database_stats in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:102

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  AppState::test_policy, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/state.rs:524
  AppState::test_write_policy, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/state.rs:533
  AppState::with_cloud_client_write, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/state.rs:547
  AppState::with_cloud_client, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/state.rs:555
  AppState::with_enterprise_client, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/state.rs:580
  AppState::with_clients, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/state.rs:605

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod redisctl_mcp::audit, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/audit.rs:1
  mod redisctl_mcp::state, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/state.rs:1
  mod redisctl_mcp::serde_helpers::string_or_opt_i64, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:27
  mod redisctl_mcp::error, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/error.rs:1
  mod redisctl_mcp::serde_helpers::string_or_usize, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:88
  mod redisctl_mcp::policy, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/policy.rs:1
  mod redisctl_mcp::serde_helpers, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:1
  mod redisctl_mcp::presets, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/presets.rs:1
  mod redisctl_mcp::serde_helpers::string_or_i64, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:8
  mod redisctl_mcp::serde_helpers::string_or_opt_u64, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:67
  mod redisctl_mcp::serde_helpers::string_or_f64, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:138
  mod redisctl_mcp::prompts, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/prompts.rs:1
  mod redisctl_mcp::resources, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/resources.rs:1
  mod redisctl_mcp::serde_helpers::string_or_u64, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:48
  mod redisctl_mcp::serde_helpers::string_or_opt_usize, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/serde_helpers.rs:110

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  DATABASE_ESSENTIALS in file /tmp/.tmptQEVJw/redisctl-mcp/src/presets.rs:100
  ENTERPRISE_ESSENTIALS in file /tmp/.tmptQEVJw/redisctl-mcp/src/presets.rs:78
  RAW_TOOL_DENY_DEFAULTS in file /tmp/.tmptQEVJw/redisctl-mcp/src/policy.rs:115
  CLOUD_ESSENTIALS in file /tmp/.tmptQEVJw/redisctl-mcp/src/presets.rs:54
  SYSTEM_TOOLS in file /tmp/.tmptQEVJw/redisctl-mcp/src/presets.rs:307
  APP_ESSENTIALS in file /tmp/.tmptQEVJw/redisctl-mcp/src/presets.rs:127

--- failure pub_module_level_const_now_doc_hidden: pub module-level const is now #[doc(hidden)] ---

Description:
A public const is now marked #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/pub_module_level_const_now_doc_hidden.ron

Failed in:
  SUB_MODULES in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/mod.rs:34
  SUB_MODULES in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/mod.rs:28
  TOOL_NAMES in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/profile.rs:16
  SUB_MODULES in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/mod.rs:43

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct redisctl_mcp::policy::Policy, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/policy.rs:248
  struct redisctl_mcp::audit::AuditLayer, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/audit.rs:68
  struct redisctl_mcp::tools::enterprise::GetEnterpriseBuiltinRolesInput, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/rbac.rs:308
  struct redisctl_mcp::policy::ToolsetPolicy, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/policy.rs:45
  struct redisctl_mcp::state::AppState, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/state.rs:50
  struct redisctl_mcp::audit::AuditService, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/audit.rs:97
  struct redisctl_mcp::tools::enterprise::GetDatabaseEndpointsInput, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/databases.rs:145
  struct redisctl_mcp::tools::enterprise::ValidateLicenseInput, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/cluster.rs:290
  struct redisctl_mcp::audit::AuditConfig, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/audit.rs:39
  struct redisctl_mcp::policy::ToolsetPolicySummary, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/policy.rs:514
  struct redisctl_mcp::policy::PolicyConfig, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/policy.rs:63
  struct redisctl_mcp::policy::PolicySummary, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/policy.rs:496
  struct redisctl_mcp::tools::enterprise::GetProxyStatsInput, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/proxy.rs:44
  struct redisctl_mcp::tools::enterprise::CreateDebugInfoInput, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/observability.rs:280
  struct redisctl_mcp::presets::ToolVisibility, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/presets.rs:218
  struct redisctl_mcp::tools::enterprise::ListDebugInfoTasksInput, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/observability.rs:251
  struct redisctl_mcp::presets::ToolsConfig, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/presets.rs:30
  struct redisctl_mcp::tools::enterprise::GetDebugInfoStatusInput, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/tools/enterprise/observability.rs:264
  struct redisctl_mcp::state::CachedClients, previously in file /tmp/.tmptQEVJw/redisctl-mcp/src/state.rs:40

--- failure struct_now_doc_hidden: pub struct is now #[doc(hidden)] ---

Description:
A pub struct is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_now_doc_hidden.ron

Failed in:
  struct DeleteDatabaseInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:1103
  struct JsonNumincrbyInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:251
  struct RpushInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:1068
  struct JsonClearInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:389
  struct DeleteEnterpriseRoleInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:283
  struct CreateDatabaseTagInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:912
  struct AliasDeleteInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/aliases.rs:119
  struct UpdateDatabaseInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:486
  struct GetFixedDatabaseImportStatusInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:515
  struct SubModule in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/mod.rs:11
  struct ListUsersInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:38
  struct PingInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:27
  struct Command in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/bulk.rs:12
  struct TouchInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:732
  struct UpdateRedisRuleInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:501
  struct ListAclUsersInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:251
  struct KeyTypeInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:196
  struct DeleteFixedDatabaseTagInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/fixed.rs:669
  struct DisableMaintenanceModeInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/cluster.rs:164
  struct GetPscEndpointsInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:741
  struct GetUserInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/rbac.rs:48
  struct ConfigSetInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:302
  struct BackupEnterpriseDatabaseInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:169
  struct JsonGetInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/json.rs:40
  struct ZcountInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:798
  struct FtAliasupdateInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:766
  struct DeleteRedisRuleInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:527
  struct GetAclUserInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/account.rs:264
  struct ExportEnterpriseDatabaseInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/enterprise/databases.rs:351
  struct ActiveActiveRegionToDeleteInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:66
  struct CreatePscEndpointInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:759
  struct GetDatabaseImportStatusInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs:396
  struct FtProfileInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:399
  struct GetAaPscServiceInput in file /tmp/.tmpM5ALj6/redisctl/crates/redisctl-mcp/src/tools/cloud/networking.rs:920
  struct SetDefaultEnterpriseInput in file /tmp/.tmpM5ALj6/redisctl/crates/redis