### PR TITLE
docs: correct compose file path in Docker integration test doc comments

### DIFF
--- a/crates/redisctl-mcp/tests/enterprise_mcp_docker_integration_tests.rs
+++ b/crates/redisctl-mcp/tests/enterprise_mcp_docker_integration_tests.rs
@@ -2,13 +2,13 @@
 //! Docker-backed Enterprise MCP live-integration tests.
 //!
 //! Requires the local Enterprise demo cluster:
-//!   docker compose up -d
-//!   docker compose logs -f redis-enterprise-init  # wait for ready
+//!   docker compose -f docker/docker-compose.enterprise-demo.yml up -d
+//!   docker compose -f docker/docker-compose.enterprise-demo.yml logs -f redis-enterprise-init  # wait for ready
 //!
 //! Run with:
 //!   cargo test --test enterprise_mcp_docker_integration_tests --features enterprise -- --ignored
 //!
-//! Env vars (set by docker-compose.yml):
+//! Env vars (set by docker/docker-compose.enterprise-demo.yml):
 //!   REDIS_ENTERPRISE_URL=https://localhost:9443
 //!   REDIS_ENTERPRISE_USER=admin@redis.local
 //!   REDIS_ENTERPRISE_PASSWORD=Redis123!

--- a/crates/redisctl/tests/enterprise_docker_integration_tests.rs
+++ b/crates/redisctl/tests/enterprise_docker_integration_tests.rs
@@ -3,9 +3,9 @@
 //! These tests require a running Redis Enterprise cluster via Docker Compose:
 //!
 //! ```bash
-//! docker compose up -d
+//! docker compose -f docker/docker-compose.enterprise-demo.yml up -d
 //! # Wait for initialization
-//! docker compose logs -f redis-enterprise-init
+//! docker compose -f docker/docker-compose.enterprise-demo.yml logs -f redis-enterprise-init
 //! ```
 //!
 //! Run tests with:
@@ -13,7 +13,7 @@
 //! cargo test --test enterprise_docker_integration_tests -- --ignored
 //! ```
 //!
-//! Environment variables (set by docker-compose.yml):
+//! Environment variables (set by docker/docker-compose.enterprise-demo.yml):
 //! - REDIS_ENTERPRISE_URL: https://localhost:9443
 //! - REDIS_ENTERPRISE_USER: admin@redis.local
 //! - REDIS_ENTERPRISE_PASSWORD: Redis123!


### PR DESCRIPTION
## Problem

The module doc comments in the two Docker-backed integration test files instruct the reader to start the cluster with:

```bash
docker compose up -d
docker compose logs -f redis-enterprise-init
```

There is no compose file at the repository root, so both commands fail. The Enterprise demo cluster is defined in `docker/docker-compose.enterprise-demo.yml` (services `redis-enterprise` on 9443 and `redis-enterprise-init`).

## Change

Comment-only. In `crates/redisctl/tests/enterprise_docker_integration_tests.rs` and `crates/redisctl-mcp/tests/enterprise_mcp_docker_integration_tests.rs`:

- `docker compose up -d` -> `docker compose -f docker/docker-compose.enterprise-demo.yml up -d`
- the matching `docker compose logs -f redis-enterprise-init` gets the same `-f` path
- the "set by docker-compose.yml" note now names `docker/docker-compose.enterprise-demo.yml`

No test behavior changes. The same wrong command was corrected in `CONTRIBUTING.md` in #1075; these two files were out of scope there.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p redisctl --test enterprise_docker_integration_tests` (4 passed, 40 ignored as expected without Docker)
- Confirmed `docker/docker-compose.enterprise-demo.yml` exists and defines the `redis-enterprise-init` service and port 9443
