### PR TITLE
chore(ci): correct stale Action version annotations

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -42,7 +42,7 @@ jobs:
           toolchain: stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install and run cargo-deny
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: "v1-rust"
           shared-key: "quick"
@@ -81,7 +81,7 @@ jobs:
           toolchain: stable
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: "v1-rust"
           shared-key: "test-${{ matrix.package }}"
@@ -103,7 +103,7 @@ jobs:
           toolchain: stable
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: "v1-rust"
           shared-key: "integration"
@@ -136,7 +136,7 @@ jobs:
           toolchain: stable
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: "v1-rust"
           shared-key: "build"
@@ -164,7 +164,7 @@ jobs:
           toolchain: stable
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: "v1-rust"
           shared-key: "coverage"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -121,7 +121,7 @@ jobs:
           toolchain: stable
 
       - name: Cache cargo registry
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: "v1-rust"
           shared-key: "doc"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,7 +37,7 @@ jobs:
           toolchain: 1.90
 
       - name: Cache cargo registry
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,7 @@ in detail.
 5. When complete and green, mark the PR “Ready for review”.
 6. Prefer “Squash and merge” to produce a clean, single commit on `main`.
 7. Reference and close related issues in the PR description.
+8. When updating a full-SHA GitHub Action pin, keep its trailing release-version annotation in sync.
 
 ## Release Process
 


### PR DESCRIPTION
## Summary

- Correct all eight `Swatinem/rust-cache` annotations from v2.9.1 to v2.9.2, matching the full SHA merged in #1082.
- Document the repository convention that a full-SHA Action pin and its trailing release annotation must be updated together.

## Issue in scope

- Closes #1091

## Root cause

The grouped Dependabot update changed the `rust-cache` SHA but left its exact-version comments unchanged. Other Action annotations in that update are correct.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Audited every `rust-cache` occurrence across `.github/workflows/`

This PR is intentionally limited to CI metadata and workflow hygiene; it does not publish 0.12.0 or modify release contents.
