### PR TITLE
feat(cli): add hidden redisctl init skeleton with project detection

### DIFF
--- a/crates/redisctl/src/cli/init.rs
+++ b/crates/redisctl/src/cli/init.rs
@@ -1,0 +1,44 @@
+//! `redisctl init` argument surface.
+//!
+//! This surface is the stability contract for the planned npm exec-wrapper: flags
+//! may be added, never renamed or repurposed once released.
+
+use clap::Args;
+
+/// Agents `redisctl init` can configure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum AgentArg {
+    Claude,
+    Cursor,
+    Vscode,
+    Codex,
+    All,
+}
+
+/// Onboard this project to Redis services + set up your AI coding agent.
+#[derive(Args, Debug)]
+pub struct InitArgs {
+    /// Use an existing redis:// or rediss:// database (default: provision a local
+    /// Docker container). Also accepts a pasted Redis Cloud connect command:
+    /// redisctl init --url "redis-cli -u redis://default:...@host:port"
+    #[arg(long, value_name = "REDIS_URL")]
+    pub url: Option<String>,
+
+    /// Database name, recorded in the generated project skill
+    #[arg(long, value_name = "LABEL")]
+    pub name: Option<String>,
+
+    /// Configure a specific agent (repeatable or comma-separated). Default: detect
+    /// installed tools and configure all of them
+    #[arg(long = "agent", value_enum, value_delimiter = ',', value_name = "NAME")]
+    pub agents: Vec<AgentArg>,
+
+    /// Print the plan without changing anything
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// A pasted connect command, same as --url (the Cloud console's Copy button
+    /// output works verbatim)
+    #[arg(value_name = "PASTED", hide = true, num_args = 0..)]
+    pub pasted: Vec<String>,
+}

--- a/crates/redisctl/src/cli/init.rs
+++ b/crates/redisctl/src/cli/init.rs
@@ -39,6 +39,12 @@ pub struct InitArgs {
 
     /// A pasted connect command, same as --url (the Cloud console's Copy button
     /// output works verbatim)
-    #[arg(value_name = "PASTED", hide = true, num_args = 0..)]
+    #[arg(
+        value_name = "PASTED",
+        hide = true,
+        num_args = 0..,
+        trailing_var_arg = true,
+        allow_hyphen_values = true
+    )]
     pub pasted: Vec<String>,
 }

--- a/crates/redisctl/src/cli/init.rs
+++ b/crates/redisctl/src/cli/init.rs
@@ -16,7 +16,7 @@ pub enum AgentArg {
 }
 
 /// Onboard this project to Redis services + set up your AI coding agent.
-#[derive(Args, Debug)]
+#[derive(Args)]
 pub struct InitArgs {
     /// Use an existing redis:// or rediss:// database (default: provision a local
     /// Docker container). Also accepts a pasted Redis Cloud connect command:
@@ -47,4 +47,41 @@ pub struct InitArgs {
         allow_hyphen_values = true
     )]
     pub pasted: Vec<String>,
+}
+
+// Manual, because `{:?}` reaches trace logs: a URL or paste can carry a real
+// password and must never survive into them.
+impl std::fmt::Debug for InitArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InitArgs")
+            .field("url", &self.url.as_ref().map(|_| "<redacted>"))
+            .field("name", &self.name)
+            .field("agents", &self.agents)
+            .field("dry_run", &self.dry_run)
+            .field("pasted", &(!self.pasted.is_empty()).then_some("<redacted>"))
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_never_prints_url_or_paste_content() {
+        let args = InitArgs {
+            url: Some("redis://default:s3cret@h:1".into()),
+            name: Some("db".into()),
+            agents: vec![AgentArg::Claude],
+            dry_run: false,
+            pasted: vec![
+                "redis-cli".into(),
+                "-u".into(),
+                "redis://default:s3cret@h:2".into(),
+            ],
+        };
+        let debug = format!("{args:?}");
+        assert!(!debug.contains("s3cret"), "{debug}");
+        assert!(debug.contains("<redacted>"), "{debug}");
+    }
 }

--- a/crates/redisctl/src/cli/mod.rs
+++ b/crates/redisctl/src/cli/mod.rs
@@ -11,9 +11,11 @@ use redisctl_core::DeploymentType;
 
 pub mod cloud;
 pub mod enterprise;
+pub mod init;
 
 pub use cloud::*;
 pub use enterprise::*;
+pub use init::*;
 
 /// Redis management CLI with unified access to Cloud and Enterprise
 #[derive(Parser, Debug)]
@@ -243,6 +245,12 @@ PROFILE REQUIREMENT:
     redisctl profile set <name> --type database --host <HOST> --port <PORT>
   List existing profiles: redisctl profile list")]
     Db(DbCommands),
+
+    /// Onboard this project to Redis + set up your AI coding agent
+    // Hidden while the command is incomplete: merges to main can auto-release, and a
+    // half-wired command must not surface in --help.
+    #[command(hide = true)]
+    Init(InitArgs),
 
     /// Version information
     #[command(visible_alias = "ver", visible_alias = "v")]

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -43,6 +43,7 @@ const PASSTHROUGH_COMMANDS: &[&str] = &[
     "pr",   // profile alias
     "api",
     "db",
+    "init",
     "version",
     "ver", // version alias
     "v",   // version alias
@@ -562,6 +563,8 @@ async fn execute_command(cli: &Cli, conn_mgr: &ConnectionManager) -> Result<(), 
         }
 
         Commands::Db(db_cmd) => commands::db::handle_db_command(db_cmd, conn_mgr, cli.output).await,
+
+        Commands::Init(init_args) => workflows::init::run(init_args).await,
     };
 
     let duration = start.elapsed();
@@ -660,6 +663,8 @@ fn format_command(command: &Commands) -> String {
                 Open { profile, .. } => format!("db open --profile {}", profile),
             }
         }
+        // The --url value can carry a database password, so it never reaches the log.
+        Commands::Init(_) => "init [args redacted]".to_string(),
     }
 }
 

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -1,0 +1,188 @@
+//! `redisctl init` - onboard a project to Redis services and make its AI coding
+//! agent Redis-fluent.
+//!
+//! This module is the step sequence; each concern lives in its own submodule.
+
+mod output;
+mod project;
+mod util;
+
+use std::sync::OnceLock;
+
+use crate::cli::InitArgs;
+use crate::error::RedisCtlError;
+use output::{bold, dim, ok, yellow};
+
+/// What counts as a connection string, wherever one arrives: the --url flag or a
+/// bare positional (the Redis Cloud console hands out `redis-cli -u <url>`; accept
+/// that paste whole and pull the URL out of it).
+fn url_regex() -> &'static regex::Regex {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    RE.get_or_init(|| regex::Regex::new(r#"rediss?://[^\s"']+"#).expect("static regex"))
+}
+
+/// Pull a Redis URL out of pasted text. `Ok(None)` when the text is blank,
+/// an error when there is text but no URL in it.
+fn extract_url(pasted: &str) -> Result<Option<String>, RedisCtlError> {
+    if let Some(m) = url_regex().find(pasted) {
+        return Ok(Some(m.as_str().to_string()));
+    }
+    if pasted.trim().is_empty() {
+        return Ok(None);
+    }
+    Err(RedisCtlError::InvalidInput {
+        message: format!("no redis:// or rediss:// URL found in: {}", pasted.trim()),
+    })
+}
+
+pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
+    let pasted = [args.url.clone().unwrap_or_default()]
+        .into_iter()
+        .chain(args.pasted.iter().cloned())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let given_url = extract_url(&pasted)?;
+
+    output::banner();
+    let dry = args.dry_run;
+    println!(
+        "{}",
+        bold(&format!(
+            "\nredisctl init{}\n",
+            if dry {
+                " (dry run - nothing will be written)"
+            } else {
+                ""
+            }
+        ))
+    );
+
+    let cwd = std::env::current_dir().map_err(|e| RedisCtlError::FileError {
+        path: ".".into(),
+        message: e.to_string(),
+    })?;
+    let proj = project::detect(&cwd);
+    let mut descriptor = proj.runtime.as_str().to_string();
+    if let Some(pm) = proj.pm {
+        descriptor.push_str(&format!(", {pm}"));
+    }
+    if let Some(framework) = &proj.framework {
+        descriptor.push_str(&format!(", {framework}"));
+    }
+    println!(
+        "{}   {} {}",
+        bold("Project"),
+        proj.name,
+        dim(&format!("({descriptor})"))
+    );
+
+    let agents = project::choose_agents(&args.agents, &project::detect_agents(&cwd));
+    let agent_bits = proj
+        .agent_markers
+        .iter()
+        .map(|(marker, found)| format!("{marker} {}", if *found { ok("✓") } else { dim("✗") }))
+        .collect::<Vec<_>>()
+        .join("  ");
+    let names = agents
+        .iter()
+        .map(|a| a.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!(
+        "{}    {}{}   {}\n",
+        bold("Agents"),
+        names,
+        if args.agents.is_empty() {
+            dim(" (detected)")
+        } else {
+            String::new()
+        },
+        dim(&format!("existing: {agent_bits}"))
+    );
+    if proj.runtime == project::Runtime::Unknown {
+        println!(
+            "{}",
+            yellow(
+                "  note: no package manifest detected - continuing; everything redisctl init writes is language-agnostic.\n"
+            )
+        );
+    }
+
+    // No step records changes yet, so the summary prints a subject with no lines.
+    let subject = given_url.as_deref().map(|url| {
+        format!(
+            "database: {}{} via provided URL",
+            util::mask_url(url),
+            args.name
+                .as_deref()
+                .map(|n| format!(" [{n}]"))
+                .unwrap_or_default()
+        )
+    });
+    println!(
+        "{}{}",
+        bold(if dry { "Plan" } else { "Changes" }),
+        subject
+            .map(|s| format!("  {}", dim(&format!("({s})"))))
+            .unwrap_or_default()
+    );
+
+    if dry {
+        println!(
+            "{}",
+            dim("\nDry run complete. Run again without --dry-run to apply.\n")
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blank_paste_means_no_url() {
+        assert_eq!(extract_url("").unwrap(), None);
+        assert_eq!(extract_url("   ").unwrap(), None);
+    }
+
+    #[test]
+    fn raw_urls_pass_through() {
+        assert_eq!(
+            extract_url("redis://localhost:6379").unwrap().as_deref(),
+            Some("redis://localhost:6379")
+        );
+        assert_eq!(
+            extract_url("rediss://h:12000").unwrap().as_deref(),
+            Some("rediss://h:12000")
+        );
+    }
+
+    #[test]
+    fn pasted_connect_command_yields_its_url() {
+        assert_eq!(
+            extract_url("redis-cli -u redis://default:pw@host:12000")
+                .unwrap()
+                .as_deref(),
+            Some("redis://default:pw@host:12000")
+        );
+    }
+
+    #[test]
+    fn quotes_delimit_the_url() {
+        assert_eq!(
+            extract_url(r#"redis-cli -u "rediss://h:1""#)
+                .unwrap()
+                .as_deref(),
+            Some("rediss://h:1")
+        );
+    }
+
+    #[test]
+    fn text_without_a_url_is_an_error_naming_the_text() {
+        let err = extract_url("garbage in").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no redis:// or rediss:// URL found"), "{msg}");
+        assert!(msg.contains("garbage in"), "{msg}");
+    }
+}

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -31,7 +31,10 @@ fn extract_url(pasted: &str) -> Result<Option<String>, RedisCtlError> {
         return Ok(None);
     }
     Err(RedisCtlError::InvalidInput {
-        message: format!("no redis:// or rediss:// URL found in: {}", pasted.trim()),
+        message: format!(
+            "no redis:// or rediss:// URL found in: {}",
+            util::mask_url(pasted.trim())
+        ),
     })
 }
 
@@ -184,5 +187,13 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("no redis:// or rediss:// URL found"), "{msg}");
         assert!(msg.contains("garbage in"), "{msg}");
+    }
+
+    #[test]
+    fn rejected_input_never_echoes_a_credential() {
+        let err = extract_url("redisx://default:secret@host:6379").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("redisx://default:****@host:6379"), "{msg}");
+        assert!(!msg.contains("secret"), "{msg}");
     }
 }

--- a/crates/redisctl/src/workflows/init/output.rs
+++ b/crates/redisctl/src/workflows/init/output.rs
@@ -1,0 +1,148 @@
+//! Terminal output for `redisctl init`: colour helpers and the banner.
+//!
+//! Colours only when stdout is a terminal, Redis red at the best depth the terminal
+//! offers (24-bit when COLORTERM says so, the nearest 256-colour index otherwise).
+
+use std::io::IsTerminal;
+
+fn tty() -> bool {
+    std::io::stdout().is_terminal()
+}
+
+fn paint(code: &str, s: &str) -> String {
+    if tty() {
+        format!("\x1b[{code}m{s}\x1b[0m")
+    } else {
+        s.to_string()
+    }
+}
+
+pub fn bold(s: &str) -> String {
+    paint("1", s)
+}
+
+pub fn dim(s: &str) -> String {
+    paint("2", s)
+}
+
+pub fn yellow(s: &str) -> String {
+    paint("33", s)
+}
+
+/// Success marker. Deliberately not red: the payoff must not share a hue with a failure.
+pub fn ok(s: &str) -> String {
+    paint("97;1", s)
+}
+
+fn truecolor() -> bool {
+    std::env::var("COLORTERM")
+        .map(|v| v.contains("truecolor") || v.contains("24bit"))
+        .unwrap_or(false)
+}
+
+fn brand(rgb: &str, idx: u8, s: &str) -> String {
+    if truecolor() {
+        paint(&format!("38;2;{rgb}"), s)
+    } else {
+        paint(&format!("38;5;{idx}"), s)
+    }
+}
+
+fn brand_red(s: &str) -> String {
+    brand("255;68;56", 203, s)
+}
+
+fn brand_edge(s: &str) -> String {
+    brand("196;39;27", 160, s)
+}
+
+/// The wordmark: blocks filled in brand red, with the box-drawing characters that
+/// trace their edge in the darker tone. TTY only, keeping piped output clean.
+const WORDMARK: [&str; 6] = [
+    "██████╗ ███████╗██████╗ ██╗███████╗",
+    "██╔══██╗██╔════╝██╔══██╗██║██╔════╝",
+    "██████╔╝█████╗  ██║  ██║██║███████╗",
+    "██╔══██╗██╔══╝  ██║  ██║██║╚════██║",
+    "██║  ██║███████╗██████╔╝██║███████║",
+    "╚═╝  ╚═╝╚══════╝╚═════╝ ╚═╝╚══════╝",
+];
+
+/// How a wordmark character is coloured: the blocks get the fill tone, spaces stay
+/// plain, everything else (the box-drawing edge) gets the darker tone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RunKind {
+    Block,
+    Edge,
+    Space,
+}
+
+fn classify(c: char) -> RunKind {
+    match c {
+        '█' | '▀' | '▄' | '▌' | '▐' => RunKind::Block,
+        ' ' => RunKind::Space,
+        _ => RunKind::Edge,
+    }
+}
+
+/// Split a wordmark line into runs of like-classified characters, so colour is chosen
+/// per run instead of per character.
+fn split_runs(line: &str) -> Vec<(RunKind, String)> {
+    let mut runs: Vec<(RunKind, String)> = Vec::new();
+    for c in line.chars() {
+        let kind = classify(c);
+        match runs.last_mut() {
+            Some((last, run)) if *last == kind => run.push(c),
+            _ => runs.push((kind, c.to_string())),
+        }
+    }
+    runs
+}
+
+pub fn banner() {
+    if !tty() {
+        return;
+    }
+    let art: Vec<String> = WORDMARK
+        .iter()
+        .map(|line| {
+            split_runs(line)
+                .into_iter()
+                .map(|(kind, run)| match kind {
+                    RunKind::Block => brand_red(&run),
+                    RunKind::Edge => brand_edge(&run),
+                    RunKind::Space => run,
+                })
+                .collect::<String>()
+        })
+        .collect();
+    println!("\n{}\n", art.join("\n"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_runs_groups_blocks_and_edges() {
+        assert_eq!(
+            split_runs("██╔═██"),
+            vec![
+                (RunKind::Block, "██".to_string()),
+                (RunKind::Edge, "╔═".to_string()),
+                (RunKind::Block, "██".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn split_runs_keeps_spaces_uncoloured() {
+        assert_eq!(
+            split_runs("█ ╗"),
+            vec![
+                (RunKind::Block, "█".to_string()),
+                (RunKind::Space, " ".to_string()),
+                (RunKind::Edge, "╗".to_string()),
+            ]
+        );
+    }
+}

--- a/crates/redisctl/src/workflows/init/project.rs
+++ b/crates/redisctl/src/workflows/init/project.rs
@@ -1,0 +1,331 @@
+//! The project side: what it is built with and which coding agents to configure.
+
+use std::path::Path;
+
+use crate::cli::AgentArg;
+
+use super::util::{exists, has_bin, read_if};
+
+/// The coding agents `redisctl init` can configure, in canonical order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Agent {
+    Claude,
+    Cursor,
+    Vscode,
+    Codex,
+}
+
+pub const KNOWN_AGENTS: [Agent; 4] = [Agent::Claude, Agent::Cursor, Agent::Vscode, Agent::Codex];
+
+impl Agent {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Agent::Claude => "claude",
+            Agent::Cursor => "cursor",
+            Agent::Vscode => "vscode",
+            Agent::Codex => "codex",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Runtime {
+    Node,
+    Python,
+    Go,
+    Rust,
+    Java,
+    Unknown,
+}
+
+impl Runtime {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Runtime::Node => "node",
+            Runtime::Python => "python",
+            Runtime::Go => "go",
+            Runtime::Rust => "rust",
+            Runtime::Java => "java",
+            Runtime::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Project {
+    pub name: String,
+    pub runtime: Runtime,
+    pub pm: Option<&'static str>,
+    pub framework: Option<String>,
+    /// Existing agent-config markers in the project, in display order.
+    pub agent_markers: Vec<(&'static str, bool)>,
+}
+
+/// Lockfiles first, so the bare manifest cannot shadow the real package manager.
+const PACKAGE_MANAGERS: [(&str, &str); 6] = [
+    ("bun.lockb", "bun"),
+    ("bun.lock", "bun"),
+    ("pnpm-lock.yaml", "pnpm"),
+    ("yarn.lock", "yarn"),
+    ("package-lock.json", "npm"),
+    ("package.json", "npm"),
+];
+
+const FRAMEWORKS: [&str; 11] = [
+    "next",
+    "nuxt",
+    "astro",
+    "remix",
+    "@remix-run/node",
+    "express",
+    "fastify",
+    "hono",
+    "koa",
+    "nest",
+    "@nestjs/core",
+];
+
+/// Detect what the project in `dir` is built with.
+pub fn detect(dir: &Path) -> Project {
+    let mut pm = PACKAGE_MANAGERS
+        .iter()
+        .find(|(file, _)| exists(dir, file))
+        .map(|(_, pm)| *pm);
+
+    let mut runtime = Runtime::Unknown;
+    let mut name = dir
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "project".to_string());
+    let mut framework = None;
+    if exists(dir, "package.json") {
+        runtime = Runtime::Node;
+        if let Some(pkg) = read_if(dir, "package.json")
+            .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+        {
+            if let Some(pkg_name) = pkg["name"].as_str() {
+                name = pkg_name.to_string();
+            }
+            framework = FRAMEWORKS
+                .iter()
+                .find(|f| !pkg["dependencies"][f].is_null() || !pkg["devDependencies"][f].is_null())
+                .map(|f| f.to_string());
+        }
+        // Unparseable package.json: keep defaults.
+    } else if exists(dir, "pyproject.toml") || exists(dir, "requirements.txt") {
+        runtime = Runtime::Python;
+    } else if exists(dir, "go.mod") {
+        runtime = Runtime::Go;
+    } else if exists(dir, "Cargo.toml") {
+        runtime = Runtime::Rust;
+    } else if exists(dir, "pom.xml")
+        || exists(dir, "build.gradle")
+        || exists(dir, "build.gradle.kts")
+    {
+        runtime = Runtime::Java;
+        pm = Some(if exists(dir, "pom.xml") {
+            "maven"
+        } else {
+            "gradle"
+        });
+    }
+
+    let agent_markers = vec![
+        ("AGENTS.md", exists(dir, "AGENTS.md")),
+        ("CLAUDE.md", exists(dir, "CLAUDE.md")),
+        (".claude/", exists(dir, ".claude")),
+        (".mcp.json", exists(dir, ".mcp.json")),
+        (".cursor/", exists(dir, ".cursor")),
+    ];
+    Project {
+        name,
+        runtime,
+        pm,
+        framework,
+        agent_markers,
+    }
+}
+
+/// The agents to configure: an explicit `--agent` list wins (canonical order, `all`
+/// expands), otherwise whatever was detected, otherwise all of them - having no agent
+/// tooling detected is not a reason to configure none.
+pub fn choose_agents(requested: &[AgentArg], detected: &[Agent]) -> Vec<Agent> {
+    if !requested.is_empty() {
+        if requested.contains(&AgentArg::All) {
+            return KNOWN_AGENTS.to_vec();
+        }
+        return KNOWN_AGENTS
+            .into_iter()
+            .filter(|agent| {
+                requested.iter().any(|r| {
+                    matches!(
+                        (r, agent),
+                        (AgentArg::Claude, Agent::Claude)
+                            | (AgentArg::Cursor, Agent::Cursor)
+                            | (AgentArg::Vscode, Agent::Vscode)
+                            | (AgentArg::Codex, Agent::Codex)
+                    )
+                })
+            })
+            .collect();
+    }
+    if detected.is_empty() {
+        KNOWN_AGENTS.to_vec()
+    } else {
+        detected.to_vec()
+    }
+}
+
+/// Detect which agent tools this machine/project uses.
+pub fn detect_agents(dir: &Path) -> Vec<Agent> {
+    let home = std::env::home_dir().unwrap_or_default();
+    let detectors: [(Agent, bool); 4] = [
+        (
+            Agent::Claude,
+            has_bin("claude")
+                || exists(dir, ".claude")
+                || exists(dir, "CLAUDE.md")
+                || exists(dir, ".mcp.json"),
+        ),
+        (
+            Agent::Cursor,
+            has_bin("cursor") || exists(dir, ".cursor") || home.join(".cursor").exists(),
+        ),
+        (Agent::Vscode, has_bin("code") || exists(dir, ".vscode")),
+        (
+            Agent::Codex,
+            has_bin("codex") || home.join(".codex").exists(),
+        ),
+    ];
+    detectors
+        .into_iter()
+        .filter_map(|(agent, found)| found.then_some(agent))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn dir_with(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        for (name, content) in files {
+            fs::write(dir.path().join(name), content).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn detects_node_with_npm_name_and_framework() {
+        let dir = dir_with(&[
+            (
+                "package.json",
+                r#"{"name":"demo-shop","dependencies":{"express":"^4.18.2"}}"#,
+            ),
+            ("package-lock.json", "{}"),
+        ]);
+        let p = detect(dir.path());
+        assert_eq!(p.runtime, Runtime::Node);
+        assert_eq!(p.pm, Some("npm"));
+        assert_eq!(p.name, "demo-shop");
+        assert_eq!(p.framework.as_deref(), Some("express"));
+    }
+
+    #[test]
+    fn lockfile_beats_bare_manifest_for_package_manager() {
+        let dir = dir_with(&[("package.json", r#"{"name":"x"}"#), ("pnpm-lock.yaml", "")]);
+        assert_eq!(detect(dir.path()).pm, Some("pnpm"));
+    }
+
+    #[test]
+    fn framework_found_in_dev_dependencies() {
+        let dir = dir_with(&[(
+            "package.json",
+            r#"{"name":"x","devDependencies":{"fastify":"^5"}}"#,
+        )]);
+        assert_eq!(detect(dir.path()).framework.as_deref(), Some("fastify"));
+    }
+
+    #[test]
+    fn unparseable_package_json_keeps_node_with_defaults() {
+        let dir = dir_with(&[("package.json", "not json")]);
+        let p = detect(dir.path());
+        assert_eq!(p.runtime, Runtime::Node);
+        let basename = dir.path().file_name().unwrap().to_string_lossy();
+        assert_eq!(p.name, basename);
+        assert_eq!(p.framework, None);
+    }
+
+    #[test]
+    fn detects_python_go_rust_java() {
+        assert_eq!(
+            detect(dir_with(&[("pyproject.toml", "")]).path()).runtime,
+            Runtime::Python
+        );
+        assert_eq!(
+            detect(dir_with(&[("requirements.txt", "")]).path()).runtime,
+            Runtime::Python
+        );
+        assert_eq!(
+            detect(dir_with(&[("go.mod", "")]).path()).runtime,
+            Runtime::Go
+        );
+        assert_eq!(
+            detect(dir_with(&[("Cargo.toml", "")]).path()).runtime,
+            Runtime::Rust
+        );
+        let maven = detect(dir_with(&[("pom.xml", "")]).path());
+        assert_eq!((maven.runtime, maven.pm), (Runtime::Java, Some("maven")));
+        let gradle = detect(dir_with(&[("build.gradle.kts", "")]).path());
+        assert_eq!((gradle.runtime, gradle.pm), (Runtime::Java, Some("gradle")));
+    }
+
+    #[test]
+    fn empty_dir_is_unknown_named_after_the_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = detect(dir.path());
+        assert_eq!(p.runtime, Runtime::Unknown);
+        assert_eq!(p.pm, None);
+        let basename = dir.path().file_name().unwrap().to_string_lossy();
+        assert_eq!(p.name, basename);
+    }
+
+    #[test]
+    fn agent_markers_reflect_existing_files() {
+        let dir = dir_with(&[("AGENTS.md", ""), (".mcp.json", "{}")]);
+        fs::create_dir(dir.path().join(".cursor")).unwrap();
+        let markers = detect(dir.path()).agent_markers;
+        assert_eq!(
+            markers,
+            vec![
+                ("AGENTS.md", true),
+                ("CLAUDE.md", false),
+                (".claude/", false),
+                (".mcp.json", true),
+                (".cursor/", true),
+            ]
+        );
+    }
+
+    #[test]
+    fn explicit_agents_win_in_canonical_order() {
+        let chosen = choose_agents(&[AgentArg::Codex, AgentArg::Claude], &[Agent::Vscode]);
+        assert_eq!(chosen, vec![Agent::Claude, Agent::Codex]);
+    }
+
+    #[test]
+    fn all_expands_to_every_agent() {
+        assert_eq!(choose_agents(&[AgentArg::All], &[]), KNOWN_AGENTS.to_vec());
+    }
+
+    #[test]
+    fn detected_agents_used_when_no_flag() {
+        assert_eq!(choose_agents(&[], &[Agent::Cursor]), vec![Agent::Cursor]);
+    }
+
+    #[test]
+    fn nothing_detected_configures_all() {
+        assert_eq!(choose_agents(&[], &[]), KNOWN_AGENTS.to_vec());
+    }
+}

--- a/crates/redisctl/src/workflows/init/util.rs
+++ b/crates/redisctl/src/workflows/init/util.rs
@@ -1,0 +1,58 @@
+//! Small shared helpers for `redisctl init`: masking, binary lookup, project file reads.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+/// Mask the password in a Redis URL so it never lands in terminal output.
+pub fn mask_url(url: &str) -> String {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re =
+        RE.get_or_init(|| regex::Regex::new(r"(rediss?://[^:@/]*):[^@]*@").expect("static regex"));
+    re.replace_all(url, "$1:****@").into_owned()
+}
+
+/// Whether a binary is on PATH.
+pub fn has_bin(bin: &str) -> bool {
+    which::which(bin).is_ok()
+}
+
+/// Whether `rel` exists under `dir`.
+pub fn exists(dir: &Path, rel: &str) -> bool {
+    dir.join(rel).exists()
+}
+
+/// The content of `rel` under `dir`, or `None` when it does not exist or cannot be read.
+pub fn read_if(dir: &Path, rel: &str) -> Option<String> {
+    std::fs::read_to_string(dir.join(rel)).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mask_url_hides_the_password() {
+        assert_eq!(
+            mask_url("redis://default:s3cret@host.example:12000"),
+            "redis://default:****@host.example:12000"
+        );
+    }
+
+    #[test]
+    fn mask_url_handles_empty_username() {
+        assert_eq!(mask_url("rediss://:pw@h:1"), "rediss://:****@h:1");
+    }
+
+    #[test]
+    fn mask_url_leaves_passwordless_urls_alone() {
+        assert_eq!(mask_url("redis://localhost:6379"), "redis://localhost:6379");
+    }
+
+    #[test]
+    fn mask_url_masks_inside_larger_text() {
+        assert_eq!(
+            mask_url("connect via redis://u:pw@h:1 please"),
+            "connect via redis://u:****@h:1 please"
+        );
+    }
+}

--- a/crates/redisctl/src/workflows/init/util.rs
+++ b/crates/redisctl/src/workflows/init/util.rs
@@ -3,11 +3,14 @@
 use std::path::Path;
 use std::sync::OnceLock;
 
-/// Mask the password in a Redis URL so it never lands in terminal output.
+/// Mask the password in URL-shaped text - deliberately broader than valid redis://
+/// URLs, because rejected input gets echoed in error messages.
 pub fn mask_url(url: &str) -> String {
     static RE: OnceLock<regex::Regex> = OnceLock::new();
-    let re =
-        RE.get_or_init(|| regex::Regex::new(r"(rediss?://[^:@/]*):[^@]*@").expect("static regex"));
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r#"([A-Za-z][A-Za-z0-9+.-]*://[^:@/\s"']*|[^:@\s/"']+):[^@\s"']+@"#)
+            .expect("static regex")
+    });
     re.replace_all(url, "$1:****@").into_owned()
 }
 
@@ -53,6 +56,26 @@ mod tests {
         assert_eq!(
             mask_url("connect via redis://u:pw@h:1 please"),
             "connect via redis://u:****@h:1 please"
+        );
+    }
+
+    #[test]
+    fn mask_url_masks_unknown_schemes() {
+        assert_eq!(
+            mask_url("redisx://default:secret@host:6379"),
+            "redisx://default:****@host:6379"
+        );
+        assert_eq!(
+            mask_url("https://user:token@example.com/path"),
+            "https://user:****@example.com/path"
+        );
+    }
+
+    #[test]
+    fn mask_url_masks_bare_userinfo_without_a_scheme() {
+        assert_eq!(
+            mask_url("default:secret@host:6379"),
+            "default:****@host:6379"
         );
     }
 }

--- a/crates/redisctl/src/workflows/mod.rs
+++ b/crates/redisctl/src/workflows/mod.rs
@@ -11,6 +11,7 @@ use std::pin::Pin;
 
 pub mod cloud;
 pub mod enterprise;
+pub mod init;
 
 /// Common trait for all workflows
 pub trait Workflow: Send + Sync {

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -1,0 +1,106 @@
+//! CLI-level tests for `redisctl init`: wiring, detection, dry-run.
+//!
+//! Everything here runs against a temp directory and writes nothing.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn redisctl() -> Command {
+    Command::cargo_bin("redisctl").unwrap()
+}
+
+#[test]
+fn init_is_hidden_from_top_level_help() {
+    redisctl()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("init").not());
+}
+
+#[test]
+fn init_help_documents_the_flags() {
+    redisctl()
+        .args(["init", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--url"))
+        .stdout(predicate::str::contains("--agent"))
+        .stdout(predicate::str::contains("--dry-run"));
+}
+
+#[test]
+fn unknown_agent_is_a_usage_error() {
+    redisctl()
+        .args(["init", "--agent", "bogus"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("possible values"));
+}
+
+#[test]
+fn dry_run_detects_a_node_project() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("package.json"),
+        r#"{"name":"demo-shop","dependencies":{"express":"^4"}}"#,
+    )
+    .unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args(["init", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("demo-shop"))
+        .stdout(predicate::str::contains("(node, npm, express)"))
+        .stdout(predicate::str::contains("Plan"))
+        .stdout(predicate::str::contains("Dry run complete"));
+    // Nothing written: the manifest is still the only file.
+    assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+}
+
+#[test]
+fn unknown_runtime_gets_a_note_and_continues() {
+    let dir = tempfile::tempdir().unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args(["init", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no package manifest detected"));
+}
+
+#[test]
+fn provided_url_is_masked_in_the_plan_subject() {
+    let dir = tempfile::tempdir().unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args([
+            "init",
+            "--dry-run",
+            "--url",
+            "redis-cli -u redis://default:s3cret@host.example:12000",
+            "--name",
+            "my-db",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "redis://default:****@host.example:12000",
+        ))
+        .stdout(predicate::str::contains("[my-db]"))
+        .stdout(predicate::str::contains("s3cret").not());
+}
+
+#[test]
+fn url_without_a_redis_url_is_a_validation_error() {
+    let dir = tempfile::tempdir().unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args(["init", "--url", "http://not-redis"])
+        .assert()
+        .code(6)
+        .stderr(predicate::str::contains(
+            "no redis:// or rediss:// URL found",
+        ));
+}

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -104,3 +104,54 @@ fn url_without_a_redis_url_is_a_validation_error() {
             "no redis:// or rediss:// URL found",
         ));
 }
+
+#[test]
+fn rejected_url_input_is_credential_masked_on_stderr() {
+    let dir = tempfile::tempdir().unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args(["init", "--url", "redisx://default:s3cret@host:6379"])
+        .assert()
+        .code(6)
+        .stderr(predicate::str::contains("redisx://default:****@host:6379"))
+        .stderr(predicate::str::contains("s3cret").not());
+}
+
+#[test]
+fn rejected_url_input_is_credential_masked_in_the_json_envelope() {
+    let dir = tempfile::tempdir().unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args([
+            "init",
+            "-o",
+            "json",
+            "--url",
+            "redisx://default:s3cret@host:6379",
+        ])
+        .assert()
+        .code(6)
+        .stderr(predicate::str::contains("****"))
+        .stderr(predicate::str::contains("s3cret").not());
+}
+
+#[test]
+fn verbatim_unquoted_console_paste_is_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    // The shell-split form of an unquoted paste: -u must not parse as a redisctl flag.
+    redisctl()
+        .current_dir(dir.path())
+        .args([
+            "init",
+            "redis-cli",
+            "-u",
+            "redis://default:s3cret@host.example:12000",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "redis://default:****@host.example:12000",
+        ))
+        .stdout(predicate::str::contains("via provided URL"))
+        .stdout(predicate::str::contains("s3cret").not());
+}


### PR DESCRIPTION
First slice of porting the redis-init PoC into `redisctl init`. Slices target the integration branch `feat/init-command`; nothing reaches main until the whole stack is reviewable.

Adds a hidden `redisctl init` with `--url`, `--name`, `--agent`, `--dry-run`: project detection (runtime, package manager, framework, existing agent markers) and agent resolution (flag > detected tools > all four). `--url` also accepts a pasted Cloud-console `redis-cli -u ...` command; passwords are masked in all output. No side effects yet - dry and real runs are identical in this slice. Exit codes ride the repo taxonomy (2 usage, 6 validation).

Everything that touches the machine is deferred to its own slice (Docker, .env, skills, MCP, wizard, cloud, products, telemetry). The PoC's `-y/--yes` is banned tree-wide; the wizard slice names its replacement.

Verify:
```sh
redisctl init --dry-run    # detects, writes nothing
redisctl init --dry-run --url "redis-cli -u redis://default:secret@host:12000"    # masked
```

<img width="1772" height="839" alt="image" src="https://github.com/user-attachments/assets/bd768022-e656-4686-ae53-ac8f30c4cb50" />
<img width="964" height="317" alt="image" src="https://github.com/user-attachments/assets/fab67545-6a5c-49cb-b424-e67c6e21e904" />
<img width="1045" height="328" alt="image" src="https://github.com/user-attachments/assets/e85374bb-3999-4654-9767-940c86fc6bf4" />