### PR TITLE
test(mcp): establish the 1.0 catalog contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,15 @@ public Rust APIs must be reviewed against the
 is additive, breaking, preview-only, internal, or a safety correction, and add a contract test or a
 recorded exception where applicable.
 
+For MCP tool changes, run the catalog contract test before updating its fixture:
+
+```bash
+cargo test -p redisctl-mcp --all-features mcp_catalog_matches_1_0_baseline
+```
+
+The [MCP Compatibility and Catalog](docs/docs/mcp/compatibility.md) page explains how to review and
+record an intentional additive change. Never refresh the fixture solely to make the test pass.
+
 ## Release Process
 
 We use a manual release workflow with semantic versioning:

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -65,6 +65,7 @@ test-support = []
 
 [dev-dependencies]
 tokio = { workspace = true }
+tower-mcp = { version = "0.8.2", features = ["testing"] }
 redis-cloud = { workspace = true, features = ["test-support"] }
 redis-enterprise = { workspace = true, features = ["test-support"] }
 wiremock = { workspace = true }

--- a/crates/redisctl-mcp/src/catalog_contract.rs
+++ b/crates/redisctl-mcp/src/catalog_contract.rs
@@ -1,0 +1,1008 @@
+//! Compatibility contract for the all-features MCP tool catalog.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use tower_mcp::TestClient;
+
+use super::*;
+
+const CATALOG_FORMAT_VERSION: u32 = 1;
+#[cfg(all(feature = "cloud", feature = "enterprise", feature = "database"))]
+const CATALOG_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/mcp-catalog-v1.json"
+);
+const CATALOG_JSON: &str = include_str!("../tests/fixtures/mcp-catalog-v1.json");
+const SYSTEM_TOOLS: &[&str] = &["list_available_tools", "show_policy"];
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Catalog {
+    format_version: u32,
+    tools: Vec<CatalogTool>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CatalogTool {
+    name: String,
+    toolset: String,
+    submodule: Option<String>,
+    required_tier: String,
+    input_schema: Value,
+    output_schema: Option<Value>,
+    annotations: CatalogAnnotations,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CatalogAnnotations {
+    title: Option<String>,
+    read_only_hint: bool,
+    destructive_hint: bool,
+    idempotent_hint: bool,
+    open_world_hint: bool,
+}
+
+#[derive(Default)]
+struct Changes {
+    breaking: Vec<String>,
+    additive: Vec<String>,
+}
+
+impl Changes {
+    fn is_empty(&self) -> bool {
+        self.breaking.is_empty() && self.additive.is_empty()
+    }
+
+    fn render(&self) -> String {
+        let mut output = String::new();
+        if !self.breaking.is_empty() {
+            output.push_str("\nBreaking or incompatible changes:\n");
+            for change in &self.breaking {
+                output.push_str(&format!("- {change}\n"));
+            }
+        }
+        if !self.additive.is_empty() {
+            output.push_str("\nAdditive changes requiring catalog review:\n");
+            for change in &self.additive {
+                output.push_str(&format!("- {change}\n"));
+            }
+        }
+        output
+    }
+}
+
+fn all_toolsets() -> EnabledToolsets {
+    #[allow(unused_mut)]
+    let mut toolsets = vec![Toolset::App];
+    #[cfg(feature = "cloud")]
+    toolsets.push(Toolset::Cloud);
+    #[cfg(feature = "enterprise")]
+    toolsets.push(Toolset::Enterprise);
+    #[cfg(feature = "database")]
+    toolsets.push(Toolset::Database);
+    EnabledToolsets::all_of(toolsets)
+}
+
+async fn current_catalog() -> Catalog {
+    current_catalog_for_tier(SafetyTier::Full).await
+}
+
+async fn current_catalog_for_tier(tier: SafetyTier) -> Catalog {
+    let enabled = all_toolsets();
+    let tool_toolset = build_tool_toolset_mapping(&enabled);
+    let policy_config = PolicyConfig {
+        tier,
+        ..Default::default()
+    };
+    let policy = Arc::new(Policy::new(
+        policy_config,
+        tool_toolset.clone(),
+        "catalog-contract".to_string(),
+    ));
+    let state = Arc::new(
+        AppState::new(
+            CredentialSource::Profiles(vec![]),
+            policy.clone(),
+            None,
+            false,
+            Some("redisctl-mcp-catalog-test".to_string()),
+        )
+        .expect("catalog state should build"),
+    );
+    let router = build_router(
+        state,
+        policy,
+        &enabled,
+        ToolsConfig::default(),
+        &tool_toolset,
+        None,
+    )
+    .expect("catalog router should build");
+
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+    let definitions = client.list_tools().await;
+
+    let mut tools = definitions
+        .into_iter()
+        .map(|definition| catalog_tool(definition, &tool_toolset))
+        .collect::<Vec<_>>();
+    tools.sort_by(|left, right| left.name.cmp(&right.name));
+
+    Catalog {
+        format_version: CATALOG_FORMAT_VERSION,
+        tools,
+    }
+}
+
+fn catalog_tool(definition: Value, toolsets: &HashMap<String, ToolsetKind>) -> CatalogTool {
+    let name = definition
+        .get("name")
+        .and_then(Value::as_str)
+        .expect("tools/list entry should contain a string name")
+        .to_string();
+    let toolset_kind = toolsets.get(&name).copied();
+    let toolset = toolset_kind
+        .map(|kind| kind.to_string())
+        .or_else(|| {
+            SYSTEM_TOOLS
+                .contains(&name.as_str())
+                .then(|| "system".to_string())
+        })
+        .unwrap_or_else(|| panic!("tool {name} is missing a toolset assignment"));
+    let annotations = normalized_annotations(definition.get("annotations"));
+    let required_tier = required_tier(&annotations).to_string();
+    let submodule = toolset_kind
+        .and_then(|kind| submodule_for_tool(kind, &name))
+        .map(str::to_string);
+
+    CatalogTool {
+        name,
+        toolset,
+        submodule,
+        required_tier,
+        input_schema: contract_schema(
+            definition
+                .get("inputSchema")
+                .cloned()
+                .expect("tools/list entry should contain inputSchema"),
+        ),
+        output_schema: definition.get("outputSchema").cloned().map(contract_schema),
+        annotations,
+    }
+}
+
+fn submodule_for_tool(kind: ToolsetKind, _name: &str) -> Option<&'static str> {
+    match kind {
+        ToolsetKind::App => None,
+        ToolsetKind::Cloud => {
+            #[cfg(feature = "cloud")]
+            {
+                tools::cloud::SUB_MODULES
+                    .iter()
+                    .find(|submodule| submodule.tool_names.contains(&_name))
+                    .map(|submodule| submodule.name)
+            }
+            #[cfg(not(feature = "cloud"))]
+            {
+                None
+            }
+        }
+        ToolsetKind::Enterprise => {
+            #[cfg(feature = "enterprise")]
+            {
+                tools::enterprise::SUB_MODULES
+                    .iter()
+                    .find(|submodule| submodule.tool_names.contains(&_name))
+                    .map(|submodule| submodule.name)
+            }
+            #[cfg(not(feature = "enterprise"))]
+            {
+                None
+            }
+        }
+        ToolsetKind::Database => {
+            #[cfg(feature = "database")]
+            {
+                tools::redis::SUB_MODULES
+                    .iter()
+                    .find(|submodule| submodule.tool_names.contains(&_name))
+                    .map(|submodule| submodule.name)
+            }
+            #[cfg(not(feature = "database"))]
+            {
+                None
+            }
+        }
+    }
+}
+
+fn contract_schema(value: Value) -> Value {
+    normalize_schema_node(value)
+}
+
+fn normalize_schema_node(mut value: Value) -> Value {
+    let Value::Object(object) = &mut value else {
+        return value;
+    };
+
+    for field in ["$schema", "description", "examples", "title"] {
+        object.remove(field);
+    }
+
+    for field in [
+        "$defs",
+        "definitions",
+        "dependentSchemas",
+        "patternProperties",
+        "properties",
+    ] {
+        if let Some(Value::Object(schemas)) = object.get_mut(field) {
+            for schema in schemas.values_mut() {
+                *schema = normalize_schema_node(schema.take());
+            }
+        }
+    }
+    for field in ["allOf", "anyOf", "oneOf", "prefixItems"] {
+        if let Some(Value::Array(schemas)) = object.get_mut(field) {
+            for schema in schemas {
+                *schema = normalize_schema_node(schema.take());
+            }
+        }
+    }
+    for field in [
+        "additionalProperties",
+        "contains",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedProperties",
+    ] {
+        if let Some(schema) = object.get_mut(field) {
+            *schema = normalize_schema_node(schema.take());
+        }
+    }
+
+    value
+}
+
+fn normalized_annotations(value: Option<&Value>) -> CatalogAnnotations {
+    let annotations = value.and_then(Value::as_object);
+    CatalogAnnotations {
+        title: annotations
+            .and_then(|object| object.get("title"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        read_only_hint: annotation_bool(annotations, "readOnlyHint", false),
+        destructive_hint: annotation_bool(annotations, "destructiveHint", true),
+        idempotent_hint: annotation_bool(annotations, "idempotentHint", false),
+        open_world_hint: annotation_bool(annotations, "openWorldHint", true),
+    }
+}
+
+fn annotation_bool(annotations: Option<&Map<String, Value>>, name: &str, default: bool) -> bool {
+    annotations
+        .and_then(|object| object.get(name))
+        .and_then(Value::as_bool)
+        .unwrap_or(default)
+}
+
+fn required_tier(annotations: &CatalogAnnotations) -> &'static str {
+    if annotations.read_only_hint {
+        "read-only"
+    } else if annotations.destructive_hint {
+        "full"
+    } else {
+        "read-write"
+    }
+}
+
+fn tier_rank(tier: &str) -> u8 {
+    match tier {
+        "read-only" => 0,
+        "read-write" => 1,
+        "full" => 2,
+        _ => panic!("unknown catalog safety tier: {tier}"),
+    }
+}
+
+fn compare_catalog(baseline: &Catalog, current: &Catalog) -> Changes {
+    let mut changes = Changes::default();
+    if baseline.format_version != CATALOG_FORMAT_VERSION {
+        changes.breaking.push(format!(
+            "catalog format {} is unsupported; expected {}",
+            baseline.format_version, CATALOG_FORMAT_VERSION
+        ));
+        return changes;
+    }
+
+    let baseline_by_name = index_tools(&baseline.tools, "baseline", &mut changes);
+    let current_by_name = index_tools(&current.tools, "current catalog", &mut changes);
+
+    for (name, before) in &baseline_by_name {
+        let Some(after) = current_by_name.get(name) else {
+            changes.breaking.push(format!("tool removed: {name}"));
+            continue;
+        };
+
+        if before.toolset != after.toolset {
+            changes.breaking.push(format!(
+                "{name}: toolset changed from {} to {}",
+                before.toolset, after.toolset
+            ));
+        }
+        if before.submodule != after.submodule {
+            changes.breaking.push(format!(
+                "{name}: submodule changed from {:?} to {:?}",
+                before.submodule, after.submodule
+            ));
+        }
+        if before.required_tier != after.required_tier {
+            changes.breaking.push(format!(
+                "{name}: required safety tier changed from {} to {}",
+                before.required_tier, after.required_tier
+            ));
+        }
+        compare_annotations(name, &before.annotations, &after.annotations, &mut changes);
+        compare_schema(
+            &format!("{name}.inputSchema"),
+            &before.input_schema,
+            &after.input_schema,
+            &mut changes,
+        );
+        compare_output_schema(
+            name,
+            &before.output_schema,
+            &after.output_schema,
+            &mut changes,
+        );
+    }
+
+    for name in current_by_name.keys() {
+        if !baseline_by_name.contains_key(name) {
+            changes.additive.push(format!("tool added: {name}"));
+        }
+    }
+
+    changes
+}
+
+fn index_tools<'a>(
+    tools: &'a [CatalogTool],
+    label: &str,
+    changes: &mut Changes,
+) -> BTreeMap<&'a str, &'a CatalogTool> {
+    let mut indexed = BTreeMap::new();
+    for tool in tools {
+        if indexed.insert(tool.name.as_str(), tool).is_some() {
+            changes
+                .breaking
+                .push(format!("duplicate tool name in {label}: {}", tool.name));
+        }
+    }
+    indexed
+}
+
+fn compare_annotations(
+    name: &str,
+    before: &CatalogAnnotations,
+    after: &CatalogAnnotations,
+    changes: &mut Changes,
+) {
+    if before.title != after.title {
+        changes.additive.push(format!(
+            "{name}: annotation title changed from {:?} to {:?}",
+            before.title, after.title
+        ));
+    }
+    for (field, old, new) in [
+        ("readOnlyHint", before.read_only_hint, after.read_only_hint),
+        (
+            "destructiveHint",
+            before.destructive_hint,
+            after.destructive_hint,
+        ),
+        (
+            "idempotentHint",
+            before.idempotent_hint,
+            after.idempotent_hint,
+        ),
+        (
+            "openWorldHint",
+            before.open_world_hint,
+            after.open_world_hint,
+        ),
+    ] {
+        if old != new {
+            let message = format!("{name}: {field} changed from {old} to {new}");
+            let weakens_safety = matches!(field, "readOnlyHint" | "destructiveHint")
+                || (field == "idempotentHint" && old)
+                || (field == "openWorldHint" && !old);
+            if weakens_safety {
+                changes.breaking.push(message);
+            } else {
+                changes.additive.push(message);
+            }
+        }
+    }
+}
+
+fn compare_output_schema(
+    name: &str,
+    before: &Option<Value>,
+    after: &Option<Value>,
+    changes: &mut Changes,
+) {
+    match (before, after) {
+        (None, None) => {}
+        (None, Some(_)) => changes
+            .additive
+            .push(format!("{name}: structured output schema added")),
+        (Some(_), None) => changes
+            .breaking
+            .push(format!("{name}: structured output schema removed")),
+        (Some(before), Some(after)) if before != after => changes
+            .breaking
+            .push(format!("{name}: structured output schema changed")),
+        (Some(_), Some(_)) => {}
+    }
+}
+
+fn compare_schema(path: &str, before: &Value, after: &Value, changes: &mut Changes) {
+    match (before, after) {
+        (Value::Object(before), Value::Object(after)) => {
+            compare_schema_object(path, before, after, changes)
+        }
+        (Value::Array(before), Value::Array(after)) => {
+            if before != after {
+                changes
+                    .breaking
+                    .push(format!("{path}: schema array changed"));
+            }
+        }
+        _ if before != after => changes.breaking.push(format!(
+            "{path}: schema value changed from {before} to {after}"
+        )),
+        _ => {}
+    }
+}
+
+fn compare_schema_object(
+    path: &str,
+    before: &Map<String, Value>,
+    after: &Map<String, Value>,
+    changes: &mut Changes,
+) {
+    compare_named_schemas(path, "properties", before, after, changes);
+    compare_named_schemas(path, "$defs", before, after, changes);
+    compare_required(path, before, after, changes);
+    compare_variants(path, "enum", before, after, changes);
+    compare_variants(path, "anyOf", before, after, changes);
+    compare_variants(path, "oneOf", before, after, changes);
+
+    const HANDLED: &[&str] = &["properties", "$defs", "required", "enum", "anyOf", "oneOf"];
+    const DOCUMENTATION: &[&str] = &["title", "description", "examples"];
+
+    for (key, value) in before {
+        if HANDLED.contains(&key.as_str()) || DOCUMENTATION.contains(&key.as_str()) {
+            continue;
+        }
+        match after.get(key) {
+            Some(current) => compare_schema(&format!("{path}.{key}"), value, current, changes),
+            None if key == "default" => changes.breaking.push(format!("{path}: default removed")),
+            None => changes
+                .additive
+                .push(format!("{path}: constraint removed: {key}")),
+        }
+    }
+    for key in after.keys() {
+        if before.contains_key(key)
+            || HANDLED.contains(&key.as_str())
+            || DOCUMENTATION.contains(&key.as_str())
+        {
+            continue;
+        }
+        if key == "default" {
+            changes.breaking.push(format!("{path}: default added"));
+        } else {
+            changes
+                .breaking
+                .push(format!("{path}: new constraint added: {key}"));
+        }
+    }
+}
+
+fn compare_named_schemas(
+    path: &str,
+    field: &str,
+    before: &Map<String, Value>,
+    after: &Map<String, Value>,
+    changes: &mut Changes,
+) {
+    let before = before
+        .get(field)
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let after = after
+        .get(field)
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    for (name, schema) in &before {
+        match after.get(name) {
+            Some(current) => {
+                compare_schema(&format!("{path}.{field}.{name}"), schema, current, changes)
+            }
+            None => changes
+                .breaking
+                .push(format!("{path}: {field} entry removed: {name}")),
+        }
+    }
+    for name in after.keys() {
+        if !before.contains_key(name) {
+            let message = format!("{path}: {field} entry added: {name}");
+            changes.additive.push(message);
+        }
+    }
+}
+
+fn required_fields(object: &Map<String, Value>) -> BTreeSet<String> {
+    object
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect()
+}
+
+fn compare_required(
+    path: &str,
+    before: &Map<String, Value>,
+    after: &Map<String, Value>,
+    changes: &mut Changes,
+) {
+    let before = required_fields(before);
+    let after = required_fields(after);
+    for field in before.difference(&after) {
+        changes
+            .additive
+            .push(format!("{path}: input is no longer required: {field}"));
+    }
+    for field in after.difference(&before) {
+        changes
+            .breaking
+            .push(format!("{path}: new required input: {field}"));
+    }
+}
+
+fn compare_variants(
+    path: &str,
+    field: &str,
+    before: &Map<String, Value>,
+    after: &Map<String, Value>,
+    changes: &mut Changes,
+) {
+    let before = before
+        .get(field)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let after = after
+        .get(field)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    for variant in &before {
+        if !after.contains(variant) {
+            changes.breaking.push(format!(
+                "{path}.{field}: accepted schema variant removed: {variant}"
+            ));
+        }
+    }
+    for variant in &after {
+        if !before.contains(variant) {
+            changes.additive.push(format!(
+                "{path}.{field}: accepted schema variant added: {variant}"
+            ));
+        }
+    }
+}
+
+fn sample_catalog() -> Catalog {
+    Catalog {
+        format_version: CATALOG_FORMAT_VERSION,
+        tools: vec![CatalogTool {
+            name: "sample_tool".to_string(),
+            toolset: "database".to_string(),
+            submodule: Some("keys".to_string()),
+            required_tier: "read-only".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "key": { "type": "string" }
+                },
+                "required": ["key"]
+            }),
+            output_schema: None,
+            annotations: CatalogAnnotations {
+                title: None,
+                read_only_hint: true,
+                destructive_hint: false,
+                idempotent_hint: true,
+                open_world_hint: true,
+            },
+        }],
+    }
+}
+
+#[test]
+fn catalog_comparison_classifies_tool_additions_and_removals() {
+    let baseline = sample_catalog();
+    let mut current = sample_catalog();
+    current.tools.clear();
+
+    let changes = compare_catalog(&baseline, &current);
+    assert!(
+        changes
+            .breaking
+            .iter()
+            .any(|change| change == "tool removed: sample_tool"),
+        "tool removal should be breaking"
+    );
+
+    let mut current = sample_catalog();
+    let mut added = current.tools[0].clone();
+    added.name = "new_tool".to_string();
+    current.tools.push(added);
+    let changes = compare_catalog(&baseline, &current);
+    assert!(
+        changes
+            .additive
+            .iter()
+            .any(|change| change == "tool added: new_tool"),
+        "tool addition should be reviewable and additive"
+    );
+}
+
+#[test]
+fn catalog_comparison_distinguishes_optional_and_required_inputs() {
+    let baseline = sample_catalog();
+    let mut current = sample_catalog();
+    current.tools[0].input_schema["properties"]["limit"] = serde_json::json!({ "type": "integer" });
+
+    let changes = compare_catalog(&baseline, &current);
+    assert!(changes.breaking.is_empty());
+    assert!(
+        changes
+            .additive
+            .iter()
+            .any(|change| change.contains("properties entry added: limit"))
+    );
+
+    current.tools[0].input_schema["required"] = serde_json::json!(["key", "limit"]);
+    let changes = compare_catalog(&baseline, &current);
+    assert!(
+        changes
+            .breaking
+            .iter()
+            .any(|change| change.contains("new required input: limit"))
+    );
+}
+
+#[test]
+fn catalog_comparison_detects_safety_tier_regressions() {
+    let mut baseline = sample_catalog();
+    baseline.tools[0].annotations.read_only_hint = false;
+    baseline.tools[0].required_tier = "read-write".to_string();
+    let mut current = baseline.clone();
+    current.tools[0].annotations.read_only_hint = true;
+    current.tools[0].required_tier = "read-only".to_string();
+
+    let changes = compare_catalog(&baseline, &current);
+    assert!(changes.breaking.iter().any(|change| {
+        change.contains("required safety tier changed from read-write to read-only")
+    }));
+    assert!(
+        changes
+            .breaking
+            .iter()
+            .any(|change| change.contains("readOnlyHint changed from false to true"))
+    );
+}
+
+#[test]
+fn schema_normalization_preserves_fields_named_like_documentation_keywords() {
+    let schema = serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "ExampleInput",
+        "properties": {
+            "description": {
+                "description": "User-provided description",
+                "type": "string"
+            },
+            "title": {
+                "description": "User-provided title",
+                "type": "string"
+            }
+        }
+    });
+
+    let normalized = contract_schema(schema);
+    assert!(normalized.get("$schema").is_none());
+    assert!(normalized.get("title").is_none());
+    assert_eq!(
+        normalized["properties"]["description"],
+        serde_json::json!({ "type": "string" })
+    );
+    assert_eq!(
+        normalized["properties"]["title"],
+        serde_json::json!({ "type": "string" })
+    );
+}
+
+#[test]
+fn documented_tool_counts_match_catalog() {
+    let catalog: Catalog = serde_json::from_str(CATALOG_JSON).expect("catalog fixture is valid");
+    let reference_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/docs/mcp/tools-reference.md");
+    let reference = std::fs::read_to_string(&reference_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", reference_path.display()));
+    let configuration_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/docs/mcp/configuration.md");
+    let configuration = std::fs::read_to_string(&configuration_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", configuration_path.display()));
+
+    assert!(
+        reference.contains(&format!("**{} tools**", catalog.tools.len())),
+        "tools reference total must match the catalog"
+    );
+    for (toolset, heading) in [
+        ("app", "App Toolset"),
+        ("cloud", "Cloud Toolset"),
+        ("database", "Database Toolset"),
+        ("enterprise", "Enterprise Toolset"),
+        ("system", "System Tools"),
+    ] {
+        let count = catalog
+            .tools
+            .iter()
+            .filter(|tool| tool.toolset == toolset)
+            .count();
+        assert!(
+            reference.contains(&format!("## {heading} ({count} tools)")),
+            "{toolset} heading count must match the catalog"
+        );
+        if toolset != "system" {
+            let row_prefix = format!("| `{toolset}` |");
+            let row = configuration
+                .lines()
+                .find(|line| line.starts_with(&row_prefix))
+                .unwrap_or_else(|| panic!("missing {toolset} row in MCP configuration"));
+            assert!(
+                row.ends_with(&format!("| {count} |")),
+                "{toolset} configuration count must match the catalog"
+            );
+        }
+    }
+
+    let mut submodule_counts = BTreeMap::<(&str, &str), usize>::new();
+    for tool in &catalog.tools {
+        if let Some(submodule) = tool.submodule.as_deref() {
+            *submodule_counts
+                .entry((tool.toolset.as_str(), submodule))
+                .or_default() += 1;
+        }
+    }
+    for ((toolset, submodule), count) in submodule_counts {
+        let noun = if count == 1 { "tool" } else { "tools" };
+        assert!(
+            reference.contains(&format!("### `{toolset}:{submodule}` ({count} {noun})")),
+            "{toolset}:{submodule} heading count must match the catalog"
+        );
+    }
+}
+
+#[tokio::test]
+async fn policy_tiers_filter_every_cataloged_tool() {
+    let mut baseline: Catalog =
+        serde_json::from_str(CATALOG_JSON).expect("catalog fixture is valid");
+    baseline
+        .tools
+        .retain(|tool| compiled_toolset(&tool.toolset));
+
+    for (tier, maximum_rank) in [
+        (SafetyTier::ReadOnly, 0),
+        (SafetyTier::ReadWrite, 1),
+        (SafetyTier::Full, 2),
+    ] {
+        let actual = current_catalog_for_tier(tier)
+            .await
+            .tools
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect::<BTreeSet<_>>();
+        let expected = baseline
+            .tools
+            .iter()
+            .filter(|tool| tier_rank(&tool.required_tier) <= maximum_rank)
+            .map(|tool| tool.name.clone())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            actual, expected,
+            "{tier} policy must expose exactly the cataloged tiers it permits"
+        );
+    }
+}
+
+#[tokio::test]
+async fn mcp_catalog_matches_1_0_baseline() {
+    let current = current_catalog().await;
+
+    if std::env::var_os("UPDATE_MCP_CATALOG").is_some() {
+        #[cfg(not(all(feature = "cloud", feature = "enterprise", feature = "database")))]
+        panic!("UPDATE_MCP_CATALOG requires --all-features");
+        #[cfg(all(feature = "cloud", feature = "enterprise", feature = "database"))]
+        {
+            let json = serde_json::to_string_pretty(&current).expect("catalog should serialize");
+            std::fs::write(CATALOG_PATH, format!("{json}\n"))
+                .expect("catalog fixture should update");
+            return;
+        }
+    }
+
+    let mut baseline: Catalog =
+        serde_json::from_str(CATALOG_JSON).expect("catalog fixture is valid");
+    baseline
+        .tools
+        .retain(|tool| compiled_toolset(&tool.toolset));
+    let changes = compare_catalog(&baseline, &current);
+    assert!(
+        changes.is_empty(),
+        "MCP catalog changed. Review the classification below, then run \
+         `UPDATE_MCP_CATALOG=1 cargo test -p redisctl-mcp --all-features \
+         mcp_catalog_matches_1_0_baseline` and inspect the fixture diff.{}",
+        changes.render()
+    );
+}
+
+#[test]
+fn bundled_skills_have_valid_metadata_and_tool_references() {
+    let known_tools = known_tool_names();
+    let skills_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("skills");
+    let mut entries = std::fs::read_dir(&skills_dir)
+        .expect("bundled skills directory should be readable")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("bundled skill entries should be readable");
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    let mut skill_names = HashSet::new();
+    assert!(
+        !entries.is_empty(),
+        "at least one bundled skill is expected"
+    );
+    for entry in entries {
+        if !entry
+            .file_type()
+            .expect("skill entry type should be readable")
+            .is_dir()
+        {
+            continue;
+        }
+        let directory_name = entry.file_name().to_string_lossy().into_owned();
+        let path = entry.path().join("SKILL.md");
+        let content = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+        let skill = parse_skill(&content)
+            .unwrap_or_else(|| panic!("{} has invalid frontmatter", path.display()));
+
+        assert_eq!(
+            skill.name,
+            directory_name,
+            "{}: frontmatter name must match its directory",
+            path.display()
+        );
+        assert!(
+            skill_names.insert(skill.name.clone()),
+            "duplicate bundled skill name: {}",
+            skill.name
+        );
+        assert!(
+            !skill.description.trim().is_empty(),
+            "{}: description must not be empty",
+            path.display()
+        );
+        assert!(
+            !skill.body.trim().is_empty(),
+            "{}: body must not be empty",
+            path.display()
+        );
+
+        let references = skill_tool_references(&skill.body, &known_tools, &path);
+        assert!(
+            !references.is_empty(),
+            "{}: skill must reference at least one registered tool",
+            path.display()
+        );
+    }
+}
+
+fn compiled_toolset(toolset: &str) -> bool {
+    matches!(toolset, "app" | "system")
+        || (cfg!(feature = "cloud") && toolset == "cloud")
+        || (cfg!(feature = "enterprise") && toolset == "enterprise")
+        || (cfg!(feature = "database") && toolset == "database")
+}
+
+fn known_tool_names() -> HashSet<String> {
+    let catalog: Catalog = serde_json::from_str(CATALOG_JSON).expect("catalog fixture is valid");
+    catalog.tools.into_iter().map(|tool| tool.name).collect()
+}
+
+fn skill_tool_references(body: &str, known: &HashSet<String>, path: &Path) -> HashSet<String> {
+    let mut references = HashSet::new();
+    for line in body.lines() {
+        let mut remainder = line;
+        while let Some(open) = remainder.find('`') {
+            let before = &remainder[..open];
+            let after_open = &remainder[open + 1..];
+            let Some(close) = after_open.find('`') else {
+                break;
+            };
+            let token = after_open[..close].trim();
+            if is_identifier(token) {
+                if known.contains(token) {
+                    references.insert(token.to_string());
+                } else if looks_like_tool_reference(token, before) {
+                    panic!(
+                        "{}: `{token}` looks like a tool reference but is not registered",
+                        path.display()
+                    );
+                }
+            }
+            remainder = &after_open[close + 1..];
+        }
+    }
+    references
+}
+
+fn is_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+}
+
+fn looks_like_tool_reference(token: &str, before: &str) -> bool {
+    let tool_verb = [
+        "create_",
+        "delete_",
+        "enterprise_",
+        "get_",
+        "list_",
+        "profile_",
+        "redis_",
+        "update_",
+        "wait_",
+    ]
+    .iter()
+    .any(|prefix| token.starts_with(prefix));
+    let preceding_word = before
+        .trim_end_matches(|character: char| character.is_whitespace() || character == '*')
+        .split(|character: char| !character.is_ascii_alphabetic())
+        .next_back()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    tool_verb && matches!(preceding_word.as_str(), "call" | "use" | "using" | "with")
+}

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -948,9 +948,12 @@ async fn run_http_server(
 }
 
 #[cfg(test)]
+mod catalog_contract;
+
+#[cfg(test)]
 mod tests {
     use super::*;
-    use redisctl_core::{Profile, ProfileCredentials};
+    use redisctl_core::{DeploymentType, Profile, ProfileCredentials};
 
     fn cloud_profile() -> Profile {
         Profile {
@@ -1536,6 +1539,7 @@ mod tests {
         };
         let disabled = config.disabled_toolsets();
 
+        #[allow(unused_mut)]
         let mut toolsets = vec![Toolset::App];
         #[cfg(feature = "cloud")]
         toolsets.push(Toolset::Cloud);

--- a/crates/redisctl-mcp/tests/fixtures/mcp-catalog-v1.json
+++ b/crates/redisctl-mcp/tests/fixtures/mcp-catalog-v1.json
@@ -1,0 +1,16271 @@
+{
+  "formatVersion": 1,
+  "tools": [
+    {
+      "name": "accept_aa_tgw_invitation",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "invitation_id": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "invitation_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "accept_tgw_invitation",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "invitation_id": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "invitation_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "acknowledge_enterprise_alert",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "alert_uid": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "alert_uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "add_aa_private_link_principals",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "alias": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "principal": {
+            "type": "string"
+          },
+          "principal_type": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "principal"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "add_active_active_region",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "deployment_cidr": {
+            "type": "string"
+          },
+          "dry_run": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "resp_version": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "vpc_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id",
+          "deployment_cidr"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "add_private_link_principals",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "alias": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "principal": {
+            "type": "string"
+          },
+          "principal_type": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "principal"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "backup_database",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "timeout_seconds": {
+            "default": 600,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "backup_enterprise_database",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "bdb_uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "timeout_seconds": {
+            "default": 600,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "bdb_uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "backup_fixed_database",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "adhoc_backup_path": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "cloud_raw_api",
+      "toolset": "cloud",
+      "submodule": "raw",
+      "requiredTier": "full",
+      "inputSchema": {
+        "$defs": {
+          "HttpMethod": {
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE"
+            ],
+            "type": "string"
+          }
+        },
+        "properties": {
+          "body": {
+            "default": null
+          },
+          "dry_run": {
+            "default": false,
+            "type": "boolean"
+          },
+          "method": {
+            "$ref": "#/$defs/HttpMethod"
+          },
+          "path": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "method",
+          "path"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_aa_private_link",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "alias": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "principal": {
+            "type": "string"
+          },
+          "principal_type": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "share_name": {
+            "type": "string"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "share_name",
+          "principal",
+          "principal_type"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_aa_psc_endpoint",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "endpoint_connection_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "endpoint_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "gcp_project_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gcp_vpc_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gcp_vpc_subnet_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "psc_service_id",
+          "endpoint_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_aa_psc_service",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_aa_tgw_attachment",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "aws_account_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cidrs": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "tgw_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_aa_vpc_peering",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "aws_account_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "aws_region": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "destination_region": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gcp_project_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "network_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "provider": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "vpc_cidr": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "vpc_cidrs": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "vpc_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_acl_role",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "DatabaseSpec": {
+            "properties": {
+              "database_id": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "regions": {
+                "default": null,
+                "items": {
+                  "type": "string"
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "subscription_id": {
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "subscription_id",
+              "database_id"
+            ],
+            "type": "object"
+          },
+          "RedisRuleSpec": {
+            "properties": {
+              "databases": {
+                "items": {
+                  "$ref": "#/$defs/DatabaseSpec"
+                },
+                "type": "array"
+              },
+              "rule_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "rule_name",
+              "databases"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "redis_rules": {
+            "items": {
+              "$ref": "#/$defs/RedisRuleSpec"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "redis_rules"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_acl_user",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "role": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "role",
+          "password"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_cloud_account",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "access_key_id": {
+            "type": "string"
+          },
+          "access_secret_key": {
+            "type": "string"
+          },
+          "console_password": {
+            "type": "string"
+          },
+          "console_username": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "provider": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sign_in_login_url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "access_key_id",
+          "access_secret_key",
+          "console_username",
+          "console_password",
+          "sign_in_login_url"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_database",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "data_persistence": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "memory_limit_in_gb": {
+            "format": "double",
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "protocol": {
+            "default": "redis",
+            "type": "string"
+          },
+          "replication": {
+            "default": true,
+            "type": "boolean"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "timeout_seconds": {
+            "default": 600,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "name",
+          "memory_limit_in_gb"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_database_tag",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_enterprise_acl",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "acl": {
+            "type": "string"
+          },
+          "description": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "acl"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_enterprise_crdb",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "request": {}
+        },
+        "required": [
+          "request"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_enterprise_database",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "eviction_policy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "memory_size": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "persistence": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "port": {
+            "format": "uint16",
+            "maximum": 65535,
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "redis_version": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "replication": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "sharding": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "shards_count": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_enterprise_role",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "data_access": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "management": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_enterprise_user",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "email_alerts": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "password": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "role": {
+            "type": "string"
+          },
+          "role_uids": {
+            "default": null,
+            "items": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "email",
+          "password",
+          "role"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_fixed_database",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "data_eviction_policy": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "data_persistence": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "dataset_size_in_gb": {
+            "default": null,
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "enable_tls": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "memory_limit_in_gb": {
+            "default": null,
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "password": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "protocol": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "redis_version": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "replication": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "source_ips": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "support_oss_cluster_api": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_fixed_database_tag",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_fixed_subscription",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "payment_method": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "payment_method_id": {
+            "default": null,
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "plan_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "plan_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_private_link",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "alias": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "principal": {
+            "type": "string"
+          },
+          "principal_type": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "share_name": {
+            "type": "string"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "share_name",
+          "principal",
+          "principal_type"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_psc_endpoint",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "endpoint_connection_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "endpoint_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "gcp_project_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gcp_vpc_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gcp_vpc_subnet_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "psc_service_id",
+          "endpoint_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_psc_service",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_redis_rule",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "redis_rule": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "redis_rule"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_subscription",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "cloud_account_id": {
+            "default": 1,
+            "format": "int32",
+            "type": "integer"
+          },
+          "cloud_provider": {
+            "type": "string"
+          },
+          "database_name": {
+            "type": "string"
+          },
+          "memory_limit_in_gb": {
+            "format": "double",
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "protocol": {
+            "default": "redis",
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "replication": {
+            "default": true,
+            "type": "boolean"
+          },
+          "timeout_seconds": {
+            "default": 1800,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "cloud_provider",
+          "region",
+          "database_name",
+          "memory_limit_in_gb"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_tgw_attachment",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "tgw_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "create_vpc_peering",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "aws_account_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "aws_region": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gcp_project_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "network_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "provider": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "vpc_cidr": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "vpc_cidrs": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "vpc_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_aa_psc_endpoint",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "endpoint_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "psc_service_id",
+          "endpoint_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_aa_psc_service",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_aa_tgw_attachment",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "attachment_id": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "attachment_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_aa_vpc_peering",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "peering_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "peering_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_account_user",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "user_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "user_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_acl_role",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "role_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "role_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_acl_user",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "user_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "user_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_active_active_regions",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "full",
+      "inputSchema": {
+        "$defs": {
+          "ActiveActiveRegionToDeleteInput": {
+            "properties": {
+              "region": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "region"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "dry_run": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "regions": {
+            "items": {
+              "$ref": "#/$defs/ActiveActiveRegionToDeleteInput"
+            },
+            "type": "array"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "regions"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_cloud_account",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "cloud_account_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "cloud_account_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_database",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "timeout_seconds": {
+            "default": 600,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_database_tag",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "tag_key": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "tag_key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_enterprise_acl",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_enterprise_crdb",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "guid": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "guid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_enterprise_database",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_enterprise_role",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_enterprise_user",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_fixed_database",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_fixed_database_tag",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "tag_key": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "tag_key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_fixed_subscription",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_private_link",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_psc_endpoint",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "endpoint_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "psc_service_id",
+          "endpoint_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_psc_service",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_redis_rule",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "rule_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "rule_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_subscription",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "timeout_seconds": {
+            "default": 600,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_tgw_attachment",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "attachment_id": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "attachment_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "delete_vpc_peering",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "peering_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "peering_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "disable_enterprise_maintenance_mode",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "disable_enterprise_node_maintenance",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "download_cost_report",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "cost_report_id": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "cost_report_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "drain_enterprise_node",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "enable_enterprise_maintenance_mode",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "enable_enterprise_node_maintenance",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "enterprise_raw_api",
+      "toolset": "enterprise",
+      "submodule": "raw",
+      "requiredTier": "full",
+      "inputSchema": {
+        "$defs": {
+          "HttpMethod": {
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE"
+            ],
+            "type": "string"
+          }
+        },
+        "properties": {
+          "body": {
+            "default": null
+          },
+          "dry_run": {
+            "default": false,
+            "type": "boolean"
+          },
+          "method": {
+            "$ref": "#/$defs/HttpMethod"
+          },
+          "path": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "method",
+          "path"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "export_enterprise_database",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "export_location": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid",
+          "export_location"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "flush_crdb_database",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "flush_database",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "timeout_seconds": {
+            "default": 300,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "flush_enterprise_database",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "bdb_uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "timeout_seconds": {
+            "default": 600,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "bdb_uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "generate_cost_report",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "database_ids": {
+            "default": null,
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "end_date": {
+            "type": "string"
+          },
+          "format": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "regions": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "start_date": {
+            "type": "string"
+          },
+          "subscription_ids": {
+            "default": null,
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "subscription_type": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "start_date",
+          "end_date"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_aa_private_link",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_aa_private_link_endpoint_script",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_aa_psc_creation_script",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "endpoint_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "psc_service_id",
+          "endpoint_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_aa_psc_deletion_script",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "endpoint_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "psc_service_id",
+          "endpoint_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_aa_psc_endpoints",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "psc_service_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_aa_psc_service",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_aa_tgw_attachments",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_aa_tgw_invitations",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_aa_vpc_peering",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_account",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_account_user",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "user_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "user_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_acl_user",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "user_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "user_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_active_active_regions",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_all_databases_stats",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_all_nodes_stats",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_all_shards_stats",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_available_database_versions",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_backup_status",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_cloud_account",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "cloud_account_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "cloud_account_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_cluster",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_cluster_stats",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "end_time": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "interval": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "start_time": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_database",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_database_certificate",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_database_import_status",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_database_stats",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "end_time": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "interval": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "start_time": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_database_tags",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_database_upgrade_status",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_acl",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_cluster_certificates",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_cluster_policy",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_cluster_services",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_crdb",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "guid": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "guid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_crdb_tasks",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "guid": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "guid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_database",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_ldap_config",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_proxy",
+      "toolset": "enterprise",
+      "submodule": "proxy",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_role",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_service",
+      "toolset": "enterprise",
+      "submodule": "services",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "service_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "service_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_service_status",
+      "toolset": "enterprise",
+      "submodule": "services",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "service_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "service_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_user",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_enterprise_user_permissions",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_fixed_database",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_fixed_database_backup_status",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_fixed_database_import_status",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_fixed_database_slow_log",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_fixed_database_tags",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_fixed_database_upgrade_status",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_fixed_database_upgrade_versions",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_fixed_plan",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "plan_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "plan_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_fixed_plans_by_subscription",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_fixed_redis_versions",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_fixed_subscription",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_license",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_license_usage",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_module",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_modules",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_node",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_node_stats",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "end_time": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "interval": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "start_time": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_private_link",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_private_link_endpoint_script",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_psc_creation_script",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "endpoint_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "psc_service_id",
+          "endpoint_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_psc_deletion_script",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "endpoint_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "psc_service_id",
+          "endpoint_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_psc_endpoints",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "psc_service_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_psc_service",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_redis_versions",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "default": null,
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_regions",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "provider": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_session_logs",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "limit": {
+            "default": null,
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "offset": {
+            "default": null,
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_shard",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_shard_stats",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_slow_log",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_subscription",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_subscription_cidr_allowlist",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_subscription_maintenance_windows",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_subscription_pricing",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_system_logs",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "limit": {
+            "default": null,
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "offset": {
+            "default": null,
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_task",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "task_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "task_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_tgw_attachments",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_tgw_invitations",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "get_vpc_peering",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "import_database",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "import_from_uri": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "timeout_seconds": {
+            "default": 1800,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "source_type",
+          "import_from_uri"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "import_enterprise_database",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "bdb_uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "flush": {
+            "default": false,
+            "type": "boolean"
+          },
+          "import_location": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "timeout_seconds": {
+            "default": 600,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "bdb_uid",
+          "import_location"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "import_fixed_database",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "import_from_uri": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "source_type",
+          "import_from_uri"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_account_users",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_acl_roles",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_acl_users",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_alerts",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_available_tools",
+      "toolset": "system",
+      "submodule": null,
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_cloud_accounts",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_database_alerts",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_databases",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_enterprise_acls",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_enterprise_crdbs",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_enterprise_databases",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "name_filter": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status_filter": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_enterprise_proxies",
+      "toolset": "enterprise",
+      "submodule": "proxy",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_enterprise_roles",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_enterprise_services",
+      "toolset": "enterprise",
+      "submodule": "services",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_enterprise_users",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_fixed_databases",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "limit": {
+            "default": null,
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "offset": {
+            "default": null,
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_fixed_plans",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "provider": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "redis_flex": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_fixed_subscriptions",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_logs",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "end_time": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "default": null,
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "offset": {
+            "default": null,
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "order": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "start_time": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_modules",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_nodes",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_payment_methods",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_redis_rules",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_shards",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "database_uid": {
+            "default": null,
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_shards_by_database",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "bdb_uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "bdb_uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_shards_by_node",
+      "toolset": "enterprise",
+      "submodule": "observability",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "node_uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "node_uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_subscriptions",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "list_tasks",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "profile_create",
+      "toolset": "app",
+      "submodule": null,
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "api_key": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "api_secret": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "api_url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ca_cert": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "database": {
+            "default": null,
+            "format": "uint8",
+            "maximum": 255,
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "db_password": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "db_username": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "host": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "insecure": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "password": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "port": {
+            "default": null,
+            "format": "uint16",
+            "maximum": 65535,
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "profile_type": {
+            "type": "string"
+          },
+          "set_default": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "tls": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "username": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "profile_type"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "profile_delete",
+      "toolset": "app",
+      "submodule": null,
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "profile_list",
+      "toolset": "app",
+      "submodule": null,
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "profile_path",
+      "toolset": "app",
+      "submodule": null,
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "profile_set_default_cloud",
+      "toolset": "app",
+      "submodule": null,
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "profile_set_default_enterprise",
+      "toolset": "app",
+      "submodule": null,
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "profile_show",
+      "toolset": "app",
+      "submodule": null,
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "profile_validate",
+      "toolset": "app",
+      "submodule": null,
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "connect": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "rebalance_enterprise_node",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_acl_list",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_acl_whoami",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_alias_delete",
+      "toolset": "database",
+      "submodule": "aliases",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_alias_list",
+      "toolset": "database",
+      "submodule": "aliases",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_alias_run",
+      "toolset": "database",
+      "submodule": "aliases",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_alias_set",
+      "toolset": "database",
+      "submodule": "aliases",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "AliasCommand": {
+            "properties": {
+              "args": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "args"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "commands": {
+            "items": {
+              "$ref": "#/$defs/AliasCommand"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "commands"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_append",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_bulk_load",
+      "toolset": "database",
+      "submodule": "bulk",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "Command": {
+            "properties": {
+              "args": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "args"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "batch_size": {
+            "default": 1000,
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "collect_results": {
+            "default": false,
+            "type": "boolean"
+          },
+          "commands": {
+            "items": {
+              "$ref": "#/$defs/Command"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "commands"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_client_list",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_cluster_info",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_command",
+      "toolset": "database",
+      "submodule": "raw",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "args": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "command": {
+            "type": "string"
+          },
+          "dry_run": {
+            "default": false,
+            "type": "boolean"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "command"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_config_get",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "parameter": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "parameter"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_config_set",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "parameter": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "parameter",
+          "value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_connection_summary",
+      "toolset": "database",
+      "submodule": "diagnostics",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_copy",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "destination": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "replace": {
+            "default": false,
+            "type": "boolean"
+          },
+          "source": {
+            "type": "string"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "source",
+          "destination"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_dbsize",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_decr",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_del",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_dump",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_exists",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_expire",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "seconds": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "seconds"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_flushdb",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "async_flush": {
+            "default": false,
+            "type": "boolean"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_aggregate",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "index": {
+            "type": "string"
+          },
+          "limit_num": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "limit_offset": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "load_fields": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "query": {
+            "type": "string"
+          },
+          "raw_args": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "index",
+          "query"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_aliasadd",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "index": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "alias",
+          "index"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_aliasdel",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "alias"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_aliasupdate",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "index": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "alias",
+          "index"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_alter",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "FieldDefinition": {
+            "properties": {
+              "alias": {
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "field_type": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "noindex": {
+                "default": false,
+                "type": "boolean"
+              },
+              "nostem": {
+                "default": false,
+                "type": "boolean"
+              },
+              "separator": {
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sortable": {
+                "default": false,
+                "type": "boolean"
+              },
+              "weight": {
+                "default": null,
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "field_type"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "field": {
+            "$ref": "#/$defs/FieldDefinition"
+          },
+          "index": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "index",
+          "field"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_create",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "FieldDefinition": {
+            "properties": {
+              "alias": {
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "field_type": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "noindex": {
+                "default": false,
+                "type": "boolean"
+              },
+              "nostem": {
+                "default": false,
+                "type": "boolean"
+              },
+              "separator": {
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sortable": {
+                "default": false,
+                "type": "boolean"
+              },
+              "weight": {
+                "default": null,
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "field_type"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "if_exists": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "index": {
+            "type": "string"
+          },
+          "on": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "prefixes": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema": {
+            "items": {
+              "$ref": "#/$defs/FieldDefinition"
+            },
+            "type": "array"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "index",
+          "schema"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_dictadd",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "dict": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "terms": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "dict",
+          "terms"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_dictdel",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "dict": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "terms": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "dict",
+          "terms"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_dictdump",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "dict": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "dict"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_dropindex",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "delete_docs": {
+            "default": false,
+            "type": "boolean"
+          },
+          "index": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "index"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_explain",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "index": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "query": {
+            "type": "string"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "index",
+          "query"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_info",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "index": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "index"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_list",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_profile",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "command": {
+            "type": "string"
+          },
+          "index": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "query": {
+            "type": "string"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "index",
+          "command",
+          "query"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_search",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "index": {
+            "type": "string"
+          },
+          "limit_num": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "limit_offset": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "nocontent": {
+            "default": false,
+            "type": "boolean"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "query": {
+            "type": "string"
+          },
+          "return_fields": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "sortby": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sortby_order": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "verbatim": {
+            "default": false,
+            "type": "boolean"
+          },
+          "withscores": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "index",
+          "query"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_syndump",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "index": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "index"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_synupdate",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "group_id": {
+            "type": "string"
+          },
+          "index": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "terms": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "index",
+          "group_id",
+          "terms"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ft_tagvals",
+      "toolset": "database",
+      "submodule": "search",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "index": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "index",
+          "field"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_get",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_getrange",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "end": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "start": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "start",
+          "end"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hdel",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "fields"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_health_check",
+      "toolset": "database",
+      "submodule": "diagnostics",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hexists",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "field"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hexpire",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "condition": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "seconds": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "seconds",
+          "fields"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hget",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "field"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hgetall",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hincrby",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "increment": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "field",
+          "increment"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hkeys",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hlen",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hmget",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "fields"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hotkeys",
+      "toolset": "database",
+      "submodule": "diagnostics",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "pattern": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sample_size": {
+            "default": null,
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hset",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "fields": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "fields"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_hvals",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_incr",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_info",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "section": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_arrappend",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "values": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "key",
+          "values"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_arrinsert",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "index": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "values": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "key",
+          "index",
+          "values"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_arrlen",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_arrpop",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "index": {
+            "default": null,
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_arrtrim",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "start": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "stop": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "start",
+          "stop"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_clear",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_del",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_get",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "paths": {
+            "default": [
+              "$"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_mget",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_numincrby",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_objkeys",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_objlen",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_set",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "nx": {
+            "default": false,
+            "type": "boolean"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": "string"
+          },
+          "xx": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_strlen",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_toggle",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_json_type",
+      "toolset": "database",
+      "submodule": "json",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "path": {
+            "default": "$",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_key_summary",
+      "toolset": "database",
+      "submodule": "diagnostics",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_keys",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "limit": {
+            "default": 100,
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pattern": {
+            "default": "*",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_latency_history",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "event": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "event"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_lindex",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "index": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "index"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_llen",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_lpop",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "count": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_lpush",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "elements": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "elements"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_lrange",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "start": {
+            "default": 0,
+            "format": "int64",
+            "type": "integer"
+          },
+          "stop": {
+            "default": -1,
+            "format": "int64",
+            "type": "integer"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_memory_stats",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_memory_usage",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_mget",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_module_list",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_mset",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "KeyValuePair": {
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "entries": {
+            "items": {
+              "$ref": "#/$defs/KeyValuePair"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "entries"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_object_encoding",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_object_freq",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_object_help",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_object_idletime",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_persist",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ping",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_pubsub_channels",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "pattern": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_pubsub_numsub",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "channels": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_randomkey",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_rename",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "newkey": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "newkey"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_restore",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "serialized_value": {
+            "type": "string"
+          },
+          "ttl_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "ttl_ms",
+          "serialized_value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_rpop",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "count": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_rpush",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "elements": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "elements"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_sadd",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "members": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "members"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_scan",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key_type": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "default": 100,
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pattern": {
+            "default": "*",
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_scard",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_sdiff",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_seed",
+      "toolset": "database",
+      "submodule": "bulk",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "FieldValue": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "batch_size": {
+            "default": 1000,
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "count": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "data_type": {
+            "type": "string"
+          },
+          "field_values": {
+            "items": {
+              "$ref": "#/$defs/FieldValue"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "key_pattern": {
+            "type": "string"
+          },
+          "member_pattern": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "score_max": {
+            "default": null,
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "score_min": {
+            "default": null,
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "ttl": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value_pattern": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "data_type",
+          "key_pattern",
+          "count"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_set",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "ex": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "nx": {
+            "default": false,
+            "type": "boolean"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "px": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": "string"
+          },
+          "xx": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_setnx",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_setrange",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "offset": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "offset",
+          "value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_sinter",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_sismember",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "member": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "member"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_slowlog",
+      "toolset": "database",
+      "submodule": "server",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "count": {
+            "default": 10,
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_smembers",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_srem",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "members": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "members"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_strlen",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_sunion",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_touch",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_ttl",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_type",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_unlink",
+      "toolset": "database",
+      "submodule": "keys",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_xadd",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "approximate": {
+            "default": false,
+            "type": "boolean"
+          },
+          "fields": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "maxlen": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "minid": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "nomkstream": {
+            "default": false,
+            "type": "boolean"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "fields"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_xinfo_stream",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_xlen",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_xrange",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "count": {
+            "default": null,
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "end": {
+            "default": "+",
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "start": {
+            "default": "-",
+            "type": "string"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_xtrim",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "approximate": {
+            "default": false,
+            "type": "boolean"
+          },
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "strategy": {
+            "type": "string"
+          },
+          "threshold": {
+            "type": "string"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "strategy",
+          "threshold"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_zadd",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "ScoreMember": {
+            "properties": {
+              "member": {
+                "type": "string"
+              },
+              "score": {
+                "format": "double",
+                "type": "number"
+              }
+            },
+            "required": [
+              "score",
+              "member"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "ch": {
+            "default": false,
+            "type": "boolean"
+          },
+          "gt": {
+            "default": false,
+            "type": "boolean"
+          },
+          "key": {
+            "type": "string"
+          },
+          "lt": {
+            "default": false,
+            "type": "boolean"
+          },
+          "members": {
+            "items": {
+              "$ref": "#/$defs/ScoreMember"
+            },
+            "type": "array"
+          },
+          "nx": {
+            "default": false,
+            "type": "boolean"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "xx": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "key",
+          "members"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_zcard",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_zcount",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "max": {
+            "type": "string"
+          },
+          "min": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "min",
+          "max"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_zrange",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "rev": {
+            "default": false,
+            "type": "boolean"
+          },
+          "start": {
+            "default": 0,
+            "format": "int64",
+            "type": "integer"
+          },
+          "stop": {
+            "default": -1,
+            "format": "int64",
+            "type": "integer"
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "withscores": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_zrangebyscore",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "count": {
+            "default": null,
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "max": {
+            "type": "string"
+          },
+          "min": {
+            "type": "string"
+          },
+          "offset": {
+            "default": null,
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "withscores": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "key",
+          "min",
+          "max"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_zrank",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "member": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "member"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_zrem",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "members": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "members"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_zremrangebyscore",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "max": {
+            "type": "string"
+          },
+          "min": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "min",
+          "max"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "redis_zscore",
+      "toolset": "database",
+      "submodule": "structures",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "member": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "member"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "reject_aa_tgw_invitation",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "invitation_id": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "invitation_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "reject_tgw_invitation",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "invitation_id": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "invitation_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "remove_aa_private_link_principals",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "alias": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "principal": {
+            "type": "string"
+          },
+          "principal_type": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "principal"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "remove_enterprise_node",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "full",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "remove_private_link_principals",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "alias": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "principal": {
+            "type": "string"
+          },
+          "principal_type": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "principal"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "restart_enterprise_service",
+      "toolset": "enterprise",
+      "submodule": "services",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "service_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "service_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "restore_enterprise_database",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "backup_uid": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "rotate_enterprise_cluster_certificates",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "show_policy",
+      "toolset": "system",
+      "submodule": null,
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "start_enterprise_service",
+      "toolset": "enterprise",
+      "submodule": "services",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "service_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "service_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "stop_enterprise_service",
+      "toolset": "enterprise",
+      "submodule": "services",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "service_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "service_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_aa_psc_endpoint",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "endpoint_connection_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "endpoint_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "gcp_project_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gcp_vpc_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gcp_vpc_subnet_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "endpoint_id",
+          "psc_service_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_aa_tgw_attachment_cidrs",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "attachment_id": {
+            "type": "string"
+          },
+          "aws_account_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cidrs": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "tgw_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id",
+          "region_id",
+          "attachment_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_aa_vpc_peering",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "peering_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "vpc_cidr": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "vpc_cidrs": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id",
+          "peering_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_account_user",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "role": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "user_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "user_id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_acl_role",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "DatabaseSpec": {
+            "properties": {
+              "database_id": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "regions": {
+                "default": null,
+                "items": {
+                  "type": "string"
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "subscription_id": {
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "subscription_id",
+              "database_id"
+            ],
+            "type": "object"
+          },
+          "RedisRuleSpec": {
+            "properties": {
+              "databases": {
+                "items": {
+                  "$ref": "#/$defs/DatabaseSpec"
+                },
+                "type": "array"
+              },
+              "rule_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "rule_name",
+              "databases"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "redis_rules": {
+            "items": {
+              "$ref": "#/$defs/RedisRuleSpec"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "role_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "role_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_acl_user",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "password": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "role": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "user_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "user_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_cloud_account",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "access_key_id": {
+            "type": "string"
+          },
+          "access_secret_key": {
+            "type": "string"
+          },
+          "cloud_account_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "console_password": {
+            "type": "string"
+          },
+          "console_username": {
+            "type": "string"
+          },
+          "name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sign_in_login_url": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "cloud_account_id",
+          "access_key_id",
+          "access_secret_key",
+          "console_username",
+          "console_password"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_crdb_local_properties",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "data_eviction_policy": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "dataset_size_in_gb": {
+            "default": null,
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "dry_run": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "enable_tls": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "global_data_persistence": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "global_password": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "global_source_ip": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "memory_limit_in_gb": {
+            "default": null,
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "support_oss_cluster_api": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "use_external_endpoint_for_oss_cluster_api": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_database",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "data_eviction_policy": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "data_persistence": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "memory_limit_in_gb": {
+            "default": null,
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "replication": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "timeout_seconds": {
+            "default": 600,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_database_tag",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "tag_key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "tag_key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_database_tags",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "TagInput": {
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/$defs/TagInput"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "tags"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_acl",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "acl": {
+            "type": "string"
+          },
+          "description": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid",
+          "name",
+          "acl"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_cluster",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updates": {}
+        },
+        "required": [
+          "updates"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_cluster_certificates",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "certificate": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "certificate",
+          "key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_cluster_policy",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "policy": {},
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "policy"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_crdb",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "guid": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updates": {}
+        },
+        "required": [
+          "guid",
+          "updates"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_database",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "updates": {}
+        },
+        "required": [
+          "uid",
+          "updates"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_ldap_config",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "config": {},
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "config"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_license",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "license_key": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "license_key"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_node",
+      "toolset": "enterprise",
+      "submodule": "cluster",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "updates": {}
+        },
+        "required": [
+          "uid",
+          "updates"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_proxy",
+      "toolset": "enterprise",
+      "submodule": "proxy",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "updates": {}
+        },
+        "required": [
+          "uid",
+          "updates"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_role",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "data_access": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "management": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid",
+          "name"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_service",
+      "toolset": "enterprise",
+      "submodule": "services",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "config": {},
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "service_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "service_id",
+          "config"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_enterprise_user",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "email": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "email_alerts": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "password": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "role": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "role_uids": {
+            "default": null,
+            "items": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_fixed_database",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "data_eviction_policy": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "data_persistence": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "enable_tls": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "memory_limit_in_gb": {
+            "default": null,
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "password": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "replication": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "source_ips": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_fixed_database_tag",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "tag_key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "tag_key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_fixed_database_tags",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "FixedTagInput": {
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/$defs/FixedTagInput"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "tags"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_fixed_subscription",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "payment_method": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "payment_method_id": {
+            "default": null,
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "plan_id": {
+            "default": null,
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_psc_endpoint",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "endpoint_connection_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "endpoint_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "gcp_project_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gcp_vpc_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gcp_vpc_subnet_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psc_service_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "endpoint_id",
+          "psc_service_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_redis_rule",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "redis_rule": {
+            "type": "string"
+          },
+          "rule_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "rule_id",
+          "name",
+          "redis_rule"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_subscription",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "payment_method": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "payment_method_id": {
+            "default": null,
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_subscription_cidr_allowlist",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "cidr_ips": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "security_group_ids": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "subscription_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_subscription_maintenance_windows",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "$defs": {
+          "MaintenanceWindowInput": {
+            "properties": {
+              "days": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "duration_in_hours": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "start_hour": {
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "start_hour",
+              "duration_in_hours",
+              "days"
+            ],
+            "type": "object"
+          }
+        },
+        "properties": {
+          "mode": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "windows": {
+            "items": {
+              "$ref": "#/$defs/MaintenanceWindowInput"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id",
+          "mode"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_tgw_attachment_cidrs",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "attachment_id": {
+            "type": "string"
+          },
+          "aws_account_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cidrs": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "tgw_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id",
+          "attachment_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "update_vpc_peering",
+      "toolset": "cloud",
+      "submodule": "networking",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "aws_account_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "aws_region": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gcp_project_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "network_name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "peering_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "provider": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "vpc_cidr": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "vpc_cidrs": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "vpc_id": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "subscription_id",
+          "peering_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "upgrade_database_redis_version",
+      "toolset": "cloud",
+      "submodule": "subscriptions",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "target_redis_version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "target_redis_version"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "upgrade_enterprise_database_redis",
+      "toolset": "enterprise",
+      "submodule": "databases",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "force_restart": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "may_discard_data": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "redis_version": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "uid"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "upgrade_fixed_database_redis_version",
+      "toolset": "cloud",
+      "submodule": "fixed",
+      "requiredTier": "read-write",
+      "inputSchema": {
+        "properties": {
+          "database_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subscription_id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "target_version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "database_id",
+          "target_version"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "validate_enterprise_acl",
+      "toolset": "enterprise",
+      "submodule": "rbac",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "acl": {
+            "type": "string"
+          },
+          "description": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "acl"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "wait_for_cloud_task",
+      "toolset": "cloud",
+      "submodule": "account",
+      "requiredTier": "read-only",
+      "inputSchema": {
+        "properties": {
+          "interval_seconds": {
+            "default": 5,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "profile": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "task_id": {
+            "type": "string"
+          },
+          "timeout_seconds": {
+            "default": 300,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "task_id"
+        ],
+        "type": "object"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "title": null,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      }
+    }
+  ]
+}

--- a/docs/docs/mcp/architecture.md
+++ b/docs/docs/mcp/architecture.md
@@ -15,7 +15,7 @@ redisctl-mcp
     |
     +-- Policy engine (tier checks, allow/deny lists)
     +-- Audit layer (structured logging of tool calls)
-    +-- Tool router (392 tools across 4 toolsets)
+    +-- Tool router (cataloged tools across 4 toolsets)
     |       |
     |       +-- Cloud tools -> redis-cloud client -> Cloud REST API
     |       +-- Enterprise tools -> redis-enterprise client -> Enterprise REST API

--- a/docs/docs/mcp/compatibility.md
+++ b/docs/docs/mcp/compatibility.md
@@ -1,0 +1,122 @@
+# MCP Compatibility and Catalog
+
+The stable redisctl 1.x MCP contract is the tool surface exposed by the stdio server for a
+documented feature set. The all-features catalog is recorded in
+[`mcp-catalog-v1.json`](https://github.com/redis/redisctl/blob/main/crates/redisctl-mcp/tests/fixtures/mcp-catalog-v1.json)
+and checked in CI.
+
+The current all-features baseline contains 375 tools:
+
+| Toolset | Tools |
+| --- | ---: |
+| Cloud | 148 |
+| Enterprise | 85 |
+| Database | 132 |
+| App/profile | 8 |
+| System | 2 |
+
+Runtime discovery remains authoritative for a particular installation. Feature flags, `--tools`,
+visibility presets, and policy tiers can expose a supported subset of this catalog. Call
+`list_available_tools` to inspect that resolved subset.
+
+## What the catalog records
+
+Each entry records:
+
+- the tool name, toolset, and submodule;
+- its normalized input JSON Schema;
+- its structured `outputSchema`, or `null` when the tool does not declare one;
+- all MCP safety annotations with protocol defaults made explicit; and
+- the minimum redisctl safety tier derived from those annotations.
+
+Schema titles, descriptions, examples, and the repeated `$schema` declaration are excluded from
+the fixture. They are explanatory text rather than callable input constraints. Defaults, types,
+formats, accepted variants, required fields, and other validation constraints remain in the
+contract.
+
+Most current tools return MCP text content and do not declare a structured `outputSchema`.
+`outputSchema: null` records that fact; it does not turn prose or upstream-controlled JSON into a
+new structured guarantee. When redisctl owns and publishes a structured output schema, that schema
+becomes part of the catalog contract.
+
+## Compatibility rules
+
+The contract test classifies changes before maintainers update the fixture:
+
+| Change | Classification |
+| --- | --- |
+| Add a tool or optional input | Additive; requires catalog and documentation review |
+| Remove or rename a tool or accepted input | Breaking |
+| Add a required input or a stricter input constraint | Breaking |
+| Add an accepted schema variant or relax a constraint | Additive; requires review |
+| Remove or change an existing structured output schema | Breaking |
+| Move a tool to a less restrictive safety tier | Safety regression; prohibited |
+| Make a tool more restrictive | Compatibility change requiring security rationale and migration guidance |
+| Change idempotence or open-world annotations | Reviewed as a behavioral contract change |
+
+Both additive and breaking differences fail the snapshot test. This prevents a new tool or field
+from entering the stable catalog merely because it compiles. The failure explains the detected
+classification so the pull request can apply the appropriate SemVer, documentation, and migration
+treatment.
+
+## Reviewing an intentional catalog change
+
+1. Run the contract test without updating the fixture and inspect its classification:
+
+   ```bash
+   cargo test -p redisctl-mcp --all-features mcp_catalog_matches_1_0_baseline
+   ```
+
+2. Apply the compatibility policy. For an incompatible 1.x change, retain the old tool or input and
+   use the deprecation process unless a documented safety exception applies.
+3. For an accepted additive change, or while deliberately preparing the pre-1.0 baseline, refresh
+   the fixture:
+
+   ```bash
+   UPDATE_MCP_CATALOG=1 cargo test -p redisctl-mcp --all-features \
+     mcp_catalog_matches_1_0_baseline
+   ```
+
+4. Review the fixture diff. Update the tools reference, release notes, policy examples, bundled
+   skills, and migration guidance as applicable.
+5. Run the test again without `UPDATE_MCP_CATALOG` before committing.
+
+The fixture is generated through an in-process MCP client and `tools/list`, so it tests the router
+surface a client actually discovers rather than only checking handwritten name constants.
+
+## Tool deprecation
+
+A stable tool or input scheduled for replacement must:
+
+1. remain available under its existing name and behavior;
+2. identify the replacement in its tool description and reference documentation;
+3. be called out in release notes with migration guidance;
+4. remain available for at least one minor release and 90 days, whichever is longer; and
+5. be removed only in a major release.
+
+An optional replacement input may be added in a minor release. Making that input required still
+waits for a major release. Preview and internal tools follow the broader
+[Compatibility and Support Policy](../reference/compatibility.md).
+
+## Transports and deployment modes
+
+- **Stdio is stable for 1.0.** Startup behavior, safe defaults, and catalog discovery follow the
+  stable contract.
+- **HTTP is preview.** It has no built-in client authentication. Keep it on loopback or place it
+  behind a trusted gateway providing authentication, authorization, and TLS.
+- **Feature-gated builds are supported subsets.** A build without `cloud`, `enterprise`, or
+  `database` does not advertise that toolset.
+- **Raw API tools are preview passthroughs.** Their presence and redisctl-owned input contract are
+  recorded, but upstream endpoint behavior and response fields follow the upstream service.
+
+## Bundled Agent Skills
+
+Bundled Agent Skills remain preview, but CI validates that every `SKILL.md`:
+
+- has parseable `name` and `description` frontmatter;
+- uses a unique name matching its directory;
+- contains a non-empty workflow; and
+- references tools present in the compiled all-features catalog.
+
+This prevents a skill from shipping with a stale tool call while leaving broader skill catalog and
+workflow development independent of the 1.0 MCP contract.

--- a/docs/docs/mcp/configuration.md
+++ b/docs/docs/mcp/configuration.md
@@ -34,7 +34,7 @@ This page covers all three, with emphasis on `--tools` for controlling the tool 
     untrusted network.
 
     Stdio is the stable 1.0 transport. See the
-    [Compatibility and Support Policy](../reference/compatibility.md) for the MCP contract.
+    [MCP Compatibility and Catalog](compatibility.md) for the detailed MCP contract.
 
 ## The `--tools` Flag
 
@@ -72,9 +72,9 @@ The server resolves which toolsets to load in this order:
 
 | Toolset | Sub-modules | Total Tools |
 |---------|-------------|-------------|
-| `cloud` | `subscriptions`, `account`, `networking`, `fixed`, `raw` | 151 |
+| `cloud` | `subscriptions`, `account`, `networking`, `fixed`, `raw` | 148 |
 | `enterprise` | `cluster`, `databases`, `rbac`, `observability`, `proxy`, `services`, `raw` | 85 |
-| `database` | `server`, `keys`, `structures`, `diagnostics`, `json`, `search`, `aliases`, `bulk`, `raw` | 139 |
+| `database` | `server`, `keys`, `structures`, `diagnostics`, `json`, `search`, `aliases`, `bulk`, `raw` | 132 |
 | `app` | *(none -- flat toolset)* | 8 |
 | *(system)* | *(always loaded)* | 2 |
 
@@ -82,7 +82,7 @@ The two system tools (`list_available_tools` and `show_policy`) are always regis
 
 ### Examples
 
-**Cloud only** -- all Cloud sub-modules (151 tools + system):
+**Cloud only** -- all Cloud sub-modules (148 tools + system):
 
 ```bash
 redisctl-mcp --profile my-cloud --tools cloud
@@ -94,13 +94,13 @@ redisctl-mcp --profile my-cloud --tools cloud
 redisctl-mcp --profile my-cloud --tools cloud:subscriptions,cloud:networking
 ```
 
-**Enterprise monitoring** -- cluster info + observability (40 tools + system):
+**Enterprise monitoring** -- cluster info + observability (36 tools + system):
 
 ```bash
 redisctl-mcp --profile my-re --tools enterprise:cluster,enterprise:observability
 ```
 
-**Database only** -- direct Redis operations (139 tools + system):
+**Database only** -- direct Redis operations (132 tools + system):
 
 ```bash
 redisctl-mcp --database-url redis://localhost:6379 --tools database

--- a/docs/docs/mcp/index.md
+++ b/docs/docs/mcp/index.md
@@ -28,11 +28,11 @@ With the MCP server, you can:
 
     Read-only mode by default. Credentials stay in your profiles, never exposed to AI.
 
--   :material-cloud:{ .lg .middle } **Full Coverage**
+-   :material-cloud:{ .lg .middle } **Broad Coverage**
 
     ---
 
-    392 tools covering Redis Cloud, Redis Enterprise, and direct database operations.
+    Hundreds of cataloged tools covering Redis Cloud, Redis Enterprise, and direct database operations.
 
 -   :material-cog:{ .lg .middle } **IDE Integration**
 

--- a/docs/docs/mcp/tools-reference.md
+++ b/docs/docs/mcp/tools-reference.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-The redisctl MCP server exposes **392 tools** across 4 toolsets and 2 system tools for managing Redis Cloud, Redis Enterprise, and direct database operations.
+The redisctl MCP server exposes **375 tools** across 4 toolsets and 2 system tools for managing Redis Cloud, Redis Enterprise, and direct database operations. The machine-checked [MCP catalog](compatibility.md) is the compatibility source of truth.
 
 Tools are organized into **toolsets** (Cloud, Enterprise, Database, App) and further into **sub-modules** that can be selectively loaded with the [`--tools` flag](configuration.md#the-tools-flag).
 
@@ -18,7 +18,7 @@ These tools are always available regardless of `--tools` selection or visibility
 | `list_available_tools` | List all available tools grouped by toolset, showing active vs. hidden |
 | `show_policy` | Show the active safety tier, per-toolset overrides, and allow/deny lists |
 
-## Cloud Toolset (151 tools)
+## Cloud Toolset (148 tools)
 
 Redis Cloud management tools. Select with `--tools cloud` or target specific sub-modules.
 
@@ -37,7 +37,7 @@ Manages flexible subscriptions and their databases -- creation, configuration, b
 | `get_backup_status` | Get database backup status |
 | `get_database_tags` | Get database tags |
 
-### `cloud:account` (35 tools)
+### `cloud:account` (33 tools)
 
 Account management -- users, ACL users/roles/rules, cloud provider accounts, payment methods, cost reports, and task tracking.
 
@@ -52,7 +52,7 @@ Account management -- users, ACL users/roles/rules, cloud provider accounts, pay
 | `generate_cost_report` | Generate cost reports |
 | `list_tasks` | List recent async tasks |
 
-### `cloud:networking` (52 tools)
+### `cloud:networking` (51 tools)
 
 Network connectivity -- VPC peering, Transit Gateway, Private Service Connect (PSC), and AWS PrivateLink for both standard and Active-Active subscriptions.
 
@@ -181,7 +181,7 @@ System service lifecycle -- list, inspect, start, stop, restart, and status chec
 |------|-------------|
 | `enterprise_raw_api` | Execute arbitrary Redis Enterprise REST API requests |
 
-## Database Toolset (139 tools)
+## Database Toolset (132 tools)
 
 Direct Redis database operations. Requires `--database-url` connection. Select with `--tools database` or target specific sub-modules.
 
@@ -200,7 +200,7 @@ Server-level operations -- connectivity, server info, client listing, slow log, 
 | `redis_config_get` | Get config values |
 | `redis_config_set` | Set config values *(write)* |
 
-### `database:keys` (33 tools)
+### `database:keys` (31 tools)
 
 Key-space operations -- listing, scanning, get/set, type inspection, TTL, existence checks, memory usage, key mutation, multi-key operations, atomic counters, and string manipulation.
 
@@ -220,7 +220,7 @@ Key-space operations -- listing, scanning, get/set, type inspection, TTL, existe
 | `redis_incr` | Increment integer value *(write)* |
 | `redis_decr` | Decrement integer value *(write)* |
 
-### `database:structures` (41 tools)
+### `database:structures` (42 tools)
 
 Data structure operations -- hashes, lists, sets, sorted sets, streams, pub/sub inspection, set algebra, and granular field/member accessors.
 
@@ -249,7 +249,7 @@ Data structure operations -- hashes, lists, sets, sorted sets, streams, pub/sub 
 | `redis_xlen` | Get stream length |
 | `redis_pubsub_channels` | List active pub/sub channels |
 
-### `database:diagnostics` (5 tools)
+### `database:diagnostics` (4 tools)
 
 Higher-level diagnostic tools that aggregate information from multiple Redis commands.
 
@@ -258,8 +258,7 @@ Higher-level diagnostic tools that aggregate information from multiple Redis com
 | `redis_health_check` | Comprehensive health check |
 | `redis_key_summary` | Key distribution summary |
 | `redis_hotkeys` | Hot key detection |
-| `redis_connection_summary` | Connection pool summary |
-| `redis_memory_doctor` | Memory usage analysis and recommendations |
+| `redis_connection_summary` | Client totals, top source IPs, and idle/blocked connection analysis |
 
 ### `database:json` (16 tools)
 
@@ -276,9 +275,9 @@ JSON document operations using RedisJSON -- get, set, merge, delete, increment, 
 | `redis_json_objkeys` | Get JSON object keys |
 | `redis_json_numincrby` | Increment numeric JSON value *(write)* |
 
-### `database:search` (19 tools)
+### `database:search` (18 tools)
 
-Full-text and vector search via RediSearch -- index management, FT.SEARCH, FT.AGGREGATE, suggest, explain, profile, and cursor-based result iteration.
+Full-text and vector search via RediSearch -- index management, aliases, dictionaries, synonyms, FT.SEARCH, FT.AGGREGATE, explain, and profile.
 
 | Representative Tools | Description |
 |---------------------|-------------|
@@ -289,7 +288,7 @@ Full-text and vector search via RediSearch -- index management, FT.SEARCH, FT.AG
 | `redis_ft_list` | List all search indexes |
 | `redis_ft_explain` | Explain query execution plan |
 | `redis_ft_profile` | Profile query execution |
-| `redis_ft_sugadd` | Add suggestion to index *(write)* |
+| `redis_ft_aliasupdate` | Atomically repoint an index alias *(write)* |
 
 ### `database:aliases` (4 tools)
 
@@ -302,18 +301,14 @@ Session-scoped command aliases -- save, list, run, and delete named command sequ
 | `redis_alias_run` | Execute a saved alias |
 | `redis_alias_delete` | Delete a saved alias *(write)* |
 
-### `database:bulk` (6 tools)
+### `database:bulk` (2 tools)
 
-Bulk and batch operations -- multi-key get/delete, TTL management, key migration, and pattern-based bulk operations.
+Bulk data generation and loading for repeatable prototyping and test workflows.
 
-| Representative Tools | Description |
-|---------------------|-------------|
-| `redis_bulk_get` | Get multiple keys by pattern |
-| `redis_bulk_delete` | Delete keys by pattern *(write)* |
-| `redis_bulk_expire` | Set TTL on multiple keys *(write)* |
-| `redis_bulk_copy` | Copy keys to another database *(write)* |
-| `redis_pipeline_exec` | Execute a batch of commands *(write)* |
-| `redis_bulk_ttl_report` | Report TTL distribution |
+| Tool | Description |
+|------|-------------|
+| `redis_bulk_load` | Execute a bounded batch of Redis commands *(write)* |
+| `redis_seed` | Generate representative Redis data structures *(write)* |
 
 ### `database:raw` (1 tool)
 
@@ -340,12 +335,12 @@ Profile and configuration management tools. Always compiled in; no sub-modules.
 
 | Toolset | Sub-modules | Tools |
 |---------|-------------|-------|
-| Cloud | `subscriptions` (36), `account` (35), `networking` (52), `fixed` (27), `raw` (1) | **151** |
+| Cloud | `subscriptions` (36), `account` (33), `networking` (51), `fixed` (27), `raw` (1) | **148** |
 | Enterprise | `cluster` (23), `databases` (19), `rbac` (19), `observability` (13), `proxy` (3), `services` (7), `raw` (1) | **85** |
-| Database | `server` (14), `keys` (33), `structures` (41), `diagnostics` (5), `json` (16), `search` (19), `aliases` (4), `bulk` (6), `raw` (1) | **139** |
+| Database | `server` (14), `keys` (31), `structures` (42), `diagnostics` (4), `json` (16), `search` (18), `aliases` (4), `bulk` (2), `raw` (1) | **132** |
 | App | *(flat)* | **8** |
 | System | *(always on)* | **2** |
-| **Total** | | **392** |
+| **Total** | | **375** |
 
 ## Example Tool Usage
 

--- a/docs/docs/reference/compatibility.md
+++ b/docs/docs/reference/compatibility.md
@@ -130,8 +130,8 @@ Feature-gated tools are covered when their documented feature is enabled. A tool
 that was not built cannot be assumed to exist. Upstream-controlled payload fields have the same
 exception described for machine-readable CLI output.
 
-The canonical catalog and CI enforcement are tracked by
-[issue #1089](https://github.com/redis/redisctl/issues/1089).
+The [MCP Compatibility and Catalog](../mcp/compatibility.md) page documents the canonical catalog,
+CI enforcement, intentional update workflow, and tool deprecation convention.
 
 ## Rust crate compatibility
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -169,6 +169,7 @@ nav:
       - mcp/index.md
       - Getting Started: mcp/getting-started.md
       - Configuration: mcp/configuration.md
+      - Compatibility and Catalog: mcp/compatibility.md
       - Database Quickstart: mcp/database-quickstart.md
       - Cloud Quickstart: mcp/cloud-quickstart.md
       - Enterprise Quickstart: mcp/enterprise-quickstart.md


### PR DESCRIPTION
## Issue in scope

- Closes #1089.
- Coordinates with and leaves #718 open.

## Summary

- Record the 375-tool all-features MCP surface through an in-process `tools/list` request, including toolset/submodule ownership, normalized input schemas, output schemas, annotations, and derived safety tiers.
- Add compatibility-aware contract checks that distinguish additive review from breaking removals, required inputs, schema restrictions, output changes, and safety regressions.
- Verify the router at read-only, read-write, and full tiers so every cataloged tool is exposed only at its recorded minimum tier; the same baseline is checked for no-feature and individual feature-gated builds.
- Validate bundled Agent Skill metadata, unique names, non-empty workflows, and references to registered tools.
- Keep documentation counts tied to the catalog and correct stale claims: the live surface is 375 tools, not 392, and eight removed database tools were still listed in the reference.
- Document the stable stdio/preview HTTP boundary, MCP deprecation rules, structured-output caveat, and intentional catalog update workflow.
- Fix the pre-existing no-feature MCP test compile break uncovered while validating feature subsets.

## Compatibility treatment

This establishes the reviewable pre-1.0 baseline. It does not change the runtime tool surface. Future additions deliberately fail the gate until their fixture and documentation changes are reviewed; incompatible changes remain blocked under the 1.x policy.

The incoming hidden `redisctl init` stack and release publication work remain intentionally out of scope.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy -p redisctl-mcp --all-targets --no-default-features -- -D warnings`
- `cargo test --workspace --all-features`
- Catalog tests with all features, no features, and each of `cloud`, `enterprise`, and `database` individually
- `python3 -m mkdocs build -f docs/mkdocs.yml --strict`
- Markdown lint for the new MCP compatibility page
- `git diff --check`
