### PR TITLE
refactor(init): move the onboarding engine into a redisctl-init crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
         include:
           - package: redisctl-core
             targets: "--lib"
+          - package: redisctl-init
+            targets: "--lib"
           - package: redisctl
             targets: "--bins"
           - package: redisctl-mcp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,14 @@ Context and instructions for AI coding agents working on the redisctl project.
 
 ## Project Overview
 
-redisctl is a Rust workspace with three crates that share the lockstep version
+redisctl is a Rust workspace with four crates that share the lockstep version
 declared in the root `Cargo.toml`:
 
 | Crate | Path | Purpose |
 |-------|------|---------|
 | **redisctl-core** | `crates/redisctl-core/` | Shared library: config/profile management, Cloud and Enterprise API clients, error handling |
 | **redisctl** | `crates/redisctl/` | CLI binary: commands, workflows, connection management |
+| **redisctl-init** | `crates/redisctl-init/` | Onboarding engine for `redisctl init` (internal, `publish = false`): detection, planning, secret-safe URL handling |
 | **redisctl-mcp** | `crates/redisctl-mcp/` | MCP server for AI agents: ~364 tools, policy engine, skills system |
 
 ## Build and Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,6 +2918,7 @@ dependencies = [
  "redis-cloud",
  "redis-enterprise",
  "redisctl-core",
+ "redisctl-init",
  "regex",
  "rpassword",
  "serde",
@@ -2967,6 +2968,17 @@ dependencies = [
  "url",
  "urlencoding",
  "wiremock",
+]
+
+[[package]]
+name = "redisctl-init"
+version = "0.11.1"
+dependencies = [
+ "regex",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.17",
+ "which 7.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/redisctl-core",
     "crates/redisctl",
+    "crates/redisctl-init",
     "crates/redisctl-mcp",
 ]
 default-members = [

--- a/crates/redisctl-init/Cargo.toml
+++ b/crates/redisctl-init/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "redisctl-init"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Onboarding engine for redisctl init (internal, not published)"
+publish = false
+
+[dependencies]
+regex = "1.12.2"
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+which = "7"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/redisctl-init/src/lib.rs
+++ b/crates/redisctl-init/src/lib.rs
@@ -1,0 +1,162 @@
+//! Onboarding engine for `redisctl init`: project detection, secret-safe URL
+//! handling, and typed planning.
+//!
+//! Callers (the CLI today, the MCP server eventually) own their surface - flags,
+//! prompts, rendering, exit codes - and consume this crate's decisions. Nothing
+//! here prints, prompts, or exits.
+
+mod project;
+mod util;
+
+pub use project::{Agent, KNOWN_AGENTS, Project, Runtime};
+pub use util::mask_url;
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+#[derive(Debug, thiserror::Error)]
+pub enum InitError {
+    /// The input carried no connection string. The echoed text is already
+    /// credential-masked and safe to display.
+    #[error("no redis:// or rediss:// URL found in: {masked_input}")]
+    NoUrlInInput { masked_input: String },
+}
+
+/// What the caller asked for, resolved from its own surface (flags, prompts, tools).
+#[derive(Debug)]
+pub struct Options {
+    pub cwd: PathBuf,
+    /// Raw connection input: a URL, or a pasted `redis-cli -u <url>` command.
+    /// `None` means no input was given (not blank input).
+    pub url_input: Option<String>,
+    /// `None` detects installed tools; detecting none still configures all agents.
+    pub agents: Option<Vec<Agent>>,
+}
+
+/// What a run works with: the facts detected and the database it targets.
+#[derive(Debug)]
+pub struct Plan {
+    pub project: Project,
+    pub agents: Vec<Agent>,
+    pub database: Option<DatabasePlan>,
+}
+
+#[derive(Debug)]
+pub struct DatabasePlan {
+    pub url: String,
+    pub source: &'static str,
+}
+
+pub fn plan(options: &Options) -> Result<Plan, InitError> {
+    let database = options
+        .url_input
+        .as_deref()
+        .map(extract_url)
+        .transpose()?
+        .map(|url| DatabasePlan {
+            url,
+            source: "provided URL",
+        });
+    let project = project::detect(&options.cwd);
+    let agents = project::resolve_agents(
+        options.agents.as_deref(),
+        &project::detect_agents(&options.cwd),
+    );
+    Ok(Plan {
+        project,
+        agents,
+        database,
+    })
+}
+
+/// What counts as a connection string, wherever one arrives: a flag, a bare
+/// positional, or a console paste (the Redis Cloud console hands out
+/// `redis-cli -u <url>`; accept that whole and pull the URL out of it).
+fn url_regex() -> &'static regex::Regex {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    RE.get_or_init(|| regex::Regex::new(r#"rediss?://[^\s"']+"#).expect("static regex"))
+}
+
+fn extract_url(input: &str) -> Result<String, InitError> {
+    match url_regex().find(input) {
+        Some(m) => Ok(m.as_str().to_string()),
+        None => Err(InitError::NoUrlInInput {
+            masked_input: util::mask_url(input.trim()),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_urls_pass_through() {
+        assert_eq!(
+            extract_url("redis://localhost:6379").unwrap(),
+            "redis://localhost:6379"
+        );
+        assert_eq!(extract_url("rediss://h:12000").unwrap(), "rediss://h:12000");
+    }
+
+    #[test]
+    fn pasted_connect_command_yields_its_url() {
+        assert_eq!(
+            extract_url("redis-cli -u redis://default:pw@host:12000").unwrap(),
+            "redis://default:pw@host:12000"
+        );
+    }
+
+    #[test]
+    fn quotes_delimit_the_url() {
+        assert_eq!(
+            extract_url(r#"redis-cli -u "rediss://h:1""#).unwrap(),
+            "rediss://h:1"
+        );
+    }
+
+    #[test]
+    fn text_without_a_url_is_an_error_naming_the_text() {
+        let msg = extract_url("garbage in").unwrap_err().to_string();
+        assert!(msg.contains("no redis:// or rediss:// URL found"), "{msg}");
+        assert!(msg.contains("garbage in"), "{msg}");
+    }
+
+    #[test]
+    fn rejected_input_never_echoes_a_credential() {
+        let msg = extract_url("redisx://default:secret@host:6379")
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("redisx://default:****@host:6379"), "{msg}");
+        assert!(!msg.contains("secret"), "{msg}");
+    }
+
+    #[test]
+    fn plan_carries_detection_and_the_provided_database() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("go.mod"), "module demo\n").unwrap();
+        let plan = plan(&Options {
+            cwd: dir.path().to_path_buf(),
+            url_input: Some("redis-cli -u redis://h:1".into()),
+            agents: Some(vec![Agent::Claude]),
+        })
+        .unwrap();
+        assert_eq!(plan.project.runtime, Runtime::Go);
+        assert_eq!(plan.agents, vec![Agent::Claude]);
+        let db = plan.database.unwrap();
+        assert_eq!(db.url, "redis://h:1");
+        assert_eq!(db.source, "provided URL");
+    }
+
+    #[test]
+    fn plan_without_input_has_no_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan = plan(&Options {
+            cwd: dir.path().to_path_buf(),
+            url_input: None,
+            agents: Some(vec![Agent::Codex]),
+        })
+        .unwrap();
+        assert!(plan.database.is_none());
+    }
+}

--- a/crates/redisctl-init/src/project.rs
+++ b/crates/redisctl-init/src/project.rs
@@ -2,9 +2,7 @@
 
 use std::path::Path;
 
-use crate::cli::AgentArg;
-
-use super::util::{exists, has_bin, read_if};
+use crate::util::{exists, has_bin, read_if};
 
 /// The coding agents `redisctl init` can configure, in canonical order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -146,33 +144,17 @@ pub fn detect(dir: &Path) -> Project {
     }
 }
 
-/// The agents to configure: an explicit `--agent` list wins (canonical order, `all`
-/// expands), otherwise whatever was detected, otherwise all of them - having no agent
-/// tooling detected is not a reason to configure none.
-pub fn choose_agents(requested: &[AgentArg], detected: &[Agent]) -> Vec<Agent> {
-    if !requested.is_empty() {
-        if requested.contains(&AgentArg::All) {
-            return KNOWN_AGENTS.to_vec();
-        }
-        return KNOWN_AGENTS
+/// The agents to configure: an explicit request wins (canonical order, deduped),
+/// otherwise whatever was detected, otherwise all of them - having no agent tooling
+/// detected is not a reason to configure none.
+pub fn resolve_agents(requested: Option<&[Agent]>, detected: &[Agent]) -> Vec<Agent> {
+    match requested {
+        Some(requested) => KNOWN_AGENTS
             .into_iter()
-            .filter(|agent| {
-                requested.iter().any(|r| {
-                    matches!(
-                        (r, agent),
-                        (AgentArg::Claude, Agent::Claude)
-                            | (AgentArg::Cursor, Agent::Cursor)
-                            | (AgentArg::Vscode, Agent::Vscode)
-                            | (AgentArg::Codex, Agent::Codex)
-                    )
-                })
-            })
-            .collect();
-    }
-    if detected.is_empty() {
-        KNOWN_AGENTS.to_vec()
-    } else {
-        detected.to_vec()
+            .filter(|agent| requested.contains(agent))
+            .collect(),
+        None if detected.is_empty() => KNOWN_AGENTS.to_vec(),
+        None => detected.to_vec(),
     }
 }
 
@@ -310,22 +292,17 @@ mod tests {
 
     #[test]
     fn explicit_agents_win_in_canonical_order() {
-        let chosen = choose_agents(&[AgentArg::Codex, AgentArg::Claude], &[Agent::Vscode]);
+        let chosen = resolve_agents(Some(&[Agent::Codex, Agent::Claude]), &[Agent::Vscode]);
         assert_eq!(chosen, vec![Agent::Claude, Agent::Codex]);
     }
 
     #[test]
-    fn all_expands_to_every_agent() {
-        assert_eq!(choose_agents(&[AgentArg::All], &[]), KNOWN_AGENTS.to_vec());
-    }
-
-    #[test]
-    fn detected_agents_used_when_no_flag() {
-        assert_eq!(choose_agents(&[], &[Agent::Cursor]), vec![Agent::Cursor]);
+    fn detected_agents_used_when_nothing_requested() {
+        assert_eq!(resolve_agents(None, &[Agent::Cursor]), vec![Agent::Cursor]);
     }
 
     #[test]
     fn nothing_detected_configures_all() {
-        assert_eq!(choose_agents(&[], &[]), KNOWN_AGENTS.to_vec());
+        assert_eq!(resolve_agents(None, &[]), KNOWN_AGENTS.to_vec());
     }
 }

--- a/crates/redisctl-init/src/util.rs
+++ b/crates/redisctl-init/src/util.rs
@@ -1,4 +1,4 @@
-//! Small shared helpers for `redisctl init`: masking, binary lookup, project file reads.
+//! Small shared helpers: credential masking, binary lookup, project file reads.
 
 use std::path::Path;
 use std::sync::OnceLock;

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 redisctl-core = { version = "0.11.1", path = "../redisctl-core" }
+redisctl-init = { version = "0.11.1", path = "../redisctl-init" }
 redis-cloud = { workspace = true, features = ["tower-integration"] }
 redis-enterprise = { workspace = true, features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -171,6 +171,16 @@ pub enum RedisCtlError {
 /// Result type for redisctl operations
 pub type Result<T> = std::result::Result<T, RedisCtlError>;
 
+impl From<redisctl_init::InitError> for RedisCtlError {
+    fn from(err: redisctl_init::InitError) -> Self {
+        match err {
+            redisctl_init::InitError::NoUrlInInput { .. } => RedisCtlError::InvalidInput {
+                message: err.to_string(),
+            },
+        }
+    }
+}
+
 impl RedisCtlError {
     /// Get helpful suggestions for resolving this error
     pub fn suggestions(&self) -> Vec<String> {
@@ -274,6 +284,13 @@ impl RedisCtlError {
                 "Check the command documentation: redisctl <command> --help".to_string(),
                 "Use the appropriate command for your deployment type".to_string(),
             ],
+            // `redisctl init` input errors name the fix themselves; the file-format
+            // tips below would mislead.
+            RedisCtlError::InvalidInput { message }
+                if message.contains("no redis:// or rediss:// URL found") =>
+            {
+                vec![]
+            }
             RedisCtlError::InvalidInput { .. } => vec![
                 "Check the command syntax: redisctl <command> --help".to_string(),
                 "Verify input file format is correct (JSON/YAML)".to_string(),

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -1,41 +1,36 @@
 //! `redisctl init` - onboard a project to Redis services and make its AI coding
 //! agent Redis-fluent.
 //!
-//! This module is the step sequence; each concern lives in its own submodule.
+//! This module owns only the CLI surface: argument shaping, banner, colours, and
+//! rendering. The decisions live in the `redisctl-init` engine crate.
 
 mod output;
-mod project;
-mod util;
 
-use std::sync::OnceLock;
+use redisctl_init as engine;
 
-use crate::cli::InitArgs;
+use crate::cli::{AgentArg, InitArgs};
 use crate::error::RedisCtlError;
 use output::{bold, dim, ok, yellow};
 
-/// What counts as a connection string, wherever one arrives: the --url flag or a
-/// bare positional (the Redis Cloud console hands out `redis-cli -u <url>`; accept
-/// that paste whole and pull the URL out of it).
-fn url_regex() -> &'static regex::Regex {
-    static RE: OnceLock<regex::Regex> = OnceLock::new();
-    RE.get_or_init(|| regex::Regex::new(r#"rediss?://[^\s"']+"#).expect("static regex"))
-}
-
-/// Pull a Redis URL out of pasted text. `Ok(None)` when the text is blank,
-/// an error when there is text but no URL in it.
-fn extract_url(pasted: &str) -> Result<Option<String>, RedisCtlError> {
-    if let Some(m) = url_regex().find(pasted) {
-        return Ok(Some(m.as_str().to_string()));
+fn requested_agents(flags: &[AgentArg]) -> Option<Vec<engine::Agent>> {
+    if flags.is_empty() {
+        return None;
     }
-    if pasted.trim().is_empty() {
-        return Ok(None);
+    if flags.contains(&AgentArg::All) {
+        return Some(engine::KNOWN_AGENTS.to_vec());
     }
-    Err(RedisCtlError::InvalidInput {
-        message: format!(
-            "no redis:// or rediss:// URL found in: {}",
-            util::mask_url(pasted.trim())
-        ),
-    })
+    Some(
+        flags
+            .iter()
+            .filter_map(|flag| match flag {
+                AgentArg::Claude => Some(engine::Agent::Claude),
+                AgentArg::Cursor => Some(engine::Agent::Cursor),
+                AgentArg::Vscode => Some(engine::Agent::Vscode),
+                AgentArg::Codex => Some(engine::Agent::Codex),
+                AgentArg::All => None,
+            })
+            .collect(),
+    )
 }
 
 pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
@@ -44,7 +39,15 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         .chain(args.pasted.iter().cloned())
         .collect::<Vec<_>>()
         .join(" ");
-    let given_url = extract_url(&pasted)?;
+    let options = engine::Options {
+        cwd: std::env::current_dir().map_err(|e| RedisCtlError::FileError {
+            path: ".".into(),
+            message: e.to_string(),
+        })?,
+        url_input: (!pasted.trim().is_empty()).then_some(pasted),
+        agents: requested_agents(&args.agents),
+    };
+    let plan = engine::plan(&options)?;
 
     output::banner();
     let dry = args.dry_run;
@@ -60,11 +63,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         ))
     );
 
-    let cwd = std::env::current_dir().map_err(|e| RedisCtlError::FileError {
-        path: ".".into(),
-        message: e.to_string(),
-    })?;
-    let proj = project::detect(&cwd);
+    let proj = &plan.project;
     let mut descriptor = proj.runtime.as_str().to_string();
     if let Some(pm) = proj.pm {
         descriptor.push_str(&format!(", {pm}"));
@@ -79,14 +78,14 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         dim(&format!("({descriptor})"))
     );
 
-    let agents = project::choose_agents(&args.agents, &project::detect_agents(&cwd));
     let agent_bits = proj
         .agent_markers
         .iter()
         .map(|(marker, found)| format!("{marker} {}", if *found { ok("✓") } else { dim("✗") }))
         .collect::<Vec<_>>()
         .join("  ");
-    let names = agents
+    let names = plan
+        .agents
         .iter()
         .map(|a| a.as_str())
         .collect::<Vec<_>>()
@@ -102,7 +101,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         },
         dim(&format!("existing: {agent_bits}"))
     );
-    if proj.runtime == project::Runtime::Unknown {
+    if proj.runtime == engine::Runtime::Unknown {
         println!(
             "{}",
             yellow(
@@ -111,15 +110,15 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         );
     }
 
-    // No step records changes yet, so the summary prints a subject with no lines.
-    let subject = given_url.as_deref().map(|url| {
+    let subject = plan.database.as_ref().map(|db| {
         format!(
-            "database: {}{} via provided URL",
-            util::mask_url(url),
+            "database: {}{} via {}",
+            engine::mask_url(&db.url),
             args.name
                 .as_deref()
                 .map(|n| format!(" [{n}]"))
-                .unwrap_or_default()
+                .unwrap_or_default(),
+            db.source
         )
     });
     println!(
@@ -137,63 +136,4 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         );
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn blank_paste_means_no_url() {
-        assert_eq!(extract_url("").unwrap(), None);
-        assert_eq!(extract_url("   ").unwrap(), None);
-    }
-
-    #[test]
-    fn raw_urls_pass_through() {
-        assert_eq!(
-            extract_url("redis://localhost:6379").unwrap().as_deref(),
-            Some("redis://localhost:6379")
-        );
-        assert_eq!(
-            extract_url("rediss://h:12000").unwrap().as_deref(),
-            Some("rediss://h:12000")
-        );
-    }
-
-    #[test]
-    fn pasted_connect_command_yields_its_url() {
-        assert_eq!(
-            extract_url("redis-cli -u redis://default:pw@host:12000")
-                .unwrap()
-                .as_deref(),
-            Some("redis://default:pw@host:12000")
-        );
-    }
-
-    #[test]
-    fn quotes_delimit_the_url() {
-        assert_eq!(
-            extract_url(r#"redis-cli -u "rediss://h:1""#)
-                .unwrap()
-                .as_deref(),
-            Some("rediss://h:1")
-        );
-    }
-
-    #[test]
-    fn text_without_a_url_is_an_error_naming_the_text() {
-        let err = extract_url("garbage in").unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("no redis:// or rediss:// URL found"), "{msg}");
-        assert!(msg.contains("garbage in"), "{msg}");
-    }
-
-    #[test]
-    fn rejected_input_never_echoes_a_credential() {
-        let err = extract_url("redisx://default:secret@host:6379").unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("redisx://default:****@host:6379"), "{msg}");
-        assert!(!msg.contains("secret"), "{msg}");
-    }
 }

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -102,7 +102,9 @@ fn url_without_a_redis_url_is_a_validation_error() {
         .code(6)
         .stderr(predicate::str::contains(
             "no redis:// or rediss:// URL found",
-        ));
+        ))
+        // The generic file-format tips make no sense for a connection string.
+        .stderr(predicate::str::contains("JSON/YAML").not());
 }
 
 #[test]


### PR DESCRIPTION
Stacked on #1093. The engine/surface boundary requested in the #1093 review, established before the mutation-heavy slices.

New internal crate `crates/redisctl-init` (`publish = false`): detection, secret-safe URL handling, and the typed `Options` → `plan()` → `Plan` boundary. Nothing in it prints, prompts, or exits. `redisctl` keeps clap, rendering, and exit-code mapping. Behavior is unchanged - the existing CLI suite passes untouched (the parity proof), plus 23 engine unit tests. One boundary fix: init's invalid-input error drops the irrelevant JSON/YAML tips.

**To settle before the merge to main:** a crates.io-published `redisctl` cannot depend on an unpublished path-only crate (`cargo publish` rejects it) - internal-publish vs release-config handling is your call.

Verify: `cargo test -p redisctl-init && cargo test -p redisctl --test init_cli_tests`