### PR TITLE
feat(init): provision and validate a local Docker database through plan/apply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2974,10 +2974,13 @@ dependencies = [
 name = "redisctl-init"
 version = "0.11.1"
 dependencies = [
+ "chrono",
+ "redis",
  "regex",
  "serde_json",
  "tempfile",
  "thiserror 2.0.17",
+ "tokio",
  "which 7.0.3",
 ]
 

--- a/crates/redisctl-init/Cargo.toml
+++ b/crates/redisctl-init/Cargo.toml
@@ -11,9 +11,12 @@ description = "Onboarding engine for redisctl init (internal, not published)"
 publish = false
 
 [dependencies]
+chrono = { workspace = true }
+redis = { workspace = true }
 regex = "1.12.2"
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 which = "7"
 
 [dev-dependencies]

--- a/crates/redisctl-init/src/change.rs
+++ b/crates/redisctl-init/src/change.rs
@@ -1,0 +1,41 @@
+//! The typed change report: every step of a run reports one entry, even when it
+//! decides to do nothing.
+
+/// What happens (or would happen) to a file, container, or install target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    Created,
+    Updated,
+    Unchanged,
+    Kept,
+    Planned,
+}
+
+impl Status {
+    pub fn label(self) -> &'static str {
+        match self {
+            Status::Created => "created",
+            Status::Updated => "updated",
+            Status::Unchanged => "unchanged",
+            Status::Kept => "kept",
+            Status::Planned => "planned",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Change {
+    pub subject: String,
+    pub status: Status,
+    pub note: String,
+}
+
+impl Change {
+    pub(crate) fn new(subject: impl Into<String>, status: Status, note: impl Into<String>) -> Self {
+        Self {
+            subject: subject.into(),
+            status,
+            note: note.into(),
+        }
+    }
+}

--- a/crates/redisctl-init/src/docker.rs
+++ b/crates/redisctl-init/src/docker.rs
@@ -1,0 +1,398 @@
+//! The local database: a Docker container this tool owns, reused across runs when it
+//! can be. Probing happens at plan time (read-only), starting and creating at apply
+//! time. All Docker interaction shells out to the `docker` CLI.
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::change::{Change, Status};
+use crate::env::read_env_key;
+use crate::util::{sh, slug};
+use crate::{Event, InitError};
+
+/// The decided database resolution, fixed at plan time.
+#[derive(Debug)]
+pub(crate) enum DatabaseAction {
+    /// A URL the caller supplied; nothing to provision.
+    Provided { url: String },
+    /// `.env` already carries `REDIS_URL`; a stopped local container gets a
+    /// best-effort restart (validation reports the truth either way).
+    ExistingEnv {
+        url: String,
+        restart: Option<String>,
+    },
+    /// A container from an earlier run exists but is stopped.
+    StartExisting { name: String, url: String },
+    /// A container from an earlier run is already serving.
+    AlreadyRunning {
+        name: String,
+        port: u16,
+        url: String,
+    },
+    /// No container yet: run the image on the chosen free port.
+    RunNew {
+        name: String,
+        image: String,
+        image_local: bool,
+        port: u16,
+        url: String,
+    },
+}
+
+impl DatabaseAction {
+    pub(crate) fn url(&self) -> &str {
+        match self {
+            DatabaseAction::Provided { url }
+            | DatabaseAction::ExistingEnv { url, .. }
+            | DatabaseAction::StartExisting { url, .. }
+            | DatabaseAction::AlreadyRunning { url, .. }
+            | DatabaseAction::RunNew { url, .. } => url,
+        }
+    }
+
+    pub(crate) fn source(&self, applied: bool) -> &'static str {
+        match self {
+            DatabaseAction::Provided { .. } => "provided URL",
+            DatabaseAction::ExistingEnv { .. } => "existing .env",
+            DatabaseAction::StartExisting { .. } | DatabaseAction::AlreadyRunning { .. } => {
+                "existing Docker container"
+            }
+            DatabaseAction::RunNew { .. } if applied => "new Docker container",
+            DatabaseAction::RunNew { .. } => "Docker (planned)",
+        }
+    }
+
+    pub(crate) fn preview(&self) -> Option<Change> {
+        match self {
+            DatabaseAction::Provided { .. } | DatabaseAction::ExistingEnv { .. } => None,
+            DatabaseAction::StartExisting { name, .. } => Some(Change::new(
+                format!("docker:{name}"),
+                Status::Planned,
+                "would start existing container",
+            )),
+            DatabaseAction::AlreadyRunning { name, port, .. } => Some(Change::new(
+                format!("docker:{name}"),
+                Status::Unchanged,
+                format!("already running on port {port}"),
+            )),
+            DatabaseAction::RunNew {
+                name, image, port, ..
+            } => Some(Change::new(
+                format!("docker:{name}"),
+                Status::Planned,
+                format!("would run: docker run -d --name {name} -p {port}:6379 {image}"),
+            )),
+        }
+    }
+}
+
+fn docker_ok() -> bool {
+    sh("docker", &["info", "--format", "{{.ServerVersion}}"]).status == 0
+}
+
+struct ContainerInfo {
+    running: bool,
+    port: u16,
+}
+
+const INSPECT_FORMAT: &str =
+    r#"{{.State.Running}} {{(index (index .HostConfig.PortBindings "6379/tcp") 0).HostPort}}"#;
+
+fn container_info(name: &str) -> Option<ContainerInfo> {
+    let r = sh("docker", &["inspect", "-f", INSPECT_FORMAT, name]);
+    if r.status != 0 {
+        return None;
+    }
+    parse_container_info(&r.stdout)
+}
+
+fn parse_container_info(stdout: &str) -> Option<ContainerInfo> {
+    let mut parts = stdout.trim().split(' ');
+    let running = parts.next()? == "true";
+    let port = parts.next()?.parse().ok()?;
+    Some(ContainerInfo { running, port })
+}
+
+fn container_name(cwd: &Path) -> String {
+    let basename = cwd
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    format!("redis-init-{}", slug(&basename))
+}
+
+/// Prefer an image that is already local - offline-safe and instant. Pull only as a
+/// last resort.
+const IMAGE_PREFS: [&str; 3] = ["redis:8-alpine", "redis:8", "redis:latest"];
+
+fn resolve_image() -> (String, bool) {
+    match IMAGE_PREFS
+        .iter()
+        .find(|img| sh("docker", &["image", "inspect", img]).status == 0)
+    {
+        Some(img) => ((*img).to_string(), true),
+        None => (IMAGE_PREFS[0].to_string(), false),
+    }
+}
+
+fn free_port(start: u16) -> Option<u16> {
+    (start..start + 100).find(|p| std::net::TcpListener::bind(("127.0.0.1", *p)).is_ok())
+}
+
+/// Probe (read-only) how this project gets its local database.
+pub(crate) fn plan_local_database(cwd: &Path) -> Result<DatabaseAction, InitError> {
+    let name = container_name(cwd);
+
+    if let Some(url) = read_env_key(cwd, ".env", "REDIS_URL") {
+        // Second run typically lands here: revive our container if it is just stopped.
+        let restart = container_info(&name)
+            .filter(|info| {
+                !info.running && (url.contains("localhost") || url.contains("127.0.0.1"))
+            })
+            .map(|_| name);
+        return Ok(DatabaseAction::ExistingEnv { url, restart });
+    }
+
+    if !docker_ok() {
+        return Err(InitError::DockerUnavailable);
+    }
+
+    if let Some(info) = container_info(&name) {
+        let url = format!("redis://localhost:{}", info.port);
+        return Ok(if info.running {
+            DatabaseAction::AlreadyRunning {
+                name,
+                port: info.port,
+                url,
+            }
+        } else {
+            DatabaseAction::StartExisting { name, url }
+        });
+    }
+
+    let port = free_port(6379).ok_or(InitError::NoFreePort)?;
+    let (image, image_local) = resolve_image();
+    Ok(DatabaseAction::RunNew {
+        url: format!("redis://localhost:{port}"),
+        name,
+        image,
+        image_local,
+        port,
+    })
+}
+
+/// Execute the decided action. Returns the change to report, if the action has one.
+pub(crate) async fn apply_database(
+    action: &DatabaseAction,
+    on_event: &mut dyn FnMut(Event),
+) -> Result<Option<Change>, InitError> {
+    match action {
+        DatabaseAction::Provided { .. } => Ok(None),
+        DatabaseAction::ExistingEnv { url, restart } => {
+            let Some(name) = restart else {
+                return Ok(None);
+            };
+            sh("docker", &["start", name]);
+            // Errors are validated (and reported) later.
+            let _ = wait_for_ping(url, Duration::from_secs(30)).await;
+            Ok(Some(Change::new(
+                format!("docker:{name}"),
+                Status::Updated,
+                "restarted stopped container",
+            )))
+        }
+        DatabaseAction::AlreadyRunning { name, port, .. } => Ok(Some(Change::new(
+            format!("docker:{name}"),
+            Status::Unchanged,
+            format!("already running on port {port}"),
+        ))),
+        DatabaseAction::StartExisting { name, url } => {
+            let r = sh("docker", &["start", name]);
+            if r.status != 0 {
+                return Err(InitError::DockerCommand {
+                    command: format!("docker start {name}"),
+                    stderr: r.stderr.trim().to_string(),
+                });
+            }
+            wait_for_ping(url, Duration::from_secs(30)).await?;
+            Ok(Some(Change::new(
+                format!("docker:{name}"),
+                Status::Updated,
+                "restarted stopped container",
+            )))
+        }
+        DatabaseAction::RunNew {
+            name,
+            image,
+            image_local,
+            port,
+            url,
+        } => {
+            if !image_local {
+                on_event(Event::Note(format!(
+                    "  pulling {image} (first run - may take a minute)..."
+                )));
+            }
+            on_event(Event::ProgressStart(format!(
+                "starting {image} as {name} on port {port}"
+            )));
+            let r = sh(
+                "docker",
+                &[
+                    "run",
+                    "-d",
+                    "--name",
+                    name,
+                    "-p",
+                    &format!("{port}:6379"),
+                    image,
+                ],
+            );
+            if r.status != 0 {
+                on_event(Event::ProgressDone(String::new()));
+                return Err(InitError::DockerCommand {
+                    command: "docker run".to_string(),
+                    stderr: r.stderr.trim().to_string(),
+                });
+            }
+            if let Err(e) = wait_for_ping(url, Duration::from_secs(30)).await {
+                on_event(Event::ProgressDone(String::new()));
+                return Err(e);
+            }
+            on_event(Event::ProgressDone(" ready".to_string()));
+            Ok(Some(Change::new(
+                format!("docker:{name}"),
+                Status::Created,
+                format!("{image} on port {port}"),
+            )))
+        }
+    }
+}
+
+/// Connect with a deadline; errors come back as one-line strings for the caller's
+/// failure message.
+async fn connect(
+    url: &str,
+    timeout: Duration,
+) -> Result<redis::aio::MultiplexedConnection, String> {
+    let client = redis::Client::open(url).map_err(|e| e.to_string())?;
+    match tokio::time::timeout(timeout, client.get_multiplexed_async_connection()).await {
+        Ok(Ok(conn)) => Ok(conn),
+        Ok(Err(e)) => Err(e.to_string()),
+        Err(_) => Err(format!(
+            "timed out connecting to {}",
+            crate::util::mask_url(url)
+        )),
+    }
+}
+
+async fn ping(url: &str, timeout: Duration) -> Result<(), String> {
+    let mut conn = connect(url, timeout).await?;
+    let pong: String = redis::cmd("PING")
+        .query_async(&mut conn)
+        .await
+        .map_err(|e| e.to_string())?;
+    if pong == "PONG" {
+        Ok(())
+    } else {
+        Err(format!("PING returned {pong:?}"))
+    }
+}
+
+async fn wait_for_ping(url: &str, timeout: Duration) -> Result<(), InitError> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let error = match ping(url, Duration::from_millis(1500)).await {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
+        };
+        if tokio::time::Instant::now() > deadline {
+            return Err(InitError::NotReady {
+                url: url.to_string(),
+                error,
+            });
+        }
+        tokio::time::sleep(Duration::from_millis(400)).await;
+    }
+}
+
+/// Prove the database actually works: a PING and a SET/GET round trip on a
+/// short-lived key.
+pub async fn validate(url: &str) -> Result<(), String> {
+    let mut conn = connect(url, Duration::from_secs(3)).await?;
+    let pong: String = redis::cmd("PING")
+        .query_async(&mut conn)
+        .await
+        .map_err(|e| e.to_string())?;
+    if pong != "PONG" {
+        return Err(format!("PING returned {pong:?}"));
+    }
+    let key = "redis-init:selfcheck";
+    let value = format!("ok {}", chrono::Utc::now().to_rfc3339());
+    redis::cmd("SET")
+        .arg(key)
+        .arg(&value)
+        .arg("EX")
+        .arg(60)
+        .query_async::<()>(&mut conn)
+        .await
+        .map_err(|e| e.to_string())?;
+    let got: Option<String> = redis::cmd("GET")
+        .arg(key)
+        .query_async(&mut conn)
+        .await
+        .map_err(|e| e.to_string())?;
+    if got.as_deref() != Some(value.as_str()) {
+        return Err(format!("SET/GET round trip failed (got {got:?})"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_container_info_reads_running_and_port() {
+        let info = parse_container_info("true 6380\n").unwrap();
+        assert!(info.running);
+        assert_eq!(info.port, 6380);
+    }
+
+    #[test]
+    fn parse_container_info_rejects_garbage() {
+        assert!(parse_container_info("").is_none());
+        assert!(parse_container_info("true").is_none());
+        assert!(parse_container_info("true notaport").is_none());
+    }
+
+    #[test]
+    fn container_name_slugs_the_directory() {
+        assert_eq!(
+            container_name(Path::new("/tmp/My Demo App")),
+            "redis-init-my-demo-app"
+        );
+    }
+
+    #[test]
+    fn free_port_finds_an_unused_port() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let taken = listener.local_addr().unwrap().port();
+        let free = free_port(taken).unwrap();
+        assert!(free > taken);
+    }
+
+    #[test]
+    fn existing_env_url_wins_without_docker() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "REDIS_URL=\"redis://h:1\"\n").unwrap();
+        let action = plan_local_database(dir.path()).unwrap();
+        assert_eq!(action.url(), "redis://h:1");
+        assert_eq!(action.source(true), "existing .env");
+        // No local container matches, so nothing restarts.
+        assert!(matches!(
+            action,
+            DatabaseAction::ExistingEnv { restart: None, .. }
+        ));
+    }
+}

--- a/crates/redisctl-init/src/docker.rs
+++ b/crates/redisctl-init/src/docker.rs
@@ -64,6 +64,14 @@ impl DatabaseAction {
 
     pub(crate) fn preview(&self) -> Option<Change> {
         match self {
+            DatabaseAction::ExistingEnv {
+                restart: Some(name),
+                ..
+            } => Some(Change::new(
+                format!("docker:{name}"),
+                Status::Planned,
+                "would start existing container",
+            )),
             DatabaseAction::Provided { .. } | DatabaseAction::ExistingEnv { .. } => None,
             DatabaseAction::StartExisting { name, .. } => Some(Change::new(
                 format!("docker:{name}"),
@@ -80,7 +88,7 @@ impl DatabaseAction {
             } => Some(Change::new(
                 format!("docker:{name}"),
                 Status::Planned,
-                format!("would run: docker run -d --name {name} -p {port}:6379 {image}"),
+                format!("would run: docker run -d --name {name} -p 127.0.0.1:{port}:6379 {image}"),
             )),
         }
     }
@@ -135,8 +143,19 @@ fn resolve_image() -> (String, bool) {
     }
 }
 
+/// Probed on loopback and both wildcard families: Docker publishes ports via a
+/// dual-stack [::] listener an IPv4-only probe does not see, while SO_REUSEADDR
+/// (which the std listener sets) lets a wildcard probe succeed over a
+/// loopback-only listener.
+fn port_is_free(port: u16) -> bool {
+    let in_use = |result: std::io::Result<std::net::TcpListener>| matches!(result, Err(e) if e.kind() == std::io::ErrorKind::AddrInUse);
+    !in_use(std::net::TcpListener::bind(("127.0.0.1", port)))
+        && !in_use(std::net::TcpListener::bind(("0.0.0.0", port)))
+        && !in_use(std::net::TcpListener::bind(("::", port)))
+}
+
 fn free_port(start: u16) -> Option<u16> {
-    (start..start + 100).find(|p| std::net::TcpListener::bind(("127.0.0.1", *p)).is_ok())
+    (start..start + 100).find(|p| port_is_free(*p))
 }
 
 /// Probe (read-only) how this project gets its local database.
@@ -192,8 +211,10 @@ pub(crate) async fn apply_database(
             let Some(name) = restart else {
                 return Ok(None);
             };
-            sh("docker", &["start", name]);
-            // Errors are validated (and reported) later.
+            // A failed start must not read as updated; validation reports the truth.
+            if sh("docker", &["start", name]).status != 0 {
+                return Ok(None);
+            }
             let _ = wait_for_ping(url, Duration::from_secs(30)).await;
             Ok(Some(Change::new(
                 format!("docker:{name}"),
@@ -244,7 +265,9 @@ pub(crate) async fn apply_database(
                     "--name",
                     name,
                     "-p",
-                    &format!("{port}:6379"),
+                    // Loopback only: the image runs without authentication, and a
+                    // wildcard bind would expose a writable Redis to the local network.
+                    &format!("127.0.0.1:{port}:6379"),
                     image,
                 ],
             );
@@ -372,6 +395,51 @@ mod tests {
             container_name(Path::new("/tmp/My Demo App")),
             "redis-init-my-demo-app"
         );
+    }
+
+    #[test]
+    fn existing_env_restart_is_previewed() {
+        let action = DatabaseAction::ExistingEnv {
+            url: "redis://localhost:6379".into(),
+            restart: Some("redis-init-x".into()),
+        };
+        let change = action.preview().unwrap();
+        assert_eq!(change.status, Status::Planned);
+        assert!(change.note.contains("would start"), "{}", change.note);
+
+        let no_restart = DatabaseAction::ExistingEnv {
+            url: "redis://h:1".into(),
+            restart: None,
+        };
+        assert!(no_restart.preview().is_none());
+    }
+
+    #[test]
+    fn new_container_preview_binds_loopback() {
+        let action = DatabaseAction::RunNew {
+            name: "redis-init-x".into(),
+            image: "redis:8-alpine".into(),
+            image_local: true,
+            port: 6379,
+            url: "redis://localhost:6379".into(),
+        };
+        let change = action.preview().unwrap();
+        assert!(
+            change.note.contains("-p 127.0.0.1:6379:6379"),
+            "{}",
+            change.note
+        );
+    }
+
+    #[test]
+    fn free_port_sees_a_dual_stack_ipv6_holder() {
+        // Docker Desktop publishes ports on a dual-stack [::] listener; an
+        // IPv4-only probe reads such a port as free and docker run then fails
+        // with "port is already allocated".
+        let listener = std::net::TcpListener::bind(("::", 0)).unwrap();
+        let taken = listener.local_addr().unwrap().port();
+        let free = free_port(taken).unwrap();
+        assert!(free > taken, "picked the ipv6-held port {taken}");
     }
 
     #[test]

--- a/crates/redisctl-init/src/docker.rs
+++ b/crates/redisctl-init/src/docker.rs
@@ -215,7 +215,7 @@ pub(crate) async fn apply_database(
             if sh("docker", &["start", name]).status != 0 {
                 return Ok(None);
             }
-            let _ = wait_for_ping(url, Duration::from_secs(30)).await;
+            wait_for_ping(url, Duration::from_secs(30)).await?;
             Ok(Some(Change::new(
                 format!("docker:{name}"),
                 Status::Updated,

--- a/crates/redisctl-init/src/docker.rs
+++ b/crates/redisctl-init/src/docker.rs
@@ -299,7 +299,13 @@ async fn connect(
     timeout: Duration,
 ) -> Result<redis::aio::MultiplexedConnection, String> {
     let client = redis::Client::open(url).map_err(|e| e.to_string())?;
-    match tokio::time::timeout(timeout, client.get_multiplexed_async_connection()).await {
+    let config = redis::AsyncConnectionConfig::new().set_response_timeout(timeout);
+    match tokio::time::timeout(
+        timeout,
+        client.get_multiplexed_async_connection_with_config(&config),
+    )
+    .await
+    {
         Ok(Ok(conn)) => Ok(conn),
         Ok(Err(e)) => Err(e.to_string()),
         Err(_) => Err(format!(

--- a/crates/redisctl-init/src/env.rs
+++ b/crates/redisctl-init/src/env.rs
@@ -1,0 +1,289 @@
+//! The `.env` / `.gitignore` contract: mutations are decided read-only at plan time
+//! and performed at apply time, so a dry run renders exactly what a real run does.
+
+use std::path::Path;
+
+use crate::InitError;
+use crate::change::{Change, Status};
+use crate::util::{ending_with_newline, mask_url, read_if};
+
+/// One decided file mutation. The decision (and its change report) is fixed at plan
+/// time; only the write happens at apply time.
+#[derive(Debug)]
+pub(crate) enum FileAction {
+    Write {
+        rel: String,
+        content: String,
+        status: Status,
+    },
+    Unchanged {
+        rel: String,
+    },
+    Kept {
+        rel: String,
+        note: String,
+    },
+}
+
+impl FileAction {
+    pub(crate) fn preview(&self) -> Change {
+        match self {
+            FileAction::Write { rel, status, .. } => Change::new(rel.clone(), *status, ""),
+            FileAction::Unchanged { rel } => Change::new(rel.clone(), Status::Unchanged, ""),
+            FileAction::Kept { rel, note } => Change::new(rel.clone(), Status::Kept, note.clone()),
+        }
+    }
+
+    pub(crate) fn perform(&self, dir: &Path) -> Result<Change, InitError> {
+        if let FileAction::Write { rel, content, .. } = self {
+            let path = dir.join(rel);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| InitError::WriteFailed {
+                    rel: rel.clone(),
+                    message: e.to_string(),
+                })?;
+            }
+            std::fs::write(&path, content).map_err(|e| InitError::WriteFailed {
+                rel: rel.clone(),
+                message: e.to_string(),
+            })?;
+        }
+        Ok(self.preview())
+    }
+}
+
+/// Read the file for mutation planning. A file that exists but cannot be read
+/// (permissions, non-UTF-8) must not be mistaken for a missing one: overwriting it
+/// would destroy user content.
+fn read_for_planning(dir: &Path, rel: &str) -> Result<Option<String>, InitError> {
+    match read_if(dir, rel) {
+        Some(content) => Ok(Some(content)),
+        None if dir.join(rel).exists() => Err(InitError::UnreadableFile {
+            rel: rel.to_string(),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Read one key out of a dotenv-style file: `KEY=value`, optional `export`, optional
+/// quotes.
+pub(crate) fn read_env_key(dir: &Path, rel: &str, key: &str) -> Option<String> {
+    let content = read_if(dir, rel)?;
+    let re = regex::Regex::new(&format!(
+        r"^\s*(?:export\s+)?{}\s*=\s*(.*)$",
+        regex::escape(key)
+    ))
+    .expect("escaped key regex");
+    for line in content.lines() {
+        if let Some(captures) = re.captures(line) {
+            return Some(strip_edge_quotes(captures[1].trim()).to_string());
+        }
+    }
+    None
+}
+
+fn strip_edge_quotes(value: &str) -> &str {
+    let value = value
+        .strip_prefix('"')
+        .or_else(|| value.strip_prefix('\''))
+        .unwrap_or(value);
+    value
+        .strip_suffix('"')
+        .or_else(|| value.strip_suffix('\''))
+        .unwrap_or(value)
+}
+
+/// Set a key in a dotenv-style file. Appends with a provenance comment; an existing
+/// key is never clobbered - same value reads as unchanged, a different one is kept.
+pub(crate) fn plan_env_set(
+    dir: &Path,
+    rel: &str,
+    key: &str,
+    value: &str,
+) -> Result<FileAction, InitError> {
+    // Quoted so the .env stays shell-sourceable.
+    let line = format!("{key}=\"{value}\"");
+    let Some(content) = read_for_planning(dir, rel)? else {
+        return Ok(FileAction::Write {
+            rel: rel.to_string(),
+            content: format!("# Added by redisctl init\n{line}\n"),
+            status: Status::Created,
+        });
+    };
+    match read_env_key(dir, rel, key) {
+        Some(existing) if existing == value => Ok(FileAction::Unchanged {
+            rel: rel.to_string(),
+        }),
+        Some(_) => Ok(FileAction::Kept {
+            rel: rel.to_string(),
+            note: format!(
+                "existing {key} left untouched (ours would be {})",
+                mask_url(value)
+            ),
+        }),
+        None => Ok(FileAction::Write {
+            rel: rel.to_string(),
+            content: format!(
+                "{}\n# Added by redisctl init\n{line}\n",
+                ending_with_newline(&content)
+            ),
+            status: Status::Updated,
+        }),
+    }
+}
+
+/// Make sure `.gitignore` covers `.env` before credentials land in it.
+pub(crate) fn plan_gitignore_env(dir: &Path) -> Result<FileAction, InitError> {
+    let content = read_for_planning(dir, ".gitignore")?;
+    let covered = content
+        .as_deref()
+        .unwrap_or("")
+        .lines()
+        .any(|line| matches!(line.trim(), ".env" | ".env*" | "*.env"));
+    if covered {
+        return Ok(FileAction::Unchanged {
+            rel: ".gitignore".to_string(),
+        });
+    }
+    let status = if content.is_none() {
+        Status::Created
+    } else {
+        Status::Updated
+    };
+    let base = content.map(|c| ending_with_newline(&c)).unwrap_or_default();
+    Ok(FileAction::Write {
+        rel: ".gitignore".to_string(),
+        content: format!("{base}\n# Added by redisctl init - never commit credentials\n.env\n"),
+        status,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn read_env_key_handles_export_spaces_and_quotes() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(".env"),
+            "# comment\nexport REDIS_URL = \"redis://localhost:6379\"\nOTHER='x'\nBARE=y\n",
+        )
+        .unwrap();
+        let read = |key| read_env_key(dir.path(), ".env", key);
+        assert_eq!(read("REDIS_URL").as_deref(), Some("redis://localhost:6379"));
+        assert_eq!(read("OTHER").as_deref(), Some("x"));
+        assert_eq!(read("BARE").as_deref(), Some("y"));
+        assert_eq!(read("MISSING"), None);
+    }
+
+    #[test]
+    fn env_set_creates_the_file_with_a_provenance_comment() {
+        let dir = tempfile::tempdir().unwrap();
+        let action =
+            plan_env_set(dir.path(), ".env", "REDIS_URL", "redis://localhost:6379").unwrap();
+        let change = action.perform(dir.path()).unwrap();
+        assert_eq!(change.status, Status::Created);
+        assert_eq!(
+            fs::read_to_string(dir.path().join(".env")).unwrap(),
+            "# Added by redisctl init\nREDIS_URL=\"redis://localhost:6379\"\n"
+        );
+    }
+
+    #[test]
+    fn env_set_appends_without_touching_existing_content() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".env"), "EXISTING=1").unwrap();
+        plan_env_set(dir.path(), ".env", "REDIS_URL", "redis://localhost:6379")
+            .unwrap()
+            .perform(dir.path())
+            .unwrap();
+        assert_eq!(
+            fs::read_to_string(dir.path().join(".env")).unwrap(),
+            "EXISTING=1\n\n# Added by redisctl init\nREDIS_URL=\"redis://localhost:6379\"\n"
+        );
+    }
+
+    #[test]
+    fn env_set_same_value_is_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(".env"),
+            "REDIS_URL=\"redis://localhost:6379\"\n",
+        )
+        .unwrap();
+        let action =
+            plan_env_set(dir.path(), ".env", "REDIS_URL", "redis://localhost:6379").unwrap();
+        assert_eq!(action.preview().status, Status::Unchanged);
+    }
+
+    #[test]
+    fn env_set_never_clobbers_a_different_value_and_masks_ours_in_the_note() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".env"), "REDIS_URL=\"redis://keep-me:1\"\n").unwrap();
+        let action = plan_env_set(
+            dir.path(),
+            ".env",
+            "REDIS_URL",
+            "redis://default:secret@h:2",
+        )
+        .unwrap();
+        let change = action.perform(dir.path()).unwrap();
+        assert_eq!(change.status, Status::Kept);
+        assert!(
+            change.note.contains("redis://default:****@h:2"),
+            "{}",
+            change.note
+        );
+        assert!(!change.note.contains("secret"));
+        assert_eq!(
+            fs::read_to_string(dir.path().join(".env")).unwrap(),
+            "REDIS_URL=\"redis://keep-me:1\"\n"
+        );
+    }
+
+    #[test]
+    fn an_existing_but_unreadable_file_is_never_overwritten() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".env"), [0xff, 0xfe, 0x00]).unwrap();
+        let err = plan_env_set(dir.path(), ".env", "REDIS_URL", "redis://h:1").unwrap_err();
+        assert!(err.to_string().contains("refusing to overwrite"), "{err}");
+        assert_eq!(
+            fs::read(dir.path().join(".env")).unwrap(),
+            [0xff, 0xfe, 0x00]
+        );
+    }
+
+    #[test]
+    fn gitignore_gains_env_once_and_respects_globs() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".gitignore"), "node_modules\n").unwrap();
+        plan_gitignore_env(dir.path())
+            .unwrap()
+            .perform(dir.path())
+            .unwrap();
+        assert_eq!(
+            fs::read_to_string(dir.path().join(".gitignore")).unwrap(),
+            "node_modules\n\n# Added by redisctl init - never commit credentials\n.env\n"
+        );
+
+        let glob_dir = tempfile::tempdir().unwrap();
+        fs::write(glob_dir.path().join(".gitignore"), "*.env\n").unwrap();
+        let action = plan_gitignore_env(glob_dir.path()).unwrap();
+        assert_eq!(action.preview().status, Status::Unchanged);
+    }
+
+    #[test]
+    fn missing_gitignore_is_created() {
+        let dir = tempfile::tempdir().unwrap();
+        plan_gitignore_env(dir.path())
+            .unwrap()
+            .perform(dir.path())
+            .unwrap();
+        assert_eq!(
+            fs::read_to_string(dir.path().join(".gitignore")).unwrap(),
+            "\n# Added by redisctl init - never commit credentials\n.env\n"
+        );
+    }
+}

--- a/crates/redisctl-init/src/env.rs
+++ b/crates/redisctl-init/src/env.rs
@@ -93,6 +93,21 @@ fn strip_edge_quotes(value: &str) -> &str {
         .unwrap_or(value)
 }
 
+fn env_assignment(key: &str, value: &str) -> Result<String, InitError> {
+    // Literal quoting keeps dotenv readers and the MCP shell in agreement.
+    let quote = if value.contains(['$', '`', '\\', '"']) {
+        '\''
+    } else {
+        '"'
+    };
+    if value.contains(quote) || value.contains(['\n', '\r']) {
+        return Err(InitError::InvalidEnvValue {
+            key: key.to_string(),
+        });
+    }
+    Ok(format!("{key}={quote}{value}{quote}"))
+}
+
 /// Set a key in a dotenv-style file. Appends with a provenance comment; an existing
 /// key is never clobbered - same value reads as unchanged, a different one is kept.
 pub(crate) fn plan_env_set(
@@ -101,8 +116,7 @@ pub(crate) fn plan_env_set(
     key: &str,
     value: &str,
 ) -> Result<FileAction, InitError> {
-    // Quoted so the .env stays shell-sourceable.
-    let line = format!("{key}=\"{value}\"");
+    let line = env_assignment(key, value)?;
     let Some(content) = read_for_planning(dir, rel)? else {
         return Ok(FileAction::Write {
             rel: rel.to_string(),

--- a/crates/redisctl-init/src/lib.rs
+++ b/crates/redisctl-init/src/lib.rs
@@ -1,13 +1,18 @@
 //! Onboarding engine for `redisctl init`: project detection, secret-safe URL
-//! handling, and typed planning.
+//! handling, typed planning, and idempotent apply.
 //!
 //! Callers (the CLI today, the MCP server eventually) own their surface - flags,
 //! prompts, rendering, exit codes - and consume this crate's decisions. Nothing
-//! here prints, prompts, or exits.
+//! here prints, prompts, or exits; long-running steps report through [`Event`].
 
+mod change;
+mod docker;
+mod env;
 mod project;
 mod util;
 
+pub use change::{Change, Status};
+pub use docker::validate;
 pub use project::{Agent, KNOWN_AGENTS, Project, Runtime};
 pub use util::mask_url;
 
@@ -20,6 +25,39 @@ pub enum InitError {
     /// credential-masked and safe to display.
     #[error("no redis:// or rediss:// URL found in: {masked_input}")]
     NoUrlInInput { masked_input: String },
+
+    #[error(
+        "Docker is not available and no --url was given.\n  Either start Docker, or point at an existing database:\n    redisctl init --url redis://localhost:6379"
+    )]
+    DockerUnavailable,
+
+    #[error("{command} failed: {stderr}")]
+    DockerCommand { command: String, stderr: String },
+
+    #[error("no free port found between 6379 and 6478")]
+    NoFreePort,
+
+    #[error("Redis at {url} did not become ready: {error}")]
+    NotReady { url: String, error: String },
+
+    #[error("'{rel}' exists but cannot be read - refusing to overwrite it")]
+    UnreadableFile { rel: String },
+
+    #[error("cannot write '{rel}': {message}")]
+    WriteFailed { rel: String, message: String },
+}
+
+/// Progress reporting from [`apply`]: the caller renders these however its surface
+/// wants (spinner, log line, nothing).
+#[derive(Debug)]
+pub enum Event {
+    /// A long-running step began; keep its line open until `ProgressDone`.
+    ProgressStart(String),
+    /// The open step finished with this outcome (" ready", " done", or empty when
+    /// an error message follows on its own line).
+    ProgressDone(String),
+    /// A one-off informational line.
+    Note(String),
 }
 
 /// What the caller asked for, resolved from its own surface (flags, prompts, tools).
@@ -33,40 +71,82 @@ pub struct Options {
     pub agents: Option<Vec<Agent>>,
 }
 
-/// What a run works with: the facts detected and the database it targets.
+/// What a run works with: the facts detected, the database it targets, and the
+/// mutations decided. Rendering a plan is the dry run; [`apply`] performs it.
 #[derive(Debug)]
 pub struct Plan {
     pub project: Project,
     pub agents: Vec<Agent>,
-    pub database: Option<DatabasePlan>,
+    database: docker::DatabaseAction,
+    file_actions: Vec<env::FileAction>,
+    cwd: PathBuf,
 }
 
+impl Plan {
+    pub fn database_url(&self) -> &str {
+        self.database.url()
+    }
+
+    /// The database's provenance for the summary line. `applied` picks the wording
+    /// for a real run over the planned one ("new Docker container" vs
+    /// "Docker (planned)").
+    pub fn database_source(&self, applied: bool) -> &'static str {
+        self.database.source(applied)
+    }
+
+    /// The change report this plan predicts, in the order a run reports it.
+    pub fn changes(&self) -> Vec<Change> {
+        self.database
+            .preview()
+            .into_iter()
+            .chain(self.file_actions.iter().map(|action| action.preview()))
+            .collect()
+    }
+}
+
+/// The change report of an applied plan.
 #[derive(Debug)]
-pub struct DatabasePlan {
-    pub url: String,
-    pub source: &'static str,
+pub struct Report {
+    pub changes: Vec<Change>,
 }
 
 pub fn plan(options: &Options) -> Result<Plan, InitError> {
-    let database = options
-        .url_input
-        .as_deref()
-        .map(extract_url)
-        .transpose()?
-        .map(|url| DatabasePlan {
-            url,
-            source: "provided URL",
-        });
+    let database = match options.url_input.as_deref() {
+        Some(input) => docker::DatabaseAction::Provided {
+            url: extract_url(input)?,
+        },
+        None => docker::plan_local_database(&options.cwd)?,
+    };
     let project = project::detect(&options.cwd);
     let agents = project::resolve_agents(
         options.agents.as_deref(),
         &project::detect_agents(&options.cwd),
     );
+    let file_actions = vec![
+        env::plan_env_set(&options.cwd, ".env", "REDIS_URL", database.url())?,
+        env::plan_gitignore_env(&options.cwd)?,
+    ];
     Ok(Plan {
         project,
         agents,
         database,
+        file_actions,
+        cwd: options.cwd.clone(),
     })
+}
+
+/// Perform the plan's mutations: provision or revive the database, then write the
+/// project files. Idempotent by construction - a second run plans only unchanged
+/// entries.
+pub async fn apply(plan: &Plan, on_event: &mut dyn FnMut(Event)) -> Result<Report, InitError> {
+    let mut changes = Vec::new();
+    if let Some(change) = docker::apply_database(&plan.database, on_event).await? {
+        changes.push(change);
+    }
+    for action in &plan.file_actions {
+        changes.push(action.perform(&plan.cwd)?);
+    }
+    Ok(Report { changes })
 }
 
 /// What counts as a connection string, wherever one arrives: a flag, a bare
@@ -143,20 +223,58 @@ mod tests {
         .unwrap();
         assert_eq!(plan.project.runtime, Runtime::Go);
         assert_eq!(plan.agents, vec![Agent::Claude]);
-        let db = plan.database.unwrap();
-        assert_eq!(db.url, "redis://h:1");
-        assert_eq!(db.source, "provided URL");
+        assert_eq!(plan.database_url(), "redis://h:1");
+        assert_eq!(plan.database_source(true), "provided URL");
     }
 
     #[test]
-    fn plan_without_input_has_no_database() {
+    fn plan_predicts_the_env_wiring() {
         let dir = tempfile::tempdir().unwrap();
         let plan = plan(&Options {
             cwd: dir.path().to_path_buf(),
-            url_input: None,
+            url_input: Some("redis://h:1".into()),
             agents: Some(vec![Agent::Codex]),
         })
         .unwrap();
-        assert!(plan.database.is_none());
+        let changes = plan.changes();
+        let subjects: Vec<_> = changes.iter().map(|c| c.subject.as_str()).collect();
+        assert_eq!(subjects, vec![".env", ".gitignore"]);
+        assert!(changes.iter().all(|c| c.status == Status::Created));
+        // Planning writes nothing.
+        assert!(!dir.path().join(".env").exists());
+    }
+
+    #[tokio::test]
+    async fn apply_writes_what_the_plan_predicted() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan = plan(&Options {
+            cwd: dir.path().to_path_buf(),
+            url_input: Some("redis://h:1".into()),
+            agents: Some(vec![Agent::Codex]),
+        })
+        .unwrap();
+        let report = apply(&plan, &mut |_| {}).await.unwrap();
+        assert_eq!(report.changes.len(), 2);
+        let env = std::fs::read_to_string(dir.path().join(".env")).unwrap();
+        assert!(env.contains("REDIS_URL=\"redis://h:1\""), "{env}");
+        assert!(
+            std::fs::read_to_string(dir.path().join(".gitignore"))
+                .unwrap()
+                .contains(".env")
+        );
+
+        // A second plan over the applied state reads back all-unchanged.
+        let replan = super::plan(&Options {
+            cwd: dir.path().to_path_buf(),
+            url_input: Some("redis://h:1".into()),
+            agents: Some(vec![Agent::Codex]),
+        })
+        .unwrap();
+        assert!(
+            replan
+                .changes()
+                .iter()
+                .all(|c| c.status == Status::Unchanged)
+        );
     }
 }

--- a/crates/redisctl-init/src/lib.rs
+++ b/crates/redisctl-init/src/lib.rs
@@ -43,6 +43,9 @@ pub enum InitError {
     #[error("'{rel}' exists but cannot be read - refusing to overwrite it")]
     UnreadableFile { rel: String },
 
+    #[error("cannot safely quote {key} for .env; remove line breaks or encode quotes in the URL")]
+    InvalidEnvValue { key: String },
+
     #[error("cannot write '{rel}': {message}")]
     WriteFailed { rel: String, message: String },
 }

--- a/crates/redisctl-init/src/util.rs
+++ b/crates/redisctl-init/src/util.rs
@@ -19,6 +19,55 @@ pub fn has_bin(bin: &str) -> bool {
     which::which(bin).is_ok()
 }
 
+pub(crate) struct ShOutput {
+    pub status: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Run a command and capture its output; a spawn failure reads as status -1.
+pub(crate) fn sh(cmd: &str, args: &[&str]) -> ShOutput {
+    match std::process::Command::new(cmd).args(args).output() {
+        Ok(out) => ShOutput {
+            status: out.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        },
+        Err(e) => ShOutput {
+            status: -1,
+            stdout: String::new(),
+            stderr: e.to_string(),
+        },
+    }
+}
+
+/// Lowercase, runs of anything non-alphanumeric collapsed to one dash, edges trimmed.
+pub(crate) fn slug(s: &str) -> String {
+    let mut out = String::new();
+    for c in s.to_lowercase().chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+        } else if !out.is_empty() && !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let out = out.trim_end_matches('-');
+    if out.is_empty() {
+        "project".to_string()
+    } else {
+        out.to_string()
+    }
+}
+
+/// Appending to a file whose last line has no newline would splice onto it.
+pub(crate) fn ending_with_newline(content: &str) -> String {
+    if content.is_empty() || content.ends_with('\n') {
+        content.to_string()
+    } else {
+        format!("{content}\n")
+    }
+}
+
 /// Whether `rel` exists under `dir`.
 pub fn exists(dir: &Path, rel: &str) -> bool {
     dir.join(rel).exists()
@@ -77,5 +126,19 @@ mod tests {
             mask_url("default:secret@host:6379"),
             "default:****@host:6379"
         );
+    }
+
+    #[test]
+    fn slug_collapses_and_trims() {
+        assert_eq!(slug("My App (v2)"), "my-app-v2");
+        assert_eq!(slug("--hello--"), "hello");
+        assert_eq!(slug("!!!"), "project");
+    }
+
+    #[test]
+    fn ending_with_newline_appends_only_when_missing() {
+        assert_eq!(ending_with_newline("a\n"), "a\n");
+        assert_eq!(ending_with_newline("a"), "a\n");
+        assert_eq!(ending_with_newline(""), "");
     }
 }

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -173,10 +173,23 @@ pub type Result<T> = std::result::Result<T, RedisCtlError>;
 
 impl From<redisctl_init::InitError> for RedisCtlError {
     fn from(err: redisctl_init::InitError) -> Self {
-        match err {
-            redisctl_init::InitError::NoUrlInInput { .. } => RedisCtlError::InvalidInput {
+        use redisctl_init::InitError;
+        match &err {
+            InitError::NoUrlInInput { .. } => RedisCtlError::InvalidInput {
                 message: err.to_string(),
             },
+            InitError::NotReady { .. } => RedisCtlError::ConnectionError {
+                message: err.to_string(),
+            },
+            InitError::UnreadableFile { rel } | InitError::WriteFailed { rel, .. } => {
+                RedisCtlError::FileError {
+                    path: rel.clone(),
+                    message: err.to_string(),
+                }
+            }
+            InitError::DockerUnavailable
+            | InitError::DockerCommand { .. }
+            | InitError::NoFreePort => RedisCtlError::Other(err.to_string()),
         }
     }
 }
@@ -219,6 +232,14 @@ impl RedisCtlError {
                 suggestions
                     .push("Test connectivity: redisctl profile validate --connect".to_string());
                 suggestions
+            }
+            // `redisctl init` connection failures carry their remedy inline; the
+            // profile-oriented tips below do not apply (no profile is involved).
+            RedisCtlError::ConnectionError { message }
+                if message.contains("remove REDIS_URL from .env")
+                    || message.contains("did not become ready") =>
+            {
+                vec![]
             }
             RedisCtlError::ConnectionError { message }
                 if message.contains("certificate")

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -175,9 +175,11 @@ impl From<redisctl_init::InitError> for RedisCtlError {
     fn from(err: redisctl_init::InitError) -> Self {
         use redisctl_init::InitError;
         match &err {
-            InitError::NoUrlInInput { .. } => RedisCtlError::InvalidInput {
-                message: err.to_string(),
-            },
+            InitError::NoUrlInInput { .. } | InitError::InvalidEnvValue { .. } => {
+                RedisCtlError::InvalidInput {
+                    message: err.to_string(),
+                }
+            }
             InitError::NotReady { .. } => RedisCtlError::ConnectionError {
                 message: err.to_string(),
             },

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -110,30 +110,74 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         );
     }
 
-    let subject = plan.database.as_ref().map(|db| {
+    let subject = |applied: bool| {
         format!(
             "database: {}{} via {}",
-            engine::mask_url(&db.url),
+            engine::mask_url(plan.database_url()),
             args.name
                 .as_deref()
                 .map(|n| format!(" [{n}]"))
                 .unwrap_or_default(),
-            db.source
+            plan.database_source(applied)
         )
-    });
-    println!(
-        "{}{}",
-        bold(if dry { "Plan" } else { "Changes" }),
-        subject
-            .map(|s| format!("  {}", dim(&format!("({s})"))))
-            .unwrap_or_default()
-    );
+    };
 
     if dry {
+        println!(
+            "{}  {}",
+            bold("Plan"),
+            dim(&format!("({})", subject(false)))
+        );
+        for change in plan.changes() {
+            println!("{}", output::change_line(&change));
+        }
         println!(
             "{}",
             dim("\nDry run complete. Run again without --dry-run to apply.\n")
         );
+        return Ok(());
     }
+
+    let mut progress: Option<output::Progress> = None;
+    let report = engine::apply(&plan, &mut |event| match event {
+        engine::Event::ProgressStart(label) => progress = Some(output::progress(&label)),
+        engine::Event::ProgressDone(outcome) => {
+            if let Some(p) = progress.as_mut() {
+                p.done(&outcome);
+            }
+        }
+        engine::Event::Note(text) => println!("{}", dim(&text)),
+    })
+    .await?;
+
+    println!(
+        "{}  {}",
+        bold("Changes"),
+        dim(&format!("({})", subject(true)))
+    );
+    for change in &report.changes {
+        println!("{}", output::change_line(change));
+    }
+
+    print!("\n{}  ", bold("Validate"));
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+    match engine::validate(plan.database_url()).await {
+        Ok(()) => println!(
+            "{} PING  {} SET/GET  {}",
+            ok("✓"),
+            ok("✓"),
+            dim(&format!("({})", engine::mask_url(plan.database_url())))
+        ),
+        Err(e) => {
+            println!("{} {e}", output::red("✗"));
+            return Err(RedisCtlError::ConnectionError {
+                message: format!(
+                    "could not talk to Redis at {}\n  If this URL is stale, remove REDIS_URL from .env and re-run, or pass --url.",
+                    engine::mask_url(plan.database_url())
+                ),
+            });
+        }
+    }
+    println!();
     Ok(())
 }

--- a/crates/redisctl/src/workflows/init/output.rs
+++ b/crates/redisctl/src/workflows/init/output.rs
@@ -34,6 +34,64 @@ pub fn ok(s: &str) -> String {
     paint("97;1", s)
 }
 
+pub fn red(s: &str) -> String {
+    paint("31", s)
+}
+
+fn icon(status: redisctl_init::Status) -> String {
+    use redisctl_init::Status;
+    match status {
+        Status::Created => brand_red("+"),
+        Status::Updated => yellow("~"),
+        Status::Unchanged => dim("="),
+        Status::Kept => yellow("!"),
+        Status::Planned => yellow("»"),
+    }
+}
+
+/// One summary line: icon, status, subject, note.
+pub fn change_line(change: &redisctl_init::Change) -> String {
+    let note = if change.note.is_empty() {
+        String::new()
+    } else {
+        dim(&format!("  {}", change.note))
+    };
+    format!(
+        "  {} {:<9} {}{}",
+        icon(change.status),
+        change.status.label(),
+        change.subject,
+        note
+    )
+}
+
+/// A "doing X..." line that stays open until it is closed exactly once - with
+/// " ready", " done", or nothing when an error message follows on its own line.
+pub struct Progress {
+    open: bool,
+}
+
+pub fn progress(label: &str) -> Progress {
+    use std::io::Write;
+    print!("{}", dim(&format!("  {label}...")));
+    let _ = std::io::stdout().flush();
+    Progress { open: true }
+}
+
+impl Progress {
+    pub fn done(&mut self, outcome: &str) {
+        if !self.open {
+            return;
+        }
+        self.open = false;
+        if outcome.is_empty() {
+            println!();
+        } else {
+            println!("{}", dim(outcome));
+        }
+    }
+}
+
 fn truecolor() -> bool {
     std::env::var("COLORTERM")
         .map(|v| v.contains("truecolor") || v.contains("24bit"))
@@ -132,6 +190,27 @@ mod tests {
                 (RunKind::Block, "██".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn change_line_pads_the_status_and_appends_the_note() {
+        let change = redisctl_init::Change {
+            subject: ".env".into(),
+            status: redisctl_init::Status::Created,
+            note: "REDIS_URL".into(),
+        };
+        // Piped output (tests are not a tty), so no colour codes.
+        assert_eq!(change_line(&change), "  + created   .env  REDIS_URL");
+    }
+
+    #[test]
+    fn change_line_without_a_note_has_no_trailing_spaces() {
+        let change = redisctl_init::Change {
+            subject: ".gitignore".into(),
+            status: redisctl_init::Status::Unchanged,
+            note: String::new(),
+        };
+        assert_eq!(change_line(&change), "  = unchanged .gitignore");
     }
 
     #[test]

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -210,12 +210,19 @@ fn a_different_existing_redis_url_is_kept_not_clobbered() {
     std::fs::write(dir.path().join(".env"), "REDIS_URL=\"redis://keep-me:1\"\n").unwrap();
     redisctl()
         .current_dir(dir.path())
-        .args(["init", "--dry-run", "--url", "redis://default:pw@other:2"])
+        .args([
+            "init",
+            "--dry-run",
+            "--url",
+            "redis://default:s3cret@other:2",
+        ])
         .assert()
         .success()
         .stdout(predicate::str::contains("kept"))
         .stdout(predicate::str::contains("left untouched"))
-        .stdout(predicate::str::contains("pw").not());
+        // A short token here once collided with a random tempdir name printed in the
+        // Project line; whole-output negative assertions need collision-proof tokens.
+        .stdout(predicate::str::contains("s3cret").not());
     assert_eq!(
         std::fs::read_to_string(dir.path().join(".env")).unwrap(),
         "REDIS_URL=\"redis://keep-me:1\"\n"

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -1,6 +1,8 @@
-//! CLI-level tests for `redisctl init`: wiring, detection, dry-run.
+//! CLI-level tests for `redisctl init`: wiring, detection, dry-run, env contract.
 //!
-//! Everything here runs against a temp directory and writes nothing.
+//! Everything here is hermetic: temp directories only, no Docker (the dry-run tests
+//! pass --url so the database step never probes the Docker daemon), and network
+//! contact limited to refused loopback connections.
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -39,7 +41,7 @@ fn unknown_agent_is_a_usage_error() {
 }
 
 #[test]
-fn dry_run_detects_a_node_project() {
+fn dry_run_detects_a_node_project_and_plans_the_env_wiring() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(
         dir.path().join("package.json"),
@@ -48,12 +50,14 @@ fn dry_run_detects_a_node_project() {
     .unwrap();
     redisctl()
         .current_dir(dir.path())
-        .args(["init", "--dry-run"])
+        .args(["init", "--dry-run", "--url", "redis://localhost:6379"])
         .assert()
         .success()
         .stdout(predicate::str::contains("demo-shop"))
         .stdout(predicate::str::contains("(node, npm, express)"))
         .stdout(predicate::str::contains("Plan"))
+        .stdout(predicate::str::contains("created   .env"))
+        .stdout(predicate::str::contains(".gitignore"))
         .stdout(predicate::str::contains("Dry run complete"));
     // Nothing written: the manifest is still the only file.
     assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
@@ -64,7 +68,7 @@ fn unknown_runtime_gets_a_note_and_continues() {
     let dir = tempfile::tempdir().unwrap();
     redisctl()
         .current_dir(dir.path())
-        .args(["init", "--dry-run"])
+        .args(["init", "--dry-run", "--url", "redis://localhost:6379"])
         .assert()
         .success()
         .stdout(predicate::str::contains("no package manifest detected"));
@@ -140,20 +144,80 @@ fn rejected_url_input_is_credential_masked_in_the_json_envelope() {
 #[test]
 fn verbatim_unquoted_console_paste_is_accepted() {
     let dir = tempfile::tempdir().unwrap();
-    // The shell-split form of an unquoted paste: -u must not parse as a redisctl flag.
+    // The shell-split form of an unquoted paste: -u must not parse as a redisctl
+    // flag. The URL points at a refused loopback port, so the run proceeds past
+    // parsing, writes the contract, and fails at validation - proving both halves.
     redisctl()
         .current_dir(dir.path())
         .args([
             "init",
             "redis-cli",
             "-u",
-            "redis://default:s3cret@host.example:12000",
+            "redis://default:s3cret@127.0.0.1:9",
         ])
         .assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "redis://default:****@host.example:12000",
-        ))
+        .code(10)
+        .stdout(predicate::str::contains("redis://default:****@127.0.0.1:9"))
         .stdout(predicate::str::contains("via provided URL"))
-        .stdout(predicate::str::contains("s3cret").not());
+        .stdout(predicate::str::contains("s3cret").not())
+        .stderr(predicate::str::contains("could not talk to Redis"))
+        .stderr(predicate::str::contains("s3cret").not());
+}
+
+#[test]
+fn dead_url_writes_env_then_fails_validation_with_the_stale_hint() {
+    let dir = tempfile::tempdir().unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args(["init", "--url", "redis://127.0.0.1:9"])
+        .assert()
+        .code(10)
+        .stdout(predicate::str::contains("Validate"))
+        .stderr(predicate::str::contains("could not talk to Redis"))
+        .stderr(predicate::str::contains("remove REDIS_URL from .env"))
+        // The message carries its own remedy; the profile-oriented connection tips
+        // do not apply to init and must stay out.
+        .stderr(predicate::str::contains("profile").not());
+    // .env is written before validation, so the failure can name it and the user
+    // can fix or remove the stale URL.
+    let env = std::fs::read_to_string(dir.path().join(".env")).unwrap();
+    assert!(env.contains("REDIS_URL=\"redis://127.0.0.1:9\""), "{env}");
+    let gitignore = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+    assert!(gitignore.contains(".env"), "{gitignore}");
+}
+
+#[test]
+fn rerun_with_a_url_reports_env_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".env"),
+        "REDIS_URL=\"redis://127.0.0.1:9\"\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join(".gitignore"), ".env\n").unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args(["init", "--dry-run", "--url", "redis://127.0.0.1:9"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("unchanged .env"))
+        .stdout(predicate::str::contains("unchanged .gitignore"));
+}
+
+#[test]
+fn a_different_existing_redis_url_is_kept_not_clobbered() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join(".env"), "REDIS_URL=\"redis://keep-me:1\"\n").unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args(["init", "--dry-run", "--url", "redis://default:pw@other:2"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("kept"))
+        .stdout(predicate::str::contains("left untouched"))
+        .stdout(predicate::str::contains("pw").not());
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join(".env")).unwrap(),
+        "REDIS_URL=\"redis://keep-me:1\"\n"
+    );
 }

--- a/crates/redisctl/tests/init_docker_tests.rs
+++ b/crates/redisctl/tests/init_docker_tests.rs
@@ -1,0 +1,126 @@
+//! Live Docker suite for `redisctl init` local provisioning.
+//!
+//! Requires a running Docker daemon; each test provisions (and removes) a container
+//! named after its project directory. Run with:
+//!
+//! ```bash
+//! cargo test --test init_docker_tests -- --ignored --nocapture
+//! ```
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serial_test::serial;
+use std::path::{Path, PathBuf};
+
+fn redisctl() -> Command {
+    Command::cargo_bin("redisctl").unwrap()
+}
+
+/// Remove the test's container even when an assertion panics.
+struct RemoveContainer(String);
+
+impl Drop for RemoveContainer {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("docker")
+            .args(["rm", "-f", &self.0])
+            .output();
+    }
+}
+
+/// A project directory whose basename is alphanumeric, so the container name the
+/// command derives from it is exactly `redis-init-<basename>`.
+fn project_dir(tmp: &Path, suffix: &str) -> (PathBuf, String, RemoveContainer) {
+    let basename = format!("live{}{}", std::process::id(), suffix);
+    let dir = tmp.join(&basename);
+    std::fs::create_dir(&dir).unwrap();
+    let container = format!("redis-init-{basename}");
+    (dir.clone(), container.clone(), RemoveContainer(container))
+}
+
+fn container_running(name: &str) -> Option<bool> {
+    let out = std::process::Command::new("docker")
+        .args(["inspect", "-f", "{{.State.Running}}", name])
+        .output()
+        .unwrap();
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim() == "true")
+}
+
+#[test]
+#[ignore = "requires Docker"]
+#[serial]
+fn full_run_provisions_validates_and_rerun_is_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (dir, container, _cleanup) = project_dir(tmp.path(), "full");
+    std::fs::write(dir.join("package.json"), r#"{"name":"live-full"}"#).unwrap();
+
+    redisctl()
+        .current_dir(&dir)
+        .arg("init")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&container))
+        .stdout(predicate::str::contains("✓ PING  ✓ SET/GET"));
+    let env = std::fs::read_to_string(dir.join(".env")).unwrap();
+    assert!(env.contains("REDIS_URL=\"redis://localhost:"), "{env}");
+    let gitignore = std::fs::read_to_string(dir.join(".gitignore")).unwrap();
+    assert!(gitignore.contains(".env"), "{gitignore}");
+    assert_eq!(container_running(&container), Some(true));
+
+    // Idempotent re-run: nothing changes, validation still green.
+    redisctl()
+        .current_dir(&dir)
+        .arg("init")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("unchanged .env"))
+        .stdout(predicate::str::contains("unchanged .gitignore"))
+        .stdout(predicate::str::contains("✓ PING  ✓ SET/GET"));
+    assert_eq!(std::fs::read_to_string(dir.join(".env")).unwrap(), env);
+}
+
+#[test]
+#[ignore = "requires Docker"]
+#[serial]
+fn stopped_container_is_restarted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (dir, container, _cleanup) = project_dir(tmp.path(), "stop");
+
+    redisctl().current_dir(&dir).arg("init").assert().success();
+    let out = std::process::Command::new("docker")
+        .args(["stop", &container])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    redisctl()
+        .current_dir(&dir)
+        .arg("init")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("restarted stopped container"))
+        .stdout(predicate::str::contains("✓ PING  ✓ SET/GET"));
+    assert_eq!(container_running(&container), Some(true));
+}
+
+#[test]
+#[ignore = "requires Docker"]
+#[serial]
+fn dry_run_plans_the_container_and_writes_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (dir, container, _cleanup) = project_dir(tmp.path(), "dry");
+
+    redisctl()
+        .current_dir(&dir)
+        .args(["init", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "would run: docker run -d --name {container}"
+        )))
+        .stdout(predicate::str::contains("Dry run complete"));
+    assert!(!dir.join(".env").exists());
+    assert!(!dir.join(".gitignore").exists());
+    assert_eq!(container_running(&container), None);
+}

--- a/crates/redisctl/tests/init_docker_tests.rs
+++ b/crates/redisctl/tests/init_docker_tests.rs
@@ -107,6 +107,55 @@ fn stopped_container_is_restarted() {
 #[test]
 #[ignore = "requires Docker"]
 #[serial]
+fn restart_that_never_serves_redis_fails_instead_of_reporting_updated() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (dir, container, _cleanup) = project_dir(tmp.path(), "dead");
+
+    // A stopped container that starts fine but never serves Redis: the image's
+    // entrypoint runs `sleep` instead of redis-server.
+    let port = std::net::TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    let out = std::process::Command::new("docker")
+        .args([
+            "create",
+            "--name",
+            &container,
+            "-p",
+            &format!("127.0.0.1:{port}:6379"),
+            "redis:8-alpine",
+            "sleep",
+            "300",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    std::fs::write(
+        dir.join(".env"),
+        format!("REDIS_URL=\"redis://localhost:{port}\"\n"),
+    )
+    .unwrap();
+
+    redisctl()
+        .current_dir(&dir)
+        .arg("init")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("restarted stopped container").not())
+        .stderr(predicate::str::contains("did not become ready"));
+    // The start itself succeeded; the failure is Redis never answering.
+    assert_eq!(container_running(&container), Some(true));
+}
+
+#[test]
+#[ignore = "requires Docker"]
+#[serial]
 fn dry_run_plans_the_container_and_writes_nothing() {
     let tmp = tempfile::tempdir().unwrap();
     let (dir, container, _cleanup) = project_dir(tmp.path(), "dry");

--- a/crates/redisctl/tests/init_validation_tests.rs
+++ b/crates/redisctl/tests/init_validation_tests.rs
@@ -1,0 +1,115 @@
+//! Exercise the generated dotenv file and Redis validation through the CLI.
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+fn init(dir: &std::path::Path) -> Command {
+    let bin = dir.join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    for name in ["redis-cli", "docker", "npx"] {
+        let path = bin.join(name);
+        std::fs::write(&path, "#!/bin/sh\nexit 1\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let mut cmd = Command::cargo_bin("redisctl").unwrap();
+    cmd.current_dir(dir)
+        .env("PATH", format!("{}:/usr/bin:/bin", bin.display()))
+        .env("REDISCTL_INIT_AMPLITUDE_KEY", "")
+        .args(["init", "--agent", "claude"]);
+    cmd
+}
+
+#[test]
+fn generated_env_preserves_shell_metacharacters() {
+    let dir = tempfile::tempdir().unwrap();
+    let url = "redis://default:abc$REDISCTL_TEST_UNSET`printf-changed`@127.0.0.1:9";
+    init(dir.path()).args(["--url", url]).assert().code(10);
+    let output = std::process::Command::new("sh")
+        .args(["-c", ". ./.env; printf '%s' \"$REDIS_URL\""])
+        .env_remove("REDISCTL_TEST_UNSET")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), url);
+    Command::new("node")
+        .current_dir(dir.path())
+        .env_remove("REDIS_URL")
+        .args(["--env-file=.env", "-p", "process.env.REDIS_URL"])
+        .assert()
+        .success()
+        .stdout(format!("{url}\n"));
+    init(dir.path())
+        .args(["--url", url, "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("unchanged .env"));
+}
+
+fn stalled_redis(command: &'static str) -> u16 {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                break;
+            }
+            let count: usize = line.trim().strip_prefix('*').unwrap().parse().unwrap();
+            let mut args = Vec::new();
+            for _ in 0..count {
+                line.clear();
+                reader.read_line(&mut line).unwrap();
+                line.clear();
+                reader.read_line(&mut line).unwrap();
+                args.push(line.trim().to_string());
+            }
+            if args[0].eq_ignore_ascii_case(command) {
+                continue;
+            }
+            let reply = if args[0].eq_ignore_ascii_case("PING") {
+                "+PONG\r\n"
+            } else {
+                "+OK\r\n"
+            };
+            if stream.write_all(reply.as_bytes()).is_err() {
+                break;
+            }
+        }
+    });
+    port
+}
+
+#[test]
+fn validation_times_out_when_ping_stalls() {
+    assert_validation_timeout("PING");
+}
+
+#[test]
+fn validation_times_out_when_set_stalls() {
+    assert_validation_timeout("SET");
+}
+
+#[test]
+fn validation_times_out_when_get_stalls() {
+    assert_validation_timeout("GET");
+}
+
+fn assert_validation_timeout(command: &'static str) {
+    let dir = tempfile::tempdir().unwrap();
+    let url = format!("redis://127.0.0.1:{}", stalled_redis(command));
+    init(dir.path())
+        .args(["--url", &url])
+        .timeout(Duration::from_secs(8))
+        .assert()
+        .code(10)
+        .stdout(predicates::str::contains("timed out"));
+}


### PR DESCRIPTION
Stacked on #1098. The database half of onboarding on the plan/apply boundary: probing is read-only at plan time, mutations happen at apply, and the dry run renders exactly what a real run performs.

- Database resolution: existing `.env` `REDIS_URL` → a container from an earlier run (restarted if stopped) → a new container on the first free port, local image preferred. Container names keep the PoC's `redis-init-` prefix so both tools reuse the same container.
- Apply shells out to docker (as the PoC does) with a 30s wait-for-PING; validation is PING + SET/GET via the `redis` crate. New containers bind loopback only.
- `.env` is append-only with a provenance comment and never clobbers an existing `REDIS_URL`; an unreadable `.env` fails at plan time, so nothing gets overwritten. `.gitignore` gains `.env` before credentials land.
- Idempotent: a second run reports everything unchanged.
- Exit codes: readiness/validation 10, docker missing/failed 1.

Tests: hermetic engine + CLI suites (no daemon touched); `init_docker_tests.rs` is the live tier (`--ignored`, `#[serial]`).

Verify: `redisctl init --dry-run`, then `redisctl init && redisctl init`.

### Dry run
<img width="1172" height="374" alt="image" src="https://github.com/user-attachments/assets/ee0da398-cde3-485a-84bf-d29202e909f3" />

### Init run
<img width="966" height="398" alt="image" src="https://github.com/user-attachments/assets/606d4c82-d054-45d5-8b12-a02728c1e250" />
<img width="1184" height="199" alt="image" src="https://github.com/user-attachments/assets/06e2a197-85e0-45d8-83d1-47c0c122ebed" />

### Second run
<img width="956" height="355" alt="image" src="https://github.com/user-attachments/assets/67a2f518-b388-461a-8eb5-bc1620ba36ee" />