### PR TITLE
feat(init): wire the project - .env.example, client SDK, redis-cli

### DIFF
--- a/crates/redisctl-init/src/change.rs
+++ b/crates/redisctl-init/src/change.rs
@@ -8,6 +8,7 @@ pub enum Status {
     Updated,
     Unchanged,
     Kept,
+    Skipped,
     Planned,
 }
 
@@ -18,6 +19,7 @@ impl Status {
             Status::Updated => "updated",
             Status::Unchanged => "unchanged",
             Status::Kept => "kept",
+            Status::Skipped => "skipped",
             Status::Planned => "planned",
         }
     }

--- a/crates/redisctl-init/src/env.rs
+++ b/crates/redisctl-init/src/env.rs
@@ -15,6 +15,7 @@ pub(crate) enum FileAction {
         rel: String,
         content: String,
         status: Status,
+        note: String,
     },
     Unchanged {
         rel: String,
@@ -28,7 +29,9 @@ pub(crate) enum FileAction {
 impl FileAction {
     pub(crate) fn preview(&self) -> Change {
         match self {
-            FileAction::Write { rel, status, .. } => Change::new(rel.clone(), *status, ""),
+            FileAction::Write {
+                rel, status, note, ..
+            } => Change::new(rel.clone(), *status, note.clone()),
             FileAction::Unchanged { rel } => Change::new(rel.clone(), Status::Unchanged, ""),
             FileAction::Kept { rel, note } => Change::new(rel.clone(), Status::Kept, note.clone()),
         }
@@ -122,6 +125,7 @@ pub(crate) fn plan_env_set(
             rel: rel.to_string(),
             content: format!("# Added by redisctl init\n{line}\n"),
             status: Status::Created,
+            note: String::new(),
         });
     };
     match read_env_key(dir, rel, key) {
@@ -142,6 +146,7 @@ pub(crate) fn plan_env_set(
                 ending_with_newline(&content)
             ),
             status: Status::Updated,
+            note: String::new(),
         }),
     }
 }
@@ -169,6 +174,7 @@ pub(crate) fn plan_gitignore_env(dir: &Path) -> Result<FileAction, InitError> {
         rel: ".gitignore".to_string(),
         content: format!("{base}\n# Added by redisctl init - never commit credentials\n.env\n"),
         status,
+        note: String::new(),
     })
 }
 

--- a/crates/redisctl-init/src/install.rs
+++ b/crates/redisctl-init/src/install.rs
@@ -1,0 +1,497 @@
+//! Client SDK and redis-cli installation: what to install is decided read-only at
+//! plan time; the package-manager commands run at apply time. An install failure is
+//! reported as skipped, never as a run failure - the onboarding still stands.
+
+use std::path::Path;
+
+use crate::change::{Change, Status};
+use crate::env::FileAction;
+use crate::project::{Project, Runtime};
+use crate::util::{ending_with_newline, exists, has_bin, read_if, sh};
+use crate::{Event, InitError};
+
+const CLI_INSTALLER: &str = "https://packages.redis.io/redis-cli/install.sh";
+
+/// One decided install, fixed at plan time.
+#[derive(Debug)]
+pub(crate) enum InstallAction {
+    /// Nothing to run: the decision (unchanged/kept/skipped) is the report.
+    Report(Change),
+    /// Run a package-manager command that installs the client package.
+    Command {
+        cmd: String,
+        args: Vec<String>,
+        file: &'static str,
+        note: String,
+    },
+    /// Append to a requirements-style manifest.
+    Append(FileAction),
+    /// Fetch redis-cli via the official installer (statically linked,
+    /// checksum-verified, no-sudo ~/.local/bin fallback).
+    InstallCli,
+}
+
+impl InstallAction {
+    pub(crate) fn preview(&self) -> Change {
+        match self {
+            InstallAction::Report(change) => change.clone(),
+            InstallAction::Command { cmd, args, .. } => Change::new(
+                "client package",
+                Status::Planned,
+                format!("would run: {cmd} {}", args.join(" ")),
+            ),
+            InstallAction::Append(action) => action.preview(),
+            InstallAction::InstallCli => Change::new(
+                "redis-cli",
+                Status::Planned,
+                format!("would install via {CLI_INSTALLER}"),
+            ),
+        }
+    }
+
+    pub(crate) fn perform(
+        &self,
+        cwd: &Path,
+        on_event: &mut dyn FnMut(Event),
+    ) -> Result<Change, InitError> {
+        match self {
+            InstallAction::Report(change) => Ok(change.clone()),
+            InstallAction::Append(action) => action.perform(cwd),
+            InstallAction::Command {
+                cmd,
+                args,
+                file,
+                note,
+            } => {
+                let shown = format!("{cmd} {}", args.join(" "));
+                on_event(Event::ProgressStart(format!(
+                    "installing client package ({shown})"
+                )));
+                let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+                let r = sh(cmd, &arg_refs);
+                if r.status != 0 {
+                    on_event(Event::ProgressDone(" failed".to_string()));
+                    return Ok(Change::new(
+                        "client package",
+                        Status::Skipped,
+                        format!("{shown} failed - install manually"),
+                    ));
+                }
+                on_event(Event::ProgressDone(" done".to_string()));
+                Ok(Change::new(*file, Status::Updated, note.clone()))
+            }
+            InstallAction::InstallCli => {
+                on_event(Event::ProgressStart(
+                    "installing redis-cli (official installer, packages.redis.io)".to_string(),
+                ));
+                let r = sh("sh", &["-c", &format!("curl -fsSL {CLI_INSTALLER} | sh")]);
+                if r.status != 0 {
+                    on_event(Event::ProgressDone(" failed".to_string()));
+                    return Ok(Change::new(
+                        "redis-cli",
+                        Status::Skipped,
+                        "installer failed - the project skill carries docker fallbacks",
+                    ));
+                }
+                on_event(Event::ProgressDone(" done".to_string()));
+                Ok(if has_bin("redis-cli") {
+                    Change::new(
+                        "redis-cli",
+                        Status::Created,
+                        "installed via the official packages.redis.io script",
+                    )
+                } else {
+                    Change::new(
+                        "redis-cli",
+                        Status::Created,
+                        "installed to ~/.local/bin - add it to PATH to use it",
+                    )
+                })
+            }
+        }
+    }
+}
+
+pub(crate) fn plan_client_install(cwd: &Path, project: &Project) -> InstallAction {
+    decide_client(cwd, project, &has_bin)
+}
+
+/// Plan one install command, whichever package manager owns the manifest. The
+/// missing-binary check happens here so a dry run reports the same skip a real
+/// run would.
+fn command(
+    has: &dyn Fn(&str) -> bool,
+    cmd: &str,
+    args: &[&str],
+    file: &'static str,
+    note: String,
+) -> InstallAction {
+    if !has(cmd) {
+        return InstallAction::Report(Change::new(
+            "client package",
+            Status::Skipped,
+            format!("{cmd} not found - install client package manually"),
+        ));
+    }
+    InstallAction::Command {
+        cmd: cmd.to_string(),
+        args: args.iter().map(|s| s.to_string()).collect(),
+        file,
+        note,
+    }
+}
+
+fn decide_client(cwd: &Path, project: &Project, has: &dyn Fn(&str) -> bool) -> InstallAction {
+    let unchanged =
+        |note: &str| InstallAction::Report(Change::new("client package", Status::Unchanged, note));
+    let skipped =
+        |note: &str| InstallAction::Report(Change::new("client package", Status::Skipped, note));
+
+    match project.runtime {
+        Runtime::Node => {
+            let Ok(pkg) = serde_json::from_str::<serde_json::Value>(
+                &read_if(cwd, "package.json").unwrap_or_default(),
+            ) else {
+                return InstallAction::Report(Change::new(
+                    "package.json",
+                    Status::Kept,
+                    "unparseable; skipping client install",
+                ));
+            };
+            if !pkg["dependencies"]["redis"].is_null() || !pkg["devDependencies"]["redis"].is_null()
+            {
+                return InstallAction::Report(Change::new(
+                    "package.json",
+                    Status::Unchanged,
+                    "redis client already a dependency",
+                ));
+            }
+            let pm = project.pm.unwrap_or("npm");
+            let args: &[&str] = if pm == "npm" {
+                &["install", "redis"]
+            } else {
+                &["add", "redis"]
+            };
+            command(
+                has,
+                pm,
+                args,
+                "package.json",
+                format!("redis client installed via {pm}"),
+            )
+        }
+        Runtime::Python => {
+            let requirements = read_if(cwd, "requirements.txt");
+            let has_dep = regex::Regex::new(r"(?m)^\s*redis([\[\s=<>~!]|$)")
+                .expect("static regex")
+                .is_match(requirements.as_deref().unwrap_or(""))
+                || regex::Regex::new(r#""redis([\[">=<~]|")"#)
+                    .expect("static regex")
+                    .is_match(&read_if(cwd, "pyproject.toml").unwrap_or_default());
+            if has_dep {
+                return unchanged("redis client already a dependency");
+            }
+            if exists(cwd, "pyproject.toml") && (exists(cwd, "uv.lock") || has("uv")) {
+                return command(
+                    has,
+                    "uv",
+                    &["add", "redis"],
+                    "pyproject.toml",
+                    "redis-py installed via uv".to_string(),
+                );
+            }
+            if exists(cwd, "poetry.lock") {
+                return command(
+                    has,
+                    "poetry",
+                    &["add", "redis"],
+                    "pyproject.toml",
+                    "redis-py installed via poetry".to_string(),
+                );
+            }
+            if let Some(reqs) = requirements {
+                return InstallAction::Append(FileAction::Write {
+                    rel: "requirements.txt".to_string(),
+                    content: format!("{}redis\n", ending_with_newline(&reqs)),
+                    status: Status::Updated,
+                    note: "redis-py added - run pip install -r requirements.txt".to_string(),
+                });
+            }
+            skipped("add redis-py manually (pip install redis)")
+        }
+        Runtime::Go => {
+            if read_if(cwd, "go.mod")
+                .unwrap_or_default()
+                .contains("github.com/redis/go-redis")
+            {
+                return unchanged("go-redis already a dependency");
+            }
+            command(
+                has,
+                "go",
+                &["get", "github.com/redis/go-redis/v9"],
+                "go.mod",
+                "go-redis installed".to_string(),
+            )
+        }
+        Runtime::Rust => {
+            if regex::Regex::new(r"(?m)^\s*redis\s*=")
+                .expect("static regex")
+                .is_match(&read_if(cwd, "Cargo.toml").unwrap_or_default())
+            {
+                return unchanged("redis crate already a dependency");
+            }
+            command(
+                has,
+                "cargo",
+                &["add", "redis"],
+                "Cargo.toml",
+                "redis crate installed".to_string(),
+            )
+        }
+        Runtime::Java => {
+            // Maven/Gradle have no standard add-dependency command, and regex surgery
+            // on pom.xml is clobber-prone. The generated skill carries the exact
+            // snippet; the user's agent applies it to the build file.
+            let build = format!(
+                "{}{}{}",
+                read_if(cwd, "pom.xml").unwrap_or_default(),
+                read_if(cwd, "build.gradle").unwrap_or_default(),
+                read_if(cwd, "build.gradle.kts").unwrap_or_default()
+            );
+            if build.contains("redis.clients") || build.contains("io.lettuce") {
+                return unchanged("a Redis client is already a dependency");
+            }
+            skipped(
+                "add Jedis (redis.clients:jedis) - exact snippet is in the redis-project-setup skill",
+            )
+        }
+        Runtime::Unknown => {
+            skipped("no package manifest detected - install the Redis client for your language")
+        }
+    }
+}
+
+pub(crate) fn plan_redis_cli(install: bool) -> InstallAction {
+    decide_redis_cli(install, &has_bin)
+}
+
+fn decide_redis_cli(install: bool, has: &dyn Fn(&str) -> bool) -> InstallAction {
+    if has("redis-cli") {
+        let version = sh("redis-cli", &["--version"])
+            .stdout
+            .split_whitespace()
+            .find_map(|word| {
+                word.chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_digit())
+                    .then(|| word.to_string())
+            });
+        return InstallAction::Report(Change::new(
+            "redis-cli",
+            Status::Unchanged,
+            match version {
+                Some(v) => format!("already on PATH ({v})"),
+                None => "already on PATH".to_string(),
+            },
+        ));
+    }
+    if !install {
+        return InstallAction::Report(Change::new(
+            "redis-cli",
+            Status::Skipped,
+            "--no-install-cli; the project skill carries docker fallbacks",
+        ));
+    }
+    InstallAction::InstallCli
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project::detect;
+
+    fn project_in(dir: &Path) -> Project {
+        detect(dir)
+    }
+
+    fn dir_with(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        for (name, content) in files {
+            std::fs::write(dir.path().join(name), content).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn node_with_redis_already_present_is_unchanged() {
+        let dir = dir_with(&[("package.json", r#"{"dependencies":{"redis":"^4"}}"#)]);
+        let action = decide_client(dir.path(), &project_in(dir.path()), &|_| true);
+        let change = action.preview();
+        assert_eq!(change.status, Status::Unchanged);
+        assert_eq!(change.subject, "package.json");
+    }
+
+    #[test]
+    fn node_unparseable_manifest_is_kept() {
+        let dir = dir_with(&[("package.json", "not json")]);
+        let change = decide_client(dir.path(), &project_in(dir.path()), &|_| true).preview();
+        assert_eq!(change.status, Status::Kept);
+        assert!(change.note.contains("unparseable"), "{}", change.note);
+    }
+
+    #[test]
+    fn node_uses_the_detected_package_manager() {
+        let dir = dir_with(&[("package.json", r#"{"name":"x"}"#), ("pnpm-lock.yaml", "")]);
+        let action = decide_client(dir.path(), &project_in(dir.path()), &|_| true);
+        match action {
+            InstallAction::Command { cmd, args, .. } => {
+                assert_eq!(cmd, "pnpm");
+                assert_eq!(args, vec!["add", "redis"]);
+            }
+            other => panic!("expected a command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_missing_package_manager_reads_as_skipped() {
+        let dir = dir_with(&[("package.json", r#"{"name":"x"}"#)]);
+        let change = decide_client(dir.path(), &project_in(dir.path()), &|_| false).preview();
+        assert_eq!(change.status, Status::Skipped);
+        assert!(change.note.contains("npm not found"), "{}", change.note);
+    }
+
+    #[test]
+    fn python_requirements_get_redis_appended() {
+        let dir = dir_with(&[("requirements.txt", "flask\n")]);
+        let action = decide_client(dir.path(), &project_in(dir.path()), &|_| false);
+        match &action {
+            InstallAction::Append(FileAction::Write { content, .. }) => {
+                assert_eq!(content, "flask\nredis\n");
+            }
+            other => panic!("expected an append, got {other:?}"),
+        }
+        action.perform(dir.path(), &mut |_| {}).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("requirements.txt")).unwrap(),
+            "flask\nredis\n"
+        );
+    }
+
+    #[test]
+    fn python_existing_requirement_is_unchanged() {
+        let dir = dir_with(&[("requirements.txt", "redis>=5\n")]);
+        let change = decide_client(dir.path(), &project_in(dir.path()), &|_| true).preview();
+        assert_eq!(change.status, Status::Unchanged);
+    }
+
+    #[test]
+    fn python_pyproject_with_uv_uses_uv_add() {
+        let dir = dir_with(&[("pyproject.toml", "[project]\nname = \"x\"\n")]);
+        let action = decide_client(dir.path(), &project_in(dir.path()), &|bin| bin == "uv");
+        match action {
+            InstallAction::Command { cmd, .. } => assert_eq!(cmd, "uv"),
+            other => panic!("expected a command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn go_and_rust_get_their_native_add_commands() {
+        let go = dir_with(&[("go.mod", "module demo\n")]);
+        match decide_client(go.path(), &project_in(go.path()), &|_| true) {
+            InstallAction::Command { cmd, args, .. } => {
+                assert_eq!(cmd, "go");
+                assert_eq!(args, vec!["get", "github.com/redis/go-redis/v9"]);
+            }
+            other => panic!("expected a command, got {other:?}"),
+        }
+        let rust = dir_with(&[("Cargo.toml", "[package]\nname = \"x\"\n")]);
+        match decide_client(rust.path(), &project_in(rust.path()), &|_| true) {
+            InstallAction::Command { cmd, args, .. } => {
+                assert_eq!(cmd, "cargo");
+                assert_eq!(args, vec!["add", "redis"]);
+            }
+            other => panic!("expected a command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rust_existing_dependency_is_unchanged() {
+        let dir = dir_with(&[("Cargo.toml", "[dependencies]\nredis = \"0.27\"\n")]);
+        let change = decide_client(dir.path(), &project_in(dir.path()), &|_| true).preview();
+        assert_eq!(change.status, Status::Unchanged);
+    }
+
+    #[test]
+    fn java_is_never_mutated_only_advised() {
+        let dir = dir_with(&[("pom.xml", "<project/>")]);
+        let change = decide_client(dir.path(), &project_in(dir.path()), &|_| true).preview();
+        assert_eq!(change.status, Status::Skipped);
+        assert!(change.note.contains("Jedis"), "{}", change.note);
+
+        let with_client = dir_with(&[("pom.xml", "<dep>redis.clients</dep>")]);
+        let change = decide_client(with_client.path(), &project_in(with_client.path()), &|_| {
+            true
+        })
+        .preview();
+        assert_eq!(change.status, Status::Unchanged);
+    }
+
+    #[test]
+    fn unknown_runtime_is_skipped_with_a_hint() {
+        let dir = tempfile::tempdir().unwrap();
+        let change = decide_client(dir.path(), &project_in(dir.path()), &|_| true).preview();
+        assert_eq!(change.status, Status::Skipped);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_failing_install_command_reads_as_skipped_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let action = InstallAction::Command {
+            cmd: "false".to_string(),
+            args: vec![],
+            file: "package.json",
+            note: "never used".to_string(),
+        };
+        let change = action.perform(dir.path(), &mut |_| {}).unwrap();
+        assert_eq!(change.status, Status::Skipped);
+        assert!(change.note.contains("install manually"), "{}", change.note);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_successful_install_command_reports_the_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let action = InstallAction::Command {
+            cmd: "true".to_string(),
+            args: vec![],
+            file: "package.json",
+            note: "redis client installed via true".to_string(),
+        };
+        let change = action.perform(dir.path(), &mut |_| {}).unwrap();
+        assert_eq!(change.status, Status::Updated);
+        assert_eq!(change.subject, "package.json");
+    }
+
+    #[test]
+    fn redis_cli_present_reads_unchanged() {
+        let change = decide_redis_cli(true, &|_| true).preview();
+        assert_eq!(change.status, Status::Unchanged);
+        assert!(change.note.contains("already on PATH"), "{}", change.note);
+    }
+
+    #[test]
+    fn redis_cli_opt_out_reads_skipped() {
+        let change = decide_redis_cli(false, &|_| false).preview();
+        assert_eq!(change.status, Status::Skipped);
+        assert!(change.note.contains("--no-install-cli"), "{}", change.note);
+    }
+
+    #[test]
+    fn redis_cli_missing_plans_the_installer() {
+        let change = decide_redis_cli(true, &|_| false).preview();
+        assert_eq!(change.status, Status::Planned);
+        assert!(change.note.contains("packages.redis.io"), "{}", change.note);
+    }
+}

--- a/crates/redisctl-init/src/install.rs
+++ b/crates/redisctl-init/src/install.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use crate::change::{Change, Status};
 use crate::env::FileAction;
 use crate::project::{Project, Runtime};
-use crate::util::{ending_with_newline, exists, has_bin, read_if, sh};
+use crate::util::{ending_with_newline, exists, has_bin, read_if, sh, sh_in};
 use crate::{Event, InitError};
 
 const CLI_INSTALLER: &str = "https://packages.redis.io/redis-cli/install.sh";
@@ -68,7 +68,7 @@ impl InstallAction {
                     "installing client package ({shown})"
                 )));
                 let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-                let r = sh(cmd, &arg_refs);
+                let r = sh_in(cwd, cmd, &arg_refs);
                 if r.status != 0 {
                     on_event(Event::ProgressDone(" failed".to_string()));
                     return Ok(Change::new(
@@ -273,10 +273,22 @@ fn decide_client(cwd: &Path, project: &Project, has: &dyn Fn(&str) -> bool) -> I
 }
 
 pub(crate) fn plan_redis_cli(install: bool) -> InstallAction {
-    decide_redis_cli(install, &has_bin)
+    let local_bin = std::env::home_dir()
+        .map(|home| home.join(".local/bin/redis-cli").exists())
+        .unwrap_or(false);
+    decide_redis_cli(install, &has_bin, local_bin)
 }
 
-fn decide_redis_cli(install: bool, has: &dyn Fn(&str) -> bool) -> InstallAction {
+fn decide_redis_cli(install: bool, has: &dyn Fn(&str) -> bool, local_bin: bool) -> InstallAction {
+    // The official installer falls back to ~/.local/bin, which is often not on
+    // PATH: without this check every run would re-run curl | sh.
+    if local_bin && !has("redis-cli") {
+        return InstallAction::Report(Change::new(
+            "redis-cli",
+            Status::Unchanged,
+            "already installed to ~/.local/bin - add it to PATH to use it",
+        ));
+    }
     if has("redis-cli") {
         let version = sh("redis-cli", &["--version"])
             .stdout
@@ -474,23 +486,48 @@ mod tests {
         assert_eq!(change.subject, "package.json");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn install_commands_run_in_the_plans_directory_not_the_process_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        let action = InstallAction::Command {
+            cmd: "touch".to_string(),
+            args: vec!["sub/marker".to_string()],
+            file: "package.json",
+            note: "n".to_string(),
+        };
+        // `sub/` exists only inside the plan's cwd: the command succeeds there and
+        // nowhere else.
+        let change = action.perform(dir.path(), &mut |_| {}).unwrap();
+        assert_eq!(change.status, Status::Updated, "{}", change.note);
+        assert!(dir.path().join("sub/marker").exists());
+    }
+
+    #[test]
+    fn local_bin_redis_cli_counts_as_installed() {
+        let change = decide_redis_cli(true, &|_| false, true).preview();
+        assert_eq!(change.status, Status::Unchanged);
+        assert!(change.note.contains("~/.local/bin"), "{}", change.note);
+    }
+
     #[test]
     fn redis_cli_present_reads_unchanged() {
-        let change = decide_redis_cli(true, &|_| true).preview();
+        let change = decide_redis_cli(true, &|_| true, false).preview();
         assert_eq!(change.status, Status::Unchanged);
         assert!(change.note.contains("already on PATH"), "{}", change.note);
     }
 
     #[test]
     fn redis_cli_opt_out_reads_skipped() {
-        let change = decide_redis_cli(false, &|_| false).preview();
+        let change = decide_redis_cli(false, &|_| false, false).preview();
         assert_eq!(change.status, Status::Skipped);
         assert!(change.note.contains("--no-install-cli"), "{}", change.note);
     }
 
     #[test]
     fn redis_cli_missing_plans_the_installer() {
-        let change = decide_redis_cli(true, &|_| false).preview();
+        let change = decide_redis_cli(true, &|_| false, false).preview();
         assert_eq!(change.status, Status::Planned);
         assert!(change.note.contains("packages.redis.io"), "{}", change.note);
     }

--- a/crates/redisctl-init/src/lib.rs
+++ b/crates/redisctl-init/src/lib.rs
@@ -8,6 +8,7 @@
 mod change;
 mod docker;
 mod env;
+mod install;
 mod project;
 mod util;
 
@@ -72,6 +73,8 @@ pub struct Options {
     pub url_input: Option<String>,
     /// `None` detects installed tools; detecting none still configures all agents.
     pub agents: Option<Vec<Agent>>,
+    /// Install redis-cli when it is missing (`--no-install-cli` turns this off).
+    pub install_cli: bool,
 }
 
 /// What a run works with: the facts detected, the database it targets, and the
@@ -82,6 +85,8 @@ pub struct Plan {
     pub agents: Vec<Agent>,
     database: docker::DatabaseAction,
     file_actions: Vec<env::FileAction>,
+    client: install::InstallAction,
+    cli: install::InstallAction,
     cwd: PathBuf,
 }
 
@@ -103,6 +108,7 @@ impl Plan {
             .preview()
             .into_iter()
             .chain(self.file_actions.iter().map(|action| action.preview()))
+            .chain([self.client.preview(), self.cli.preview()])
             .collect()
     }
 }
@@ -127,13 +133,23 @@ pub fn plan(options: &Options) -> Result<Plan, InitError> {
     );
     let file_actions = vec![
         env::plan_env_set(&options.cwd, ".env", "REDIS_URL", database.url())?,
+        env::plan_env_set(
+            &options.cwd,
+            ".env.example",
+            "REDIS_URL",
+            "redis://localhost:6379",
+        )?,
         env::plan_gitignore_env(&options.cwd)?,
     ];
+    let client = install::plan_client_install(&options.cwd, &project);
+    let cli = install::plan_redis_cli(options.install_cli);
     Ok(Plan {
         project,
         agents,
         database,
         file_actions,
+        client,
+        cli,
         cwd: options.cwd.clone(),
     })
 }
@@ -149,6 +165,8 @@ pub async fn apply(plan: &Plan, on_event: &mut dyn FnMut(Event)) -> Result<Repor
     for action in &plan.file_actions {
         changes.push(action.perform(&plan.cwd)?);
     }
+    changes.push(plan.client.perform(&plan.cwd, on_event)?);
+    changes.push(plan.cli.perform(&plan.cwd, on_event)?);
     Ok(Report { changes })
 }
 
@@ -222,6 +240,7 @@ mod tests {
             cwd: dir.path().to_path_buf(),
             url_input: Some("redis-cli -u redis://h:1".into()),
             agents: Some(vec![Agent::Claude]),
+            install_cli: false,
         })
         .unwrap();
         assert_eq!(plan.project.runtime, Runtime::Go);
@@ -237,12 +256,17 @@ mod tests {
             cwd: dir.path().to_path_buf(),
             url_input: Some("redis://h:1".into()),
             agents: Some(vec![Agent::Codex]),
+            install_cli: false,
         })
         .unwrap();
         let changes = plan.changes();
         let subjects: Vec<_> = changes.iter().map(|c| c.subject.as_str()).collect();
-        assert_eq!(subjects, vec![".env", ".gitignore"]);
-        assert!(changes.iter().all(|c| c.status == Status::Created));
+        assert_eq!(
+            subjects[..3],
+            [".env", ".env.example", ".gitignore"],
+            "env wiring leads the report"
+        );
+        assert!(changes[..3].iter().all(|c| c.status == Status::Created));
         // Planning writes nothing.
         assert!(!dir.path().join(".env").exists());
     }
@@ -254,30 +278,41 @@ mod tests {
             cwd: dir.path().to_path_buf(),
             url_input: Some("redis://h:1".into()),
             agents: Some(vec![Agent::Codex]),
+            install_cli: false,
         })
         .unwrap();
         let report = apply(&plan, &mut |_| {}).await.unwrap();
-        assert_eq!(report.changes.len(), 2);
         let env = std::fs::read_to_string(dir.path().join(".env")).unwrap();
         assert!(env.contains("REDIS_URL=\"redis://h:1\""), "{env}");
+        assert!(
+            std::fs::read_to_string(dir.path().join(".env.example"))
+                .unwrap()
+                .contains("REDIS_URL=\"redis://localhost:6379\"")
+        );
         assert!(
             std::fs::read_to_string(dir.path().join(".gitignore"))
                 .unwrap()
                 .contains(".env")
         );
+        assert!(report.changes.len() >= 5, "{:?}", report.changes);
 
-        // A second plan over the applied state reads back all-unchanged.
+        // A second plan over the applied state reads the file contract back as
+        // all-unchanged (install lines depend on the machine, files must not).
         let replan = super::plan(&Options {
             cwd: dir.path().to_path_buf(),
             url_input: Some("redis://h:1".into()),
             agents: Some(vec![Agent::Codex]),
+            install_cli: false,
         })
         .unwrap();
         assert!(
             replan
                 .changes()
                 .iter()
-                .all(|c| c.status == Status::Unchanged)
+                .filter(|c| c.subject.starts_with('.'))
+                .all(|c| c.status == Status::Unchanged),
+            "{:?}",
+            replan.changes()
         );
     }
 }

--- a/crates/redisctl-init/src/util.rs
+++ b/crates/redisctl-init/src/util.rs
@@ -27,7 +27,17 @@ pub(crate) struct ShOutput {
 
 /// Run a command and capture its output; a spawn failure reads as status -1.
 pub(crate) fn sh(cmd: &str, args: &[&str]) -> ShOutput {
-    match std::process::Command::new(cmd).args(args).output() {
+    run(std::process::Command::new(cmd).args(args))
+}
+
+/// Like [`sh`], but in `dir` - commands that act on the project must not depend on
+/// the caller's process cwd.
+pub(crate) fn sh_in(dir: &Path, cmd: &str, args: &[&str]) -> ShOutput {
+    run(std::process::Command::new(cmd).args(args).current_dir(dir))
+}
+
+fn run(command: &mut std::process::Command) -> ShOutput {
+    match command.output() {
         Ok(out) => ShOutput {
             status: out.status.code().unwrap_or(-1),
             stdout: String::from_utf8_lossy(&out.stdout).into_owned(),

--- a/crates/redisctl/src/cli/init.rs
+++ b/crates/redisctl/src/cli/init.rs
@@ -33,6 +33,10 @@ pub struct InitArgs {
     #[arg(long = "agent", value_enum, value_delimiter = ',', value_name = "NAME")]
     pub agents: Vec<AgentArg>,
 
+    /// Skip installing redis-cli when it is missing
+    #[arg(long = "no-install-cli")]
+    pub no_install_cli: bool,
+
     /// Print the plan without changing anything
     #[arg(long)]
     pub dry_run: bool,

--- a/crates/redisctl/src/cli/init.rs
+++ b/crates/redisctl/src/cli/init.rs
@@ -61,6 +61,7 @@ impl std::fmt::Debug for InitArgs {
             .field("url", &self.url.as_ref().map(|_| "<redacted>"))
             .field("name", &self.name)
             .field("agents", &self.agents)
+            .field("no_install_cli", &self.no_install_cli)
             .field("dry_run", &self.dry_run)
             .field("pasted", &(!self.pasted.is_empty()).then_some("<redacted>"))
             .finish()
@@ -77,6 +78,7 @@ mod tests {
             url: Some("redis://default:s3cret@h:1".into()),
             name: Some("db".into()),
             agents: vec![AgentArg::Claude],
+            no_install_cli: false,
             dry_run: false,
             pasted: vec![
                 "redis-cli".into(),

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -46,6 +46,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         })?,
         url_input: (!pasted.trim().is_empty()).then_some(pasted),
         agents: requested_agents(&args.agents),
+        install_cli: !args.no_install_cli,
     };
     let plan = engine::plan(&options)?;
 

--- a/crates/redisctl/src/workflows/init/output.rs
+++ b/crates/redisctl/src/workflows/init/output.rs
@@ -45,6 +45,7 @@ fn icon(status: redisctl_init::Status) -> String {
         Status::Updated => yellow("~"),
         Status::Unchanged => dim("="),
         Status::Kept => yellow("!"),
+        Status::Skipped => dim("-"),
         Status::Planned => yellow("»"),
     }
 }

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -184,6 +184,11 @@ fn dead_url_writes_env_then_fails_validation_with_the_stale_hint() {
     assert!(env.contains("REDIS_URL=\"redis://127.0.0.1:9\""), "{env}");
     let gitignore = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
     assert!(gitignore.contains(".env"), "{gitignore}");
+    let example = std::fs::read_to_string(dir.path().join(".env.example")).unwrap();
+    assert!(
+        example.contains("REDIS_URL=\"redis://localhost:6379\""),
+        "{example}"
+    );
 }
 
 #[test]
@@ -227,4 +232,39 @@ fn a_different_existing_redis_url_is_kept_not_clobbered() {
         std::fs::read_to_string(dir.path().join(".env")).unwrap(),
         "REDIS_URL=\"redis://keep-me:1\"\n"
     );
+}
+
+#[test]
+fn rust_project_plans_cargo_add_and_the_example_contract() {
+    let dir = tempfile::tempdir().unwrap();
+    // cargo is guaranteed on PATH wherever these tests run.
+    std::fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"x\"\n").unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args(["init", "--dry-run", "--url", "redis://localhost:6379"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".env.example"))
+        .stdout(predicate::str::contains("would run: cargo add redis"))
+        .stdout(predicate::str::contains("redis-cli"));
+}
+
+#[test]
+fn no_install_cli_is_respected() {
+    let dir = tempfile::tempdir().unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args([
+            "init",
+            "--dry-run",
+            "--no-install-cli",
+            "--url",
+            "redis://localhost:6379",
+        ])
+        .assert()
+        .success()
+        // Whether redis-cli is installed here or not, the line must never plan the
+        // installer under --no-install-cli.
+        .stdout(predicate::str::contains("would install via").not())
+        .stdout(predicate::str::contains("redis-cli"));
 }

--- a/crates/redisctl/tests/init_docker_tests.rs
+++ b/crates/redisctl/tests/init_docker_tests.rs
@@ -58,7 +58,7 @@ fn full_run_provisions_validates_and_rerun_is_unchanged() {
 
     redisctl()
         .current_dir(&dir)
-        .arg("init")
+        .args(["init", "--no-install-cli"])
         .assert()
         .success()
         .stdout(predicate::str::contains(&container))
@@ -72,7 +72,7 @@ fn full_run_provisions_validates_and_rerun_is_unchanged() {
     // Idempotent re-run: nothing changes, validation still green.
     redisctl()
         .current_dir(&dir)
-        .arg("init")
+        .args(["init", "--no-install-cli"])
         .assert()
         .success()
         .stdout(predicate::str::contains("unchanged .env"))
@@ -88,7 +88,11 @@ fn stopped_container_is_restarted() {
     let tmp = tempfile::tempdir().unwrap();
     let (dir, container, _cleanup) = project_dir(tmp.path(), "stop");
 
-    redisctl().current_dir(&dir).arg("init").assert().success();
+    redisctl()
+        .current_dir(&dir)
+        .args(["init", "--no-install-cli"])
+        .assert()
+        .success();
     let out = std::process::Command::new("docker")
         .args(["stop", &container])
         .output()
@@ -97,7 +101,7 @@ fn stopped_container_is_restarted() {
 
     redisctl()
         .current_dir(&dir)
-        .arg("init")
+        .args(["init", "--no-install-cli"])
         .assert()
         .success()
         .stdout(predicate::str::contains("restarted stopped container"))
@@ -145,7 +149,7 @@ fn restart_that_never_serves_redis_fails_instead_of_reporting_updated() {
 
     redisctl()
         .current_dir(&dir)
-        .arg("init")
+        .args(["init", "--no-install-cli"])
         .assert()
         .failure()
         .stdout(predicate::str::contains("restarted stopped container").not())

--- a/crates/redisctl/tests/init_docker_tests.rs
+++ b/crates/redisctl/tests/init_docker_tests.rs
@@ -52,8 +52,9 @@ fn container_running(name: &str) -> Option<bool> {
 #[serial]
 fn full_run_provisions_validates_and_rerun_is_unchanged() {
     let tmp = tempfile::tempdir().unwrap();
+    // Deliberately no manifest: a package.json here would make the run perform a
+    // real npm install, and this suite needs Docker only.
     let (dir, container, _cleanup) = project_dir(tmp.path(), "full");
-    std::fs::write(dir.join("package.json"), r#"{"name":"live-full"}"#).unwrap();
 
     redisctl()
         .current_dir(&dir)


### PR DESCRIPTION
Stacked on #1100. The project half: install decisions are made read-only at plan time, commands run at apply.

- `.env.example` gets the `REDIS_URL` placeholder (same never-clobber rules, PoC report order).
- Client SDK per detected runtime: npm/pnpm/yarn/bun, uv/poetry/requirements-append, `go get`, `cargo add`; Java is advised-only (no safe way to mutate pom.xml). A missing tool or failed install reads as `skipped`, never a run failure - the database contract still lands.
- redis-cli via the official checksum-verified installer when missing; `--no-install-cli` opts out; an existing `~/.local/bin` install counts as installed.
- Dry runs report every install decision, including the skips.

Tests: engine tests use an injected `has_bin` seam so PATH contents cannot flake the matrix.

## Testing

### Dry Run
<img width="5173" height="1880" alt="1-dry-run" src="https://github.com/user-attachments/assets/4a8b22a0-61a8-4bce-8e89-d5c3d93547f7" />

### Run
<img width="4140" height="2012" alt="2-init-run" src="https://github.com/user-attachments/assets/827ddc3a-7a71-48be-9b63-1bcce68b3c09" />

### Re-Run
<img width="4140" height="1812" alt="3-rerun-unchanged" src="https://github.com/user-attachments/assets/368df436-4ce9-4fc6-b744-9cef96893c3b" />
