### PR TITLE
feat(init): install the official Redis skills with lock-aware reporting

### DIFF
--- a/crates/redisctl-init/src/lib.rs
+++ b/crates/redisctl-init/src/lib.rs
@@ -10,6 +10,7 @@ mod docker;
 mod env;
 mod install;
 mod project;
+mod skills;
 mod util;
 
 pub use change::{Change, Status};
@@ -62,6 +63,8 @@ pub enum Event {
     ProgressDone(String),
     /// A one-off informational line.
     Note(String),
+    /// A caution the caller should make visually distinct.
+    Warning(String),
 }
 
 /// What the caller asked for, resolved from its own surface (flags, prompts, tools).
@@ -75,6 +78,10 @@ pub struct Options {
     pub agents: Option<Vec<Agent>>,
     /// Install redis-cli when it is missing (`--no-install-cli` turns this off).
     pub install_cli: bool,
+    /// A local redis/agent-skills checkout to copy from instead of the skills CLI.
+    pub skills_repo: Option<PathBuf>,
+    /// Install the official skills for the user instead of into this project.
+    pub skills_global: bool,
 }
 
 /// What a run works with: the facts detected, the database it targets, and the
@@ -87,6 +94,7 @@ pub struct Plan {
     file_actions: Vec<env::FileAction>,
     client: install::InstallAction,
     cli: install::InstallAction,
+    skills: skills::SkillsAction,
     cwd: PathBuf,
 }
 
@@ -108,7 +116,11 @@ impl Plan {
             .preview()
             .into_iter()
             .chain(self.file_actions.iter().map(|action| action.preview()))
-            .chain([self.client.preview(), self.cli.preview()])
+            .chain([
+                self.client.preview(),
+                self.cli.preview(),
+                self.skills.preview(),
+            ])
             .collect()
     }
 }
@@ -143,6 +155,11 @@ pub fn plan(options: &Options) -> Result<Plan, InitError> {
     ];
     let client = install::plan_client_install(&options.cwd, &project);
     let cli = install::plan_redis_cli(options.install_cli);
+    let skills = skills::SkillsAction {
+        agents: agents.clone(),
+        global: options.skills_global,
+        repo: options.skills_repo.clone(),
+    };
     Ok(Plan {
         project,
         agents,
@@ -150,6 +167,7 @@ pub fn plan(options: &Options) -> Result<Plan, InitError> {
         file_actions,
         client,
         cli,
+        skills,
         cwd: options.cwd.clone(),
     })
 }
@@ -167,6 +185,7 @@ pub async fn apply(plan: &Plan, on_event: &mut dyn FnMut(Event)) -> Result<Repor
     }
     changes.push(plan.client.perform(&plan.cwd, on_event)?);
     changes.push(plan.cli.perform(&plan.cwd, on_event)?);
+    changes.extend(plan.skills.perform(&plan.cwd, on_event)?);
     Ok(Report { changes })
 }
 
@@ -241,6 +260,8 @@ mod tests {
             url_input: Some("redis-cli -u redis://h:1".into()),
             agents: Some(vec![Agent::Claude]),
             install_cli: false,
+            skills_repo: None,
+            skills_global: false,
         })
         .unwrap();
         assert_eq!(plan.project.runtime, Runtime::Go);
@@ -257,6 +278,8 @@ mod tests {
             url_input: Some("redis://h:1".into()),
             agents: Some(vec![Agent::Codex]),
             install_cli: false,
+            skills_repo: None,
+            skills_global: false,
         })
         .unwrap();
         let changes = plan.changes();
@@ -274,13 +297,20 @@ mod tests {
     #[tokio::test]
     async fn apply_writes_what_the_plan_predicted() {
         let dir = tempfile::tempdir().unwrap();
-        let plan = plan(&Options {
-            cwd: dir.path().to_path_buf(),
+        // A fixture checkout keeps the skills step offline.
+        let repo = tempfile::tempdir().unwrap();
+        let skill = repo.path().join("skills/redis-basics");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(skill.join("SKILL.md"), "# basics\n").unwrap();
+        let options = |cwd: &std::path::Path| Options {
+            cwd: cwd.to_path_buf(),
             url_input: Some("redis://h:1".into()),
             agents: Some(vec![Agent::Codex]),
             install_cli: false,
-        })
-        .unwrap();
+            skills_repo: Some(repo.path().to_path_buf()),
+            skills_global: false,
+        };
+        let plan = plan(&options(dir.path())).unwrap();
         let report = apply(&plan, &mut |_| {}).await.unwrap();
         let env = std::fs::read_to_string(dir.path().join(".env")).unwrap();
         assert!(env.contains("REDIS_URL=\"redis://h:1\""), "{env}");
@@ -294,25 +324,24 @@ mod tests {
                 .unwrap()
                 .contains(".env")
         );
-        assert!(report.changes.len() >= 5, "{:?}", report.changes);
+        assert!(
+            dir.path()
+                .join(".agents/skills/redis-basics/SKILL.md")
+                .exists()
+        );
+        assert!(report.changes.len() >= 6, "{:?}", report.changes);
 
         // A second plan over the applied state reads the file contract back as
-        // all-unchanged (install lines depend on the machine, files must not).
-        let replan = super::plan(&Options {
-            cwd: dir.path().to_path_buf(),
-            url_input: Some("redis://h:1".into()),
-            agents: Some(vec![Agent::Codex]),
-            install_cli: false,
-        })
-        .unwrap();
-        assert!(
-            replan
+        // all-unchanged (install and skills lines depend on machine state, the
+        // files must not).
+        let replan = super::plan(&options(dir.path())).unwrap();
+        for subject in [".env", ".env.example", ".gitignore"] {
+            let change = replan
                 .changes()
-                .iter()
-                .filter(|c| c.subject.starts_with('.'))
-                .all(|c| c.status == Status::Unchanged),
-            "{:?}",
-            replan.changes()
-        );
+                .into_iter()
+                .find(|c| c.subject == subject)
+                .unwrap();
+            assert_eq!(change.status, Status::Unchanged, "{subject}");
+        }
     }
 }

--- a/crates/redisctl-init/src/skills.rs
+++ b/crates/redisctl-init/src/skills.rs
@@ -243,10 +243,19 @@ pub(crate) struct SkillsAction {
 
 impl SkillsAction {
     fn npx_args(&self) -> Vec<String> {
-        let mut args: Vec<String> = ["-y", "skills", "add", "redis/agent-skills", "-s", "*"]
-            .into_iter()
-            .map(str::to_string)
-            .collect();
+        // Pinning @latest keeps a stale npx cache from running an old skills CLI
+        // that rejects newer flags.
+        let mut args: Vec<String> = [
+            "-y",
+            "skills@latest",
+            "add",
+            "redis/agent-skills",
+            "-s",
+            "*",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
         for agent in &self.agents {
             args.push("-a".to_string());
             args.push(cli_agent(*agent).to_string());
@@ -327,7 +336,7 @@ impl SkillsAction {
             return Ok(vec![Change::new(
                 describe_target(self.global),
                 Status::Skipped,
-                "npx skills add failed (offline?) - re-run it yourself, or pass --skills-repo <a redis/agent-skills checkout>",
+                failure_note(&r.stderr, &r.stdout, r.status),
             )]);
         }
 
@@ -461,6 +470,27 @@ impl SkillsAction {
     }
 }
 
+/// A failed install's note leads with the installer's own first error line - a
+/// generic guess once sent a real failure down the wrong path. Notes render on one
+/// line, so the line is capped.
+fn failure_note(stderr: &str, stdout: &str, status: i32) -> String {
+    let error = [stderr, stdout]
+        .iter()
+        .flat_map(|out| out.lines())
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("exit status {status}"));
+    let error = if error.chars().count() > 160 {
+        format!("{}...", error.chars().take(160).collect::<String>())
+    } else {
+        error
+    };
+    format!(
+        "npx skills add failed: {error} - re-run it yourself, or pass --skills-repo <a redis/agent-skills checkout>"
+    )
+}
+
 fn display_relative(cwd: &Path, path: &Path) -> String {
     path.strip_prefix(cwd).unwrap_or(path).display().to_string()
 }
@@ -498,8 +528,31 @@ mod tests {
         assert_eq!(change.status, Status::Planned);
         assert_eq!(
             change.note,
-            "would run: npx -y skills add redis/agent-skills -s * -a claude-code -a github-copilot -g -y"
+            "would run: npx -y skills@latest add redis/agent-skills -s * -a claude-code -a github-copilot -g -y"
         );
+    }
+
+    #[test]
+    fn failure_note_carries_the_installers_own_error() {
+        let note = failure_note("Unknown agent: codex\nrun skills --help\n", "", 1);
+        assert_eq!(
+            note,
+            "npx skills add failed: Unknown agent: codex - re-run it yourself, or pass --skills-repo <a redis/agent-skills checkout>"
+        );
+    }
+
+    #[test]
+    fn failure_note_falls_back_to_stdout_then_to_the_exit_status() {
+        assert!(failure_note("", "only stdout spoke\n", 1).contains("only stdout spoke"));
+        assert!(failure_note("", "", 127).contains("exit status 127"));
+    }
+
+    #[test]
+    fn failure_note_truncates_a_rambling_error_line() {
+        let long = "x".repeat(500);
+        let note = failure_note(&long, "", 1);
+        assert!(note.len() < 300, "{}", note.len());
+        assert!(note.contains("..."));
     }
 
     #[test]

--- a/crates/redisctl-init/src/skills.rs
+++ b/crates/redisctl-init/src/skills.rs
@@ -153,18 +153,21 @@ fn skill_dirs(root: &Path) -> Vec<String> {
 
 /// Skill dirs not tracked in the lock are the user's own; the standard installer
 /// decides what happens to colliding names, so surface them and report disk truth.
+/// Both layouts are scanned - a solo-Claude install lives in .claude/skills.
 fn unmanaged_collisions(cwd: &Path) -> BTreeMap<String, String> {
     let managed = read_lock_hashes(cwd);
-    let dir = cwd.join(SKILLS_DIR);
-    skill_dirs(&dir)
-        .into_iter()
-        .filter(|name| name != GENERATED_SKILL && !managed.contains_key(name))
-        .filter_map(|name| {
-            std::fs::read_to_string(dir.join(&name).join("SKILL.md"))
-                .ok()
-                .map(|content| (name, content))
-        })
-        .collect()
+    let mut collisions = BTreeMap::new();
+    for dir in target_dirs(cwd, false) {
+        for name in skill_dirs(&dir) {
+            if name == GENERATED_SKILL || managed.contains_key(&name) {
+                continue;
+            }
+            if let Ok(content) = std::fs::read_to_string(dir.join(&name).join("SKILL.md")) {
+                collisions.entry(name).or_insert(content);
+            }
+        }
+    }
+    collisions
 }
 
 fn walk_files(dir: &Path, base: &Path, out: &mut Vec<PathBuf>) {
@@ -256,11 +259,11 @@ impl SkillsAction {
     }
 
     pub(crate) fn preview(&self) -> Change {
-        Change::new(
-            describe_target(self.global),
-            Status::Planned,
-            format!("would run: npx {}", self.npx_args().join(" ")),
-        )
+        let note = match &self.repo {
+            Some(repo) => format!("would copy skills from {}", repo.display()),
+            None => format!("would run: npx {}", self.npx_args().join(" ")),
+        };
+        Change::new(describe_target(self.global), Status::Planned, note)
     }
 
     pub(crate) fn perform(
@@ -349,7 +352,8 @@ impl SkillsAction {
                 .map(|p| format!("{}/", display_relative(cwd, &p)))
                 .unwrap_or_else(|| name.clone());
             if let Some(previous_md) = collisions.get(name) {
-                let now = read_if(cwd, &format!("{SKILLS_DIR}/{name}/SKILL.md"));
+                let now = installed_skill_path(cwd, false, name)
+                    .and_then(|p| std::fs::read_to_string(p.join("SKILL.md")).ok());
                 let (status, note) = if now.as_deref() == Some(previous_md.as_str()) {
                     (
                         Status::Kept,
@@ -424,7 +428,7 @@ impl SkillsAction {
             let subject = if self.global {
                 format!("{}/", dst.display())
             } else {
-                format!("{SKILLS_DIR}/{name}/")
+                format!("{}/", display_relative(cwd, &dst))
             };
             if dirs_equal(&src, &dst) {
                 changes.push(Change::new(subject, Status::Unchanged, ""));
@@ -496,6 +500,43 @@ mod tests {
             change.note,
             "would run: npx -y skills add redis/agent-skills -s * -a claude-code -a github-copilot -g -y"
         );
+    }
+
+    #[test]
+    fn preview_names_the_checkout_when_one_is_given() {
+        let a = action(Path::new("/tmp/checkout"));
+        assert_eq!(a.preview().note, "would copy skills from /tmp/checkout");
+    }
+
+    #[test]
+    fn solo_claude_checkout_reports_the_real_destination() {
+        let repo = fake_checkout(&["redis-basics"]);
+        let project = tempfile::tempdir().unwrap();
+        let solo = SkillsAction {
+            agents: vec![Agent::Claude],
+            global: false,
+            repo: Some(repo.path().to_path_buf()),
+        };
+        let changes = solo.perform(project.path(), &mut |_| {}).unwrap();
+        assert_eq!(changes[0].subject, ".claude/skills/redis-basics/");
+        assert!(
+            project
+                .path()
+                .join(".claude/skills/redis-basics/SKILL.md")
+                .exists()
+        );
+        let rerun = solo.perform(project.path(), &mut |_| {}).unwrap();
+        assert!(rerun.iter().all(|c| c.status == Status::Unchanged));
+    }
+
+    #[test]
+    fn unmanaged_collisions_see_the_claude_layout_too() {
+        let project = tempfile::tempdir().unwrap();
+        let dir = project.path().join(".claude/skills/mine");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("SKILL.md"), "x").unwrap();
+        let collisions = unmanaged_collisions(project.path());
+        assert_eq!(collisions.keys().collect::<Vec<_>>(), vec!["mine"]);
     }
 
     #[test]

--- a/crates/redisctl-init/src/skills.rs
+++ b/crates/redisctl-init/src/skills.rs
@@ -1,0 +1,649 @@
+//! The official Redis agent skills from redis/agent-skills.
+//!
+//! Primary path is the industry-standard skills CLI (`npx skills add`), which owns
+//! `skills-lock.json` and its own layout. An explicitly named checkout (flag or env)
+//! is copied directly instead - an explicit local source is an explicit choice, and
+//! it works offline. With neither, the step is skipped with the remedy in the note;
+//! skills are additive and the onboarding still stands. Outcomes are only knowable
+//! after the installer runs, so previews carry the command and apply reports disk
+//! truth.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+
+use crate::change::{Change, Status};
+use crate::project::Agent;
+use crate::util::{has_bin, read_if, sh_in};
+use crate::{Event, InitError};
+
+const SKILLS_DIR: &str = ".agents/skills";
+const LOCK_FILE: &str = "skills-lock.json";
+/// The skill this tool generates itself; never treated as a foreign collision.
+const GENERATED_SKILL: &str = "redis-project-setup";
+
+/// The skills CLI's identifiers for the agents redisctl init supports; passing them
+/// explicitly (instead of `--agent '*'`) keeps the layout to the directories the
+/// chosen agents actually read.
+fn cli_agent(agent: Agent) -> &'static str {
+    match agent {
+        Agent::Claude => "claude-code",
+        Agent::Cursor => "cursor",
+        Agent::Vscode => "github-copilot",
+        Agent::Codex => "codex",
+    }
+}
+
+fn home() -> PathBuf {
+    std::env::home_dir().unwrap_or_default()
+}
+
+/// The skills CLI picks its own layout: usually a shared skills dir with per-agent
+/// symlinks, but targeting claude-code alone copies straight into .claude/skills.
+/// Probe both and report where a skill actually is, never assume.
+fn target_dirs(cwd: &Path, global: bool) -> [PathBuf; 2] {
+    if global {
+        [home().join(".agents/skills"), home().join(".claude/skills")]
+    } else {
+        [cwd.join(SKILLS_DIR), cwd.join(".claude/skills")]
+    }
+}
+
+fn installed_skill_path(cwd: &Path, global: bool, name: &str) -> Option<PathBuf> {
+    target_dirs(cwd, global)
+        .into_iter()
+        .map(|dir| dir.join(name))
+        .find(|candidate| candidate.exists())
+}
+
+/// Where an install would land, named only when nothing was actually installed -
+/// which directory the skills CLI uses is its own layout choice.
+fn describe_target(global: bool) -> String {
+    if global {
+        format!(
+            "{}/ or {}/",
+            home().join(".agents/skills").display(),
+            home().join(".claude/skills").display()
+        )
+    } else {
+        format!("{SKILLS_DIR}/")
+    }
+}
+
+/// The offline fallback picks a real destination itself, mirroring the CLI's layout
+/// choice: a lone claude-code target lands in that agent's own dir.
+fn fallback_dir(cwd: &Path, global: bool, agents: &[Agent]) -> PathBuf {
+    let solo_claude = agents == [Agent::Claude];
+    let dirs = target_dirs(cwd, global);
+    if solo_claude {
+        dirs[1].clone()
+    } else {
+        dirs[0].clone()
+    }
+}
+
+/// skills-lock.json is written and owned by the skills CLI, version 1:
+/// `{ "skills": { <name>: { ..., "computedHash": ... } } }`.
+fn read_lock_hashes(cwd: &Path) -> BTreeMap<String, String> {
+    let Some(lock) = read_if(cwd, LOCK_FILE)
+        .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+    else {
+        return BTreeMap::new();
+    };
+    lock["skills"]
+        .as_object()
+        .map(|skills| {
+            skills
+                .iter()
+                .map(|(name, meta)| {
+                    (
+                        name.clone(),
+                        meta["computedHash"]
+                            .as_str()
+                            .unwrap_or_default()
+                            .to_string(),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The CLI's global lock: same idea, but its hash schema has already changed between
+/// versions. The one thing stable across them is the `skills` key set, so read only
+/// the names - it is what separates skills this tool manages from a user's own
+/// personal ones sitting in the same tree.
+fn read_global_lock_names() -> Option<BTreeSet<String>> {
+    let content = std::fs::read_to_string(home().join(".agents/.skill-lock.json")).ok()?;
+    let lock = serde_json::from_str::<serde_json::Value>(&content).ok()?;
+    Some(lock["skills"].as_object()?.keys().cloned().collect())
+}
+
+/// Which skill-bearing directories exist right now, for the global scope. A
+/// directory counts as a skill when it holds SKILL.md.
+fn global_skill_names() -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    for dir in target_dirs(Path::new(""), true) {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if entry.path().join("SKILL.md").exists()
+                && let Some(name) = entry.file_name().to_str()
+            {
+                names.insert(name.to_string());
+            }
+        }
+    }
+    names
+}
+
+fn skill_dirs(root: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter(|entry| entry.path().join("SKILL.md").exists())
+        .filter_map(|entry| entry.file_name().to_str().map(str::to_string))
+        .collect();
+    names.sort();
+    names
+}
+
+/// Skill dirs not tracked in the lock are the user's own; the standard installer
+/// decides what happens to colliding names, so surface them and report disk truth.
+fn unmanaged_collisions(cwd: &Path) -> BTreeMap<String, String> {
+    let managed = read_lock_hashes(cwd);
+    let dir = cwd.join(SKILLS_DIR);
+    skill_dirs(&dir)
+        .into_iter()
+        .filter(|name| name != GENERATED_SKILL && !managed.contains_key(name))
+        .filter_map(|name| {
+            std::fs::read_to_string(dir.join(&name).join("SKILL.md"))
+                .ok()
+                .map(|content| (name, content))
+        })
+        .collect()
+}
+
+fn walk_files(dir: &Path, base: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_files(&path, base, out);
+        } else if let Ok(rel) = path.strip_prefix(base) {
+            out.push(rel.to_path_buf());
+        }
+    }
+}
+
+fn sorted_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    walk_files(dir, dir, &mut files);
+    files.sort();
+    files
+}
+
+fn dirs_equal(a: &Path, b: &Path) -> bool {
+    if !a.exists() || !b.exists() {
+        return false;
+    }
+    let files_a = sorted_files(a);
+    if files_a != sorted_files(b) {
+        return false;
+    }
+    files_a
+        .iter()
+        .all(|rel| std::fs::read(a.join(rel)).ok() == std::fs::read(b.join(rel)).ok())
+}
+
+/// A content signature for a skill directory, compared only within one run (before
+/// vs after the installer), so a non-cryptographic hash is enough.
+fn dir_signature(dir: &Path) -> Option<u64> {
+    if !dir.exists() {
+        return None;
+    }
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for rel in sorted_files(dir) {
+        rel.hash(&mut hasher);
+        std::fs::read(dir.join(&rel)).ok()?.hash(&mut hasher);
+    }
+    Some(hasher.finish())
+}
+
+fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let target = dst.join(entry.file_name());
+        if entry.path().is_dir() {
+            copy_dir(&entry.path(), &target)?;
+        } else {
+            std::fs::copy(entry.path(), &target)?;
+        }
+    }
+    Ok(())
+}
+
+/// The decided skills install, fixed at plan time; outcomes are disk truth read
+/// back at apply time.
+#[derive(Debug)]
+pub(crate) struct SkillsAction {
+    pub(crate) agents: Vec<Agent>,
+    pub(crate) global: bool,
+    pub(crate) repo: Option<PathBuf>,
+}
+
+impl SkillsAction {
+    fn npx_args(&self) -> Vec<String> {
+        let mut args: Vec<String> = ["-y", "skills", "add", "redis/agent-skills", "-s", "*"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        for agent in &self.agents {
+            args.push("-a".to_string());
+            args.push(cli_agent(*agent).to_string());
+        }
+        if self.global {
+            args.push("-g".to_string());
+        }
+        args.push("-y".to_string());
+        args
+    }
+
+    pub(crate) fn preview(&self) -> Change {
+        Change::new(
+            describe_target(self.global),
+            Status::Planned,
+            format!("would run: npx {}", self.npx_args().join(" ")),
+        )
+    }
+
+    pub(crate) fn perform(
+        &self,
+        cwd: &Path,
+        on_event: &mut dyn FnMut(Event),
+    ) -> Result<Vec<Change>, InitError> {
+        if let Some(repo) = &self.repo {
+            let source = repo.join("skills");
+            if !source.exists() {
+                return Ok(vec![Change::new(
+                    describe_target(self.global),
+                    Status::Skipped,
+                    format!("{} has no skills/ directory", repo.display()),
+                )]);
+            }
+            return self.copy_from(cwd, &source);
+        }
+
+        if has_bin("npx") {
+            let collisions = if self.global {
+                BTreeMap::new()
+            } else {
+                unmanaged_collisions(cwd)
+            };
+            if !collisions.is_empty() {
+                on_event(Event::Warning(format!(
+                    "  note: existing skills not tracked in {LOCK_FILE}: {} - the standard installer decides whether to replace them (delete the dir to adopt the official copy)",
+                    collisions.keys().cloned().collect::<Vec<_>>().join(", ")
+                )));
+            }
+            let before_names = self.global.then(global_skill_names);
+            let before_signatures: BTreeMap<String, Option<u64>> = before_names
+                .iter()
+                .flatten()
+                .map(|name| {
+                    (
+                        name.clone(),
+                        installed_skill_path(cwd, true, name).and_then(|p| dir_signature(&p)),
+                    )
+                })
+                .collect();
+            let before_lock = read_lock_hashes(cwd);
+
+            on_event(Event::ProgressStart(
+                "installing skills (npx skills add redis/agent-skills)".to_string(),
+            ));
+            let args = self.npx_args();
+            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            let r = sh_in(cwd, "npx", &arg_refs);
+            on_event(Event::ProgressDone(
+                if r.status == 0 { " done" } else { " failed" }.to_string(),
+            ));
+            if r.status == 0 {
+                return Ok(if self.global {
+                    self.report_global(cwd, &before_names.unwrap_or_default(), &before_signatures)
+                } else {
+                    self.report_project(cwd, &before_lock, &collisions)
+                });
+            }
+            return Ok(vec![Change::new(
+                describe_target(self.global),
+                Status::Skipped,
+                "npx skills add failed (offline?) - re-run it yourself, or pass --skills-repo <a redis/agent-skills checkout>",
+            )]);
+        }
+
+        Ok(vec![Change::new(
+            describe_target(self.global),
+            Status::Skipped,
+            "npx not found - install Node, or pass --skills-repo <a redis/agent-skills checkout>",
+        )])
+    }
+
+    /// The npx project outcome, read from the lock the CLI maintains.
+    fn report_project(
+        &self,
+        cwd: &Path,
+        before: &BTreeMap<String, String>,
+        collisions: &BTreeMap<String, String>,
+    ) -> Vec<Change> {
+        let after = read_lock_hashes(cwd);
+        let mut changes = Vec::new();
+        for (name, hash) in &after {
+            let subject = installed_skill_path(cwd, false, name)
+                .map(|p| format!("{}/", display_relative(cwd, &p)))
+                .unwrap_or_else(|| name.clone());
+            if let Some(previous_md) = collisions.get(name) {
+                let now = read_if(cwd, &format!("{SKILLS_DIR}/{name}/SKILL.md"));
+                let (status, note) = if now.as_deref() == Some(previous_md.as_str()) {
+                    (
+                        Status::Kept,
+                        "pre-existing skill left in place by the installer",
+                    )
+                } else {
+                    (Status::Updated, "replaced by npx skills add")
+                };
+                changes.push(Change::new(subject, status, note));
+                continue;
+            }
+            let status = match before.get(name) {
+                None => Status::Created,
+                Some(previous) if previous != hash => Status::Updated,
+                Some(_) => Status::Unchanged,
+            };
+            changes.push(Change::new(subject, status, "npx skills add"));
+        }
+        changes.push(Change::new(
+            LOCK_FILE,
+            Status::Unchanged,
+            "owned by the skills CLI",
+        ));
+        changes
+    }
+
+    /// The npx global outcome: the global lock names what the CLI manages; a
+    /// pre-existing personal skill in the same tree is never in it. Only when the
+    /// lock cannot be read at all does this fall back to "appeared since before" -
+    /// still never a name that was already there.
+    fn report_global(
+        &self,
+        cwd: &Path,
+        before_names: &BTreeSet<String>,
+        before_signatures: &BTreeMap<String, Option<u64>>,
+    ) -> Vec<Change> {
+        let after = global_skill_names();
+        let managed: Vec<String> = read_global_lock_names()
+            .unwrap_or_else(|| after.difference(before_names).cloned().collect())
+            .into_iter()
+            .filter(|name| after.contains(name))
+            .collect();
+        managed
+            .into_iter()
+            .map(|name| {
+                let path = installed_skill_path(cwd, true, &name);
+                let subject = path
+                    .as_ref()
+                    .map(|p| format!("{}/", p.display()))
+                    .unwrap_or_else(|| name.clone());
+                let status = if !before_names.contains(&name) {
+                    Status::Created
+                } else if path.as_deref().and_then(dir_signature)
+                    == before_signatures.get(&name).copied().flatten()
+                {
+                    Status::Unchanged
+                } else {
+                    Status::Updated
+                };
+                Change::new(subject, status, "npx skills add")
+            })
+            .collect()
+    }
+
+    /// Copy every skill from a checkout into the layout the real CLI would use.
+    fn copy_from(&self, cwd: &Path, source: &Path) -> Result<Vec<Change>, InitError> {
+        let destination = fallback_dir(cwd, self.global, &self.agents);
+        let mut changes = Vec::new();
+        for name in skill_dirs(source) {
+            let src = source.join(&name);
+            let dst = destination.join(&name);
+            let subject = if self.global {
+                format!("{}/", dst.display())
+            } else {
+                format!("{SKILLS_DIR}/{name}/")
+            };
+            if dirs_equal(&src, &dst) {
+                changes.push(Change::new(subject, Status::Unchanged, ""));
+                continue;
+            }
+            let status = if dst.exists() {
+                Status::Updated
+            } else {
+                Status::Created
+            };
+            let _ = std::fs::remove_dir_all(&dst);
+            copy_dir(&src, &dst).map_err(|e| InitError::WriteFailed {
+                rel: dst.display().to_string(),
+                message: e.to_string(),
+            })?;
+            changes.push(Change::new(
+                subject,
+                status,
+                "redis/agent-skills (local checkout; run npx skills add redis/agent-skills to adopt standard management)",
+            ));
+        }
+        if changes.is_empty() {
+            changes.push(Change::new(
+                describe_target(self.global),
+                Status::Skipped,
+                "no skills found in the checkout",
+            ));
+        }
+        Ok(changes)
+    }
+}
+
+fn display_relative(cwd: &Path, path: &Path) -> String {
+    path.strip_prefix(cwd).unwrap_or(path).display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_checkout(skills: &[&str]) -> tempfile::TempDir {
+        let repo = tempfile::tempdir().unwrap();
+        for name in skills {
+            let dir = repo.path().join("skills").join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("SKILL.md"), format!("# {name}\n")).unwrap();
+        }
+        repo
+    }
+
+    fn action(repo: &Path) -> SkillsAction {
+        SkillsAction {
+            agents: vec![Agent::Claude, Agent::Codex],
+            global: false,
+            repo: Some(repo.to_path_buf()),
+        }
+    }
+
+    #[test]
+    fn preview_carries_the_full_npx_command() {
+        let a = SkillsAction {
+            agents: vec![Agent::Claude, Agent::Vscode],
+            global: true,
+            repo: None,
+        };
+        let change = a.preview();
+        assert_eq!(change.status, Status::Planned);
+        assert_eq!(
+            change.note,
+            "would run: npx -y skills add redis/agent-skills -s * -a claude-code -a github-copilot -g -y"
+        );
+    }
+
+    #[test]
+    fn explicit_checkout_copies_and_reruns_unchanged() {
+        let repo = fake_checkout(&["redis-basics", "redis-search"]);
+        let project = tempfile::tempdir().unwrap();
+        let changes = action(repo.path())
+            .perform(project.path(), &mut |_| {})
+            .unwrap();
+        let summary: Vec<_> = changes
+            .iter()
+            .map(|c| (c.subject.as_str(), c.status))
+            .collect();
+        assert_eq!(
+            summary,
+            vec![
+                (".agents/skills/redis-basics/", Status::Created),
+                (".agents/skills/redis-search/", Status::Created),
+            ]
+        );
+        assert!(
+            project
+                .path()
+                .join(".agents/skills/redis-basics/SKILL.md")
+                .exists()
+        );
+
+        let rerun = action(repo.path())
+            .perform(project.path(), &mut |_| {})
+            .unwrap();
+        assert!(rerun.iter().all(|c| c.status == Status::Unchanged));
+    }
+
+    #[test]
+    fn a_drifted_skill_is_replaced_and_reported_updated() {
+        let repo = fake_checkout(&["redis-basics"]);
+        let project = tempfile::tempdir().unwrap();
+        action(repo.path())
+            .perform(project.path(), &mut |_| {})
+            .unwrap();
+        std::fs::write(
+            project.path().join(".agents/skills/redis-basics/SKILL.md"),
+            "user edit\n",
+        )
+        .unwrap();
+        let changes = action(repo.path())
+            .perform(project.path(), &mut |_| {})
+            .unwrap();
+        assert_eq!(changes[0].status, Status::Updated);
+        assert_eq!(
+            std::fs::read_to_string(project.path().join(".agents/skills/redis-basics/SKILL.md"))
+                .unwrap(),
+            "# redis-basics\n"
+        );
+    }
+
+    #[test]
+    fn a_checkout_without_skills_reads_skipped() {
+        let repo = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let changes = action(repo.path())
+            .perform(project.path(), &mut |_| {})
+            .unwrap();
+        assert_eq!(changes[0].status, Status::Skipped);
+        assert!(changes[0].note.contains("no skills/ directory"));
+    }
+
+    #[test]
+    fn unmanaged_collisions_ignore_the_lock_and_the_generated_skill() {
+        let project = tempfile::tempdir().unwrap();
+        for name in ["mine", "managed", GENERATED_SKILL] {
+            let dir = project.path().join(SKILLS_DIR).join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("SKILL.md"), "x").unwrap();
+        }
+        std::fs::write(
+            project.path().join(LOCK_FILE),
+            r#"{"skills":{"managed":{"computedHash":"abc"}}}"#,
+        )
+        .unwrap();
+        let collisions = unmanaged_collisions(project.path());
+        assert_eq!(collisions.keys().collect::<Vec<_>>(), vec!["mine"]);
+    }
+
+    #[test]
+    fn lock_hashes_read_the_v1_schema() {
+        let project = tempfile::tempdir().unwrap();
+        std::fs::write(
+            project.path().join(LOCK_FILE),
+            r#"{"skills":{"a":{"computedHash":"h1"},"b":{"computedHash":"h2"}}}"#,
+        )
+        .unwrap();
+        let hashes = read_lock_hashes(project.path());
+        assert_eq!(hashes.get("a").map(String::as_str), Some("h1"));
+        assert_eq!(hashes.len(), 2);
+    }
+
+    #[test]
+    fn project_report_diffs_the_lock_and_reports_disk_truth_for_collisions() {
+        let project = tempfile::tempdir().unwrap();
+        // The installer left one collision untouched and updated the lock.
+        let kept_dir = project.path().join(SKILLS_DIR).join("mine");
+        std::fs::create_dir_all(&kept_dir).unwrap();
+        std::fs::write(kept_dir.join("SKILL.md"), "original").unwrap();
+        for name in ["fresh", "same"] {
+            let dir = project.path().join(SKILLS_DIR).join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("SKILL.md"), "x").unwrap();
+        }
+        std::fs::write(
+            project.path().join(LOCK_FILE),
+            r#"{"skills":{"fresh":{"computedHash":"new"},"same":{"computedHash":"h"},"mine":{"computedHash":"m"}}}"#,
+        )
+        .unwrap();
+        let before = BTreeMap::from([("same".to_string(), "h".to_string())]);
+        let collisions = BTreeMap::from([("mine".to_string(), "original".to_string())]);
+        let a = SkillsAction {
+            agents: vec![Agent::Claude],
+            global: false,
+            repo: None,
+        };
+        let changes = a.report_project(project.path(), &before, &collisions);
+        let by_subject: BTreeMap<_, _> = changes
+            .iter()
+            .map(|c| (c.subject.clone(), c.status))
+            .collect();
+        assert_eq!(
+            by_subject.get(".agents/skills/fresh/"),
+            Some(&Status::Created)
+        );
+        assert_eq!(
+            by_subject.get(".agents/skills/same/"),
+            Some(&Status::Unchanged)
+        );
+        assert_eq!(by_subject.get(".agents/skills/mine/"), Some(&Status::Kept));
+        assert_eq!(by_subject.get(LOCK_FILE), Some(&Status::Unchanged));
+    }
+
+    #[test]
+    fn solo_claude_fallback_lands_in_the_claude_dir() {
+        let cwd = Path::new("/p");
+        assert_eq!(
+            fallback_dir(cwd, false, &[Agent::Claude]),
+            cwd.join(".claude/skills")
+        );
+        assert_eq!(
+            fallback_dir(cwd, false, &[Agent::Claude, Agent::Codex]),
+            cwd.join(SKILLS_DIR)
+        );
+    }
+}

--- a/crates/redisctl/src/cli/init.rs
+++ b/crates/redisctl/src/cli/init.rs
@@ -37,6 +37,15 @@ pub struct InitArgs {
     #[arg(long = "no-install-cli")]
     pub no_install_cli: bool,
 
+    /// Path to a redis/agent-skills checkout to copy skills from (offline-safe;
+    /// default: install via the standard skills CLI)
+    #[arg(long, value_name = "DIR", env = "REDISCTL_INIT_SKILLS_REPO")]
+    pub skills_repo: Option<std::path::PathBuf>,
+
+    /// Install the official Redis skills for your user instead of into this project
+    #[arg(long)]
+    pub skills_global: bool,
+
     /// Print the plan without changing anything
     #[arg(long)]
     pub dry_run: bool,
@@ -62,6 +71,8 @@ impl std::fmt::Debug for InitArgs {
             .field("name", &self.name)
             .field("agents", &self.agents)
             .field("no_install_cli", &self.no_install_cli)
+            .field("skills_repo", &self.skills_repo)
+            .field("skills_global", &self.skills_global)
             .field("dry_run", &self.dry_run)
             .field("pasted", &(!self.pasted.is_empty()).then_some("<redacted>"))
             .finish()
@@ -79,6 +90,8 @@ mod tests {
             name: Some("db".into()),
             agents: vec![AgentArg::Claude],
             no_install_cli: false,
+            skills_repo: None,
+            skills_global: false,
             dry_run: false,
             pasted: vec![
                 "redis-cli".into(),

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -47,6 +47,8 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         url_input: (!pasted.trim().is_empty()).then_some(pasted),
         agents: requested_agents(&args.agents),
         install_cli: !args.no_install_cli,
+        skills_repo: args.skills_repo.clone(),
+        skills_global: args.skills_global,
     };
     let plan = engine::plan(&options)?;
 
@@ -148,6 +150,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
             }
         }
         engine::Event::Note(text) => println!("{}", dim(&text)),
+        engine::Event::Warning(text) => println!("{}", yellow(&text)),
     })
     .await?;
 

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -11,6 +11,16 @@ fn redisctl() -> Command {
     Command::cargo_bin("redisctl").unwrap()
 }
 
+/// A fake redis/agent-skills checkout, so non-dry runs never reach npx or the
+/// network for the skills step.
+fn skills_fixture() -> tempfile::TempDir {
+    let repo = tempfile::tempdir().unwrap();
+    let skill = repo.path().join("skills/redis-basics");
+    std::fs::create_dir_all(&skill).unwrap();
+    std::fs::write(skill.join("SKILL.md"), "# basics\n").unwrap();
+    repo
+}
+
 #[test]
 fn init_is_hidden_from_top_level_help() {
     redisctl()
@@ -144,11 +154,13 @@ fn rejected_url_input_is_credential_masked_in_the_json_envelope() {
 #[test]
 fn verbatim_unquoted_console_paste_is_accepted() {
     let dir = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
     // The shell-split form of an unquoted paste: -u must not parse as a redisctl
     // flag. The URL points at a refused loopback port, so the run proceeds past
     // parsing, writes the contract, and fails at validation - proving both halves.
     redisctl()
         .current_dir(dir.path())
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
         .args([
             "init",
             "redis-cli",
@@ -167,8 +179,10 @@ fn verbatim_unquoted_console_paste_is_accepted() {
 #[test]
 fn dead_url_writes_env_then_fails_validation_with_the_stale_hint() {
     let dir = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
     redisctl()
         .current_dir(dir.path())
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
         .args(["init", "--url", "redis://127.0.0.1:9"])
         .assert()
         .code(10)
@@ -267,4 +281,69 @@ fn no_install_cli_is_respected() {
         // installer under --no-install-cli.
         .stdout(predicate::str::contains("would install via").not())
         .stdout(predicate::str::contains("redis-cli"));
+}
+
+#[test]
+fn dry_run_plans_the_standard_skills_install() {
+    let dir = tempfile::tempdir().unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args([
+            "init",
+            "--dry-run",
+            "--url",
+            "redis://localhost:6379",
+            "--agent",
+            "claude,codex",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "would run: npx -y skills add redis/agent-skills -s * -a claude-code -a codex -y",
+        ));
+}
+
+#[test]
+fn an_explicit_checkout_installs_skills_offline() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    // Validation fails (refused port) but the apply half has already landed.
+    redisctl()
+        .current_dir(dir.path())
+        .args([
+            "init",
+            "--url",
+            "redis://127.0.0.1:9",
+            "--skills-repo",
+            repo.path().to_str().unwrap(),
+        ])
+        .assert()
+        .code(10)
+        .stdout(predicate::str::contains(".agents/skills/redis-basics/"));
+    assert!(
+        dir.path()
+            .join(".agents/skills/redis-basics/SKILL.md")
+            .exists()
+    );
+}
+
+#[test]
+#[ignore = "requires npx + network (real skills CLI against redis/agent-skills)"]
+fn npx_path_installs_the_official_skills_with_a_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args(["init", "--url", "redis://127.0.0.1:9", "--no-install-cli"])
+        .assert()
+        .code(10)
+        .stdout(predicate::str::contains("npx skills add"))
+        .stdout(predicate::str::contains("skills-lock.json"));
+    assert!(dir.path().join("skills-lock.json").exists());
+    // Re-run: the lock diff reads everything back as unchanged.
+    redisctl()
+        .current_dir(dir.path())
+        .args(["init", "--url", "redis://127.0.0.1:9", "--no-install-cli"])
+        .assert()
+        .code(10)
+        .stdout(predicate::str::contains("unchanged .agents/skills/"));
 }

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -299,8 +299,47 @@ fn dry_run_plans_the_standard_skills_install() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "would run: npx -y skills add redis/agent-skills -s * -a claude-code -a codex -y",
+            "would run: npx -y skills@latest add redis/agent-skills -s * -a claude-code -a codex -y",
         ));
+}
+
+/// The installer's own words must reach the user; a generic "(offline?)" guess sent
+/// a real demo failure down the wrong path.
+#[test]
+#[cfg(unix)]
+fn a_failed_npx_run_surfaces_the_installers_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = tempfile::tempdir().unwrap();
+    let fake_npx = bin.path().join("npx");
+    std::fs::write(
+        &fake_npx,
+        "#!/bin/sh\necho 'Unknown agent: codex' >&2\nexit 1\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(
+        &fake_npx,
+        std::os::unix::fs::PermissionsExt::from_mode(0o755),
+    )
+    .unwrap();
+    // PATH holds only the fake, so the skills step runs it and nothing else on the
+    // machine can answer has_bin probes. Validation still fails on the refused port.
+    redisctl()
+        .current_dir(dir.path())
+        .env("PATH", bin.path())
+        .args([
+            "init",
+            "--url",
+            "redis://127.0.0.1:9",
+            "--no-install-cli",
+            "--agent",
+            "claude,codex",
+        ])
+        .assert()
+        .code(10)
+        .stdout(predicate::str::contains(
+            "npx skills add failed: Unknown agent: codex - re-run it yourself",
+        ))
+        .stdout(predicate::str::contains("(offline?)").not());
 }
 
 #[test]

--- a/crates/redisctl/tests/init_docker_tests.rs
+++ b/crates/redisctl/tests/init_docker_tests.rs
@@ -16,6 +16,16 @@ fn redisctl() -> Command {
     Command::cargo_bin("redisctl").unwrap()
 }
 
+/// A fake redis/agent-skills checkout keeps the skills step offline; this suite
+/// needs Docker only.
+fn skills_fixture() -> tempfile::TempDir {
+    let repo = tempfile::tempdir().unwrap();
+    let skill = repo.path().join("skills/redis-basics");
+    std::fs::create_dir_all(&skill).unwrap();
+    std::fs::write(skill.join("SKILL.md"), "# basics\n").unwrap();
+    repo
+}
+
 /// Remove the test's container even when an assertion panics.
 struct RemoveContainer(String);
 
@@ -56,12 +66,15 @@ fn full_run_provisions_validates_and_rerun_is_unchanged() {
     // real npm install, and this suite needs Docker only.
     let (dir, container, _cleanup) = project_dir(tmp.path(), "full");
 
+    let repo = skills_fixture();
     redisctl()
         .current_dir(&dir)
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
         .args(["init", "--no-install-cli"])
         .assert()
         .success()
         .stdout(predicate::str::contains(&container))
+        .stdout(predicate::str::contains(".agents/skills/redis-basics/"))
         .stdout(predicate::str::contains("✓ PING  ✓ SET/GET"));
     let env = std::fs::read_to_string(dir.join(".env")).unwrap();
     assert!(env.contains("REDIS_URL=\"redis://localhost:"), "{env}");
@@ -72,6 +85,7 @@ fn full_run_provisions_validates_and_rerun_is_unchanged() {
     // Idempotent re-run: nothing changes, validation still green.
     redisctl()
         .current_dir(&dir)
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
         .args(["init", "--no-install-cli"])
         .assert()
         .success()
@@ -88,8 +102,10 @@ fn stopped_container_is_restarted() {
     let tmp = tempfile::tempdir().unwrap();
     let (dir, container, _cleanup) = project_dir(tmp.path(), "stop");
 
+    let repo = skills_fixture();
     redisctl()
         .current_dir(&dir)
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
         .args(["init", "--no-install-cli"])
         .assert()
         .success();
@@ -101,6 +117,7 @@ fn stopped_container_is_restarted() {
 
     redisctl()
         .current_dir(&dir)
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
         .args(["init", "--no-install-cli"])
         .assert()
         .success()
@@ -147,8 +164,10 @@ fn restart_that_never_serves_redis_fails_instead_of_reporting_updated() {
     )
     .unwrap();
 
+    let repo = skills_fixture();
     redisctl()
         .current_dir(&dir)
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
         .args(["init", "--no-install-cli"])
         .assert()
         .failure()


### PR DESCRIPTION
Stacked on #1101. The official redis/agent-skills install with the PoC's lock semantics.

- Primary path: `npx -y skills add redis/agent-skills` in the project directory; statuses are diffed from the CLI's own `skills-lock.json` (created / unchanged / updated). Verified live against all 8 official skills.
- Unmanaged skill dirs are warned about before install and reported from disk truth afterwards (kept / updated). `--skills-global` reads names only from the user lock (its hash schema churns).
- `--skills-repo` / `$REDISCTL_INIT_SKILLS_REPO` copies from a local checkout - offline-safe, and the seam that keeps the test suite hermetic. No npx and no checkout → `skipped` with the remedy.
- Deviation: the PoC's clone-cache fallback is not ported (it needs network anyway, and a stale cache never refreshes). Skills are additive; onboarding still validates.

Tests: hermetic via the fixture checkout; one `#[ignore]` test codifies the real npx path.

Verify: run init twice in a scratch dir with a dead `--url`; first run installs 8 skills + lock, second reads all unchanged.

## Testing

### Init run
<img width="4140" height="2684" alt="1-init-with-skills" src="https://github.com/user-attachments/assets/918d4c33-1d95-42ec-a51d-f4062cbb084c" />


### Re-run
<img width="4140" height="2484" alt="2-rerun-unchanged" src="https://github.com/user-attachments/assets/302f1f7f-1bb4-46eb-bd6e-d097a17eee23" />


**Update:** the skills CLI is now invoked as `skills@latest` (a stale npx cache could run an old CLI), and a failed install reports the installer's own error line instead of a generic "(offline?)" guess.
