### PR TITLE
feat(init): generate the redis-project-setup skill with Claude symlinks

### DIFF
--- a/crates/redisctl-init/src/docker.rs
+++ b/crates/redisctl-init/src/docker.rs
@@ -19,7 +19,8 @@ pub(crate) enum DatabaseAction {
     /// best-effort restart (validation reports the truth either way).
     ExistingEnv {
         url: String,
-        restart: Option<String>,
+        container: Option<String>,
+        restart: bool,
     },
     /// A container from an earlier run exists but is stopped.
     StartExisting { name: String, url: String },
@@ -40,6 +41,16 @@ pub(crate) enum DatabaseAction {
 }
 
 impl DatabaseAction {
+    pub(crate) fn container(&self) -> Option<&str> {
+        match self {
+            DatabaseAction::Provided { .. } => None,
+            DatabaseAction::ExistingEnv { container, .. } => container.as_deref(),
+            DatabaseAction::StartExisting { name, .. }
+            | DatabaseAction::AlreadyRunning { name, .. }
+            | DatabaseAction::RunNew { name, .. } => Some(name),
+        }
+    }
+
     pub(crate) fn url(&self) -> &str {
         match self {
             DatabaseAction::Provided { url }
@@ -94,7 +105,7 @@ impl DatabaseAction {
     }
 }
 
-fn docker_ok() -> bool {
+pub(crate) fn docker_ok() -> bool {
     sh("docker", &["info", "--format", "{{.ServerVersion}}"]).status == 0
 }
 
@@ -164,12 +175,15 @@ pub(crate) fn plan_local_database(cwd: &Path) -> Result<DatabaseAction, InitErro
 
     if let Some(url) = read_env_key(cwd, ".env", "REDIS_URL") {
         // Second run typically lands here: revive our container if it is just stopped.
-        let restart = container_info(&name)
-            .filter(|info| {
-                !info.running && (url.contains("localhost") || url.contains("127.0.0.1"))
-            })
-            .map(|_| name);
-        return Ok(DatabaseAction::ExistingEnv { url, restart });
+        let info = container_info(&name);
+        let restart = info.as_ref().is_some_and(|info| {
+            !info.running && (url.contains("localhost") || url.contains("127.0.0.1"))
+        });
+        return Ok(DatabaseAction::ExistingEnv {
+            url,
+            container: info.map(|_| name),
+            restart,
+        });
     }
 
     if !docker_ok() {
@@ -207,8 +221,12 @@ pub(crate) async fn apply_database(
 ) -> Result<Option<Change>, InitError> {
     match action {
         DatabaseAction::Provided { .. } => Ok(None),
-        DatabaseAction::ExistingEnv { url, restart } => {
-            let Some(name) = restart else {
+        DatabaseAction::ExistingEnv {
+            url,
+            container,
+            restart,
+        } => {
+            let (true, Some(name)) = (*restart, container.as_deref()) else {
                 return Ok(None);
             };
             // A failed start must not read as updated; validation reports the truth.
@@ -466,7 +484,7 @@ mod tests {
         // No local container matches, so nothing restarts.
         assert!(matches!(
             action,
-            DatabaseAction::ExistingEnv { restart: None, .. }
+            DatabaseAction::ExistingEnv { restart: false, .. }
         ));
     }
 }

--- a/crates/redisctl-init/src/docker.rs
+++ b/crates/redisctl-init/src/docker.rs
@@ -76,7 +76,8 @@ impl DatabaseAction {
     pub(crate) fn preview(&self) -> Option<Change> {
         match self {
             DatabaseAction::ExistingEnv {
-                restart: Some(name),
+                restart: true,
+                container: Some(name),
                 ..
             } => Some(Change::new(
                 format!("docker:{name}"),
@@ -175,13 +176,14 @@ pub(crate) fn plan_local_database(cwd: &Path) -> Result<DatabaseAction, InitErro
 
     if let Some(url) = read_env_key(cwd, ".env", "REDIS_URL") {
         // Second run typically lands here: revive our container if it is just stopped.
+        // A leftover container only counts when .env still points at it - after a
+        // move to a remote database it must not poison the skill or get restarted.
+        let local = url.contains("localhost") || url.contains("127.0.0.1");
         let info = container_info(&name);
-        let restart = info.as_ref().is_some_and(|info| {
-            !info.running && (url.contains("localhost") || url.contains("127.0.0.1"))
-        });
+        let restart = info.as_ref().is_some_and(|info| !info.running && local);
         return Ok(DatabaseAction::ExistingEnv {
             url,
-            container: info.map(|_| name),
+            container: info.filter(|_| local).map(|_| name),
             restart,
         });
     }
@@ -425,7 +427,8 @@ mod tests {
     fn existing_env_restart_is_previewed() {
         let action = DatabaseAction::ExistingEnv {
             url: "redis://localhost:6379".into(),
-            restart: Some("redis-init-x".into()),
+            container: Some("redis-init-x".into()),
+            restart: true,
         };
         let change = action.preview().unwrap();
         assert_eq!(change.status, Status::Planned);
@@ -433,9 +436,28 @@ mod tests {
 
         let no_restart = DatabaseAction::ExistingEnv {
             url: "redis://h:1".into(),
-            restart: None,
+            container: Some("redis-init-x".into()),
+            restart: false,
         };
         assert!(no_restart.preview().is_none());
+    }
+
+    #[test]
+    fn leftover_container_is_ignored_when_env_points_elsewhere() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "REDIS_URL=\"rediss://default:x@cloud.example:12000\"\n",
+        )
+        .unwrap();
+        // Whatever containers exist on this machine, a remote URL means none of
+        // them belong to this database.
+        let action = plan_local_database(dir.path()).unwrap();
+        assert_eq!(action.container(), None);
+        assert!(matches!(
+            action,
+            DatabaseAction::ExistingEnv { restart: false, .. }
+        ));
     }
 
     #[test]

--- a/crates/redisctl-init/src/docker.rs
+++ b/crates/redisctl-init/src/docker.rs
@@ -170,22 +170,28 @@ fn free_port(start: u16) -> Option<u16> {
     (start..start + 100).find(|p| port_is_free(*p))
 }
 
+/// Decide the action for a `.env` that already carries a URL. A leftover container
+/// only counts when the URL still points at it - after a move to a remote database
+/// it must not poison the skill or get restarted. Split from the probe so that gate
+/// is testable without Docker.
+fn decide_existing_env(url: String, name: String, info: Option<ContainerInfo>) -> DatabaseAction {
+    let local = url.contains("localhost") || url.contains("127.0.0.1");
+    let restart = info.as_ref().is_some_and(|info| !info.running && local);
+    DatabaseAction::ExistingEnv {
+        url,
+        container: info.filter(|_| local).map(|_| name),
+        restart,
+    }
+}
+
 /// Probe (read-only) how this project gets its local database.
 pub(crate) fn plan_local_database(cwd: &Path) -> Result<DatabaseAction, InitError> {
     let name = container_name(cwd);
 
     if let Some(url) = read_env_key(cwd, ".env", "REDIS_URL") {
         // Second run typically lands here: revive our container if it is just stopped.
-        // A leftover container only counts when .env still points at it - after a
-        // move to a remote database it must not poison the skill or get restarted.
-        let local = url.contains("localhost") || url.contains("127.0.0.1");
         let info = container_info(&name);
-        let restart = info.as_ref().is_some_and(|info| !info.running && local);
-        return Ok(DatabaseAction::ExistingEnv {
-            url,
-            container: info.filter(|_| local).map(|_| name),
-            restart,
-        });
+        return Ok(decide_existing_env(url, name, info));
     }
 
     if !docker_ok() {
@@ -440,6 +446,38 @@ mod tests {
             restart: false,
         };
         assert!(no_restart.preview().is_none());
+    }
+
+    #[test]
+    fn leftover_container_only_counts_for_a_local_url() {
+        let stopped = || {
+            Some(ContainerInfo {
+                running: false,
+                port: 6379,
+            })
+        };
+
+        let remote = decide_existing_env(
+            "rediss://default:s3cret@cloud.example:12000".into(),
+            "redis-init-x".into(),
+            stopped(),
+        );
+        assert_eq!(remote.container(), None);
+        assert!(matches!(
+            remote,
+            DatabaseAction::ExistingEnv { restart: false, .. }
+        ));
+
+        let local = decide_existing_env(
+            "redis://localhost:6379".into(),
+            "redis-init-x".into(),
+            stopped(),
+        );
+        assert_eq!(local.container(), Some("redis-init-x"));
+        assert!(matches!(
+            local,
+            DatabaseAction::ExistingEnv { restart: true, .. }
+        ));
     }
 
     #[test]

--- a/crates/redisctl-init/src/env.rs
+++ b/crates/redisctl-init/src/env.rs
@@ -58,7 +58,7 @@ impl FileAction {
 /// Read the file for mutation planning. A file that exists but cannot be read
 /// (permissions, non-UTF-8) must not be mistaken for a missing one: overwriting it
 /// would destroy user content.
-fn read_for_planning(dir: &Path, rel: &str) -> Result<Option<String>, InitError> {
+pub(crate) fn read_for_planning(dir: &Path, rel: &str) -> Result<Option<String>, InitError> {
     match read_if(dir, rel) {
         Some(content) => Ok(Some(content)),
         None if dir.join(rel).exists() => Err(InitError::UnreadableFile {

--- a/crates/redisctl-init/src/lib.rs
+++ b/crates/redisctl-init/src/lib.rs
@@ -10,10 +10,13 @@ mod docker;
 mod env;
 mod install;
 mod project;
+mod project_skill;
 mod skills;
 mod util;
 
 pub use change::{Change, Status};
+
+pub(crate) const SKILLS_DIR: &str = ".agents/skills";
 pub use docker::validate;
 pub use project::{Agent, KNOWN_AGENTS, Project, Runtime};
 pub use util::mask_url;
@@ -71,6 +74,8 @@ pub enum Event {
 #[derive(Debug)]
 pub struct Options {
     pub cwd: PathBuf,
+    /// Database name, recorded in the generated project skill.
+    pub name: Option<String>,
     /// Raw connection input: a URL, or a pasted `redis-cli -u <url>` command.
     /// `None` means no input was given (not blank input).
     pub url_input: Option<String>,
@@ -90,6 +95,7 @@ pub struct Options {
 pub struct Plan {
     pub project: Project,
     pub agents: Vec<Agent>,
+    name: Option<String>,
     database: docker::DatabaseAction,
     file_actions: Vec<env::FileAction>,
     client: install::InstallAction,
@@ -120,6 +126,7 @@ impl Plan {
                 self.client.preview(),
                 self.cli.preview(),
                 self.skills.preview(),
+                project_skill::preview(&self.cwd),
             ])
             .collect()
     }
@@ -129,6 +136,8 @@ impl Plan {
 #[derive(Debug)]
 pub struct Report {
     pub changes: Vec<Change>,
+    /// Where the skills actually landed, for the caller's next-steps epilogue.
+    pub skills_dir: String,
 }
 
 pub fn plan(options: &Options) -> Result<Plan, InitError> {
@@ -163,6 +172,7 @@ pub fn plan(options: &Options) -> Result<Plan, InitError> {
     Ok(Plan {
         project,
         agents,
+        name: options.name.clone(),
         database,
         file_actions,
         client,
@@ -183,10 +193,45 @@ pub async fn apply(plan: &Plan, on_event: &mut dyn FnMut(Event)) -> Result<Repor
     for action in &plan.file_actions {
         changes.push(action.perform(&plan.cwd)?);
     }
-    changes.push(plan.client.perform(&plan.cwd, on_event)?);
+    let client_change = plan.client.perform(&plan.cwd, on_event)?;
+    let client_installed = matches!(client_change.status, Status::Updated | Status::Unchanged);
+    changes.push(client_change);
     changes.push(plan.cli.perform(&plan.cwd, on_event)?);
-    changes.extend(plan.skills.perform(&plan.cwd, on_event)?);
-    Ok(Report { changes })
+
+    let skills = plan.skills.perform(&plan.cwd, on_event)?;
+    let skills_dir = skills
+        .installed_dir
+        .as_ref()
+        .map(|dir| format!("{}/", dir.strip_prefix(&plan.cwd).unwrap_or(dir).display()))
+        .unwrap_or_else(|| skills::describe_target(plan.skills.global));
+    changes.extend(skills.changes);
+
+    let facts = project_skill::SkillFacts {
+        runtime: plan.project.runtime,
+        name: plan.name.as_deref(),
+        container: plan.database.container(),
+        skills: &skills.installed,
+        client_installed,
+        cli_available: util::has_bin("redis-cli"),
+        docker: docker::docker_ok(),
+    };
+    // Checkout-copied skills need links too; a global install lives under $HOME,
+    // where Claude Code's own discovery already reads it.
+    let also_link: &[String] = if !skills.via_npx && !plan.skills.global {
+        &skills.installed
+    } else {
+        &[]
+    };
+    changes.extend(project_skill::generate(
+        &plan.cwd,
+        &facts,
+        plan.agents.contains(&Agent::Claude),
+        also_link,
+    )?);
+    Ok(Report {
+        changes,
+        skills_dir,
+    })
 }
 
 /// What counts as a connection string, wherever one arrives: a flag, a bare
@@ -257,6 +302,7 @@ mod tests {
         std::fs::write(dir.path().join("go.mod"), "module demo\n").unwrap();
         let plan = plan(&Options {
             cwd: dir.path().to_path_buf(),
+            name: None,
             url_input: Some("redis-cli -u redis://h:1".into()),
             agents: Some(vec![Agent::Claude]),
             install_cli: false,
@@ -275,6 +321,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let plan = plan(&Options {
             cwd: dir.path().to_path_buf(),
+            name: None,
             url_input: Some("redis://h:1".into()),
             agents: Some(vec![Agent::Codex]),
             install_cli: false,
@@ -304,7 +351,8 @@ mod tests {
         std::fs::write(skill.join("SKILL.md"), "# basics\n").unwrap();
         let options = |cwd: &std::path::Path| Options {
             cwd: cwd.to_path_buf(),
-            url_input: Some("redis://h:1".into()),
+            name: None,
+            url_input: Some("redis-cli -u redis://h:1".into()),
             agents: Some(vec![Agent::Codex]),
             install_cli: false,
             skills_repo: Some(repo.path().to_path_buf()),

--- a/crates/redisctl-init/src/project_skill.rs
+++ b/crates/redisctl-init/src/project_skill.rs
@@ -292,6 +292,9 @@ mod tests {
         let skills = vec!["redis-core".to_string(), "redis-search".to_string()];
         let text = content(&facts(Some("redis-init-demo"), &skills));
         assert!(text.contains("docker start redis-init-demo"), "{text}");
+        // The connection string lives in .env only; the committed skill never
+        // carries a URL.
+        assert!(!text.contains("redis://"), "{text}");
         assert!(text.contains("redis-core, redis-search"), "{text}");
         assert!(text.contains("createClient({ url: process.env.REDIS_URL })"));
         assert!(text.contains("redis-cli -u \"$REDIS_URL\" PING"));

--- a/crates/redisctl-init/src/project_skill.rs
+++ b/crates/redisctl-init/src/project_skill.rs
@@ -1,0 +1,373 @@
+//! The generated `redis-project-setup` skill: project-specific facts in a skill so
+//! they load only for Redis-related prompts. The skill's description is the trigger -
+//! no AGENTS.md or CLAUDE.md is ever written or touched.
+
+use std::path::Path;
+
+use crate::change::{Change, Status};
+use crate::env::{FileAction, read_for_planning};
+use crate::project::Runtime;
+use crate::{InitError, SKILLS_DIR};
+
+pub(crate) const NAME: &str = "redis-project-setup";
+const NOTE: &str = "project-specific facts, loaded only for Redis-related prompts";
+
+/// Everything the template adapts to, known only after apply.
+pub(crate) struct SkillFacts<'a> {
+    pub(crate) runtime: Runtime,
+    pub(crate) name: Option<&'a str>,
+    pub(crate) container: Option<&'a str>,
+    pub(crate) skills: &'a [String],
+    pub(crate) client_installed: bool,
+    pub(crate) cli_available: bool,
+    pub(crate) docker: bool,
+}
+
+/// The commands the skill offers depend on what this machine can actually run: a
+/// native redis-cli, else one inside the project's container, else a throwaway
+/// container.
+fn handy_commands(facts: &SkillFacts) -> String {
+    const NATIVE_INSTALL_HINT: &str =
+        "native install: macOS `brew install redis`, Debian/Ubuntu `apt install redis-tools`";
+    let pair = |prefix: &str, target: &str| {
+        format!(
+            "- `{prefix} PING` - connection check\n- `{prefix} MONITOR` - watch live commands while debugging{target}"
+        )
+    };
+    if facts.cli_available {
+        return pair("redis-cli -u \"$REDIS_URL\"", "");
+    }
+    let via_docker = format!(
+        "\n- redis-cli is not installed on this machine; the docker forms above work as-is ({NATIVE_INSTALL_HINT})"
+    );
+    if let Some(container) = facts.container
+        && facts.docker
+    {
+        return pair(
+            &format!("docker exec -it {container} redis-cli"),
+            &via_docker,
+        );
+    }
+    if facts.docker {
+        return pair(
+            "docker run --rm -it redis:8-alpine redis-cli -u \"$REDIS_URL\"",
+            &via_docker,
+        );
+    }
+    format!(
+        "- redis-cli is not installed ({NATIVE_INSTALL_HINT}); once installed: `redis-cli -u \"$REDIS_URL\" PING`\n- Until then, inspect data with the Redis client your code already uses"
+    )
+}
+
+fn client_hint(facts: &SkillFacts) -> &'static str {
+    match (facts.runtime, facts.client_installed) {
+        (Runtime::Node, true) => {
+            "- The `redis` Node client is installed: `createClient({ url: process.env.REDIS_URL })`."
+        }
+        (Runtime::Node, false) => {
+            "- Node client: `npm install redis`, then `createClient({ url: process.env.REDIS_URL })`."
+        }
+        (Runtime::Python, true) => {
+            "- The `redis` (redis-py) client is installed: `redis.Redis.from_url(os.environ[\"REDIS_URL\"])`."
+        }
+        (Runtime::Python, false) => {
+            "- Python client: `pip install redis`, then `redis.Redis.from_url(os.environ[\"REDIS_URL\"])`."
+        }
+        (Runtime::Go, true) => {
+            "- go-redis is installed: `opt, _ := redis.ParseURL(os.Getenv(\"REDIS_URL\")); rdb := redis.NewClient(opt)`."
+        }
+        (Runtime::Go, false) => {
+            "- Go client: `go get github.com/redis/go-redis/v9`, then `redis.ParseURL(os.Getenv(\"REDIS_URL\"))`."
+        }
+        (Runtime::Rust, true) => {
+            "- The `redis` crate is installed: `redis::Client::open(env::var(\"REDIS_URL\")?)`."
+        }
+        (Runtime::Rust, false) => {
+            "- Rust client: `cargo add redis`, then `redis::Client::open(env::var(\"REDIS_URL\")?)`."
+        }
+        (Runtime::Java, true) => {
+            "- A Redis Java client is already a dependency; connect with `new JedisPooled(System.getenv(\"REDIS_URL\"))` (or your existing client)."
+        }
+        (Runtime::Java, false) => {
+            "- Java client: add Jedis to the build file - Maven: `<dependency><groupId>redis.clients</groupId><artifactId>jedis</artifactId><version>[6.0.0,)</version></dependency>`; Gradle: `implementation 'redis.clients:jedis:6.+'` - then `new JedisPooled(System.getenv(\"REDIS_URL\"))`."
+        }
+        (Runtime::Unknown, _) => {
+            "- Use your language's standard Redis client; connect with the `REDIS_URL` env var."
+        }
+    }
+}
+
+fn db_hint(facts: &SkillFacts) -> String {
+    match (facts.container, facts.name) {
+        (Some(container), _) => format!(
+            "- Local database in Docker container `{container}` - `docker start {container}` if it is down; `docker exec -it {container} redis-cli` for a REPL."
+        ),
+        (None, Some(name)) => format!(
+            "- The database is `{name}` (external, e.g. Redis Cloud); credentials live only in `.env`."
+        ),
+        (None, None) => "- The database is external (not managed by this project); credentials live only in `.env`.".to_string(),
+    }
+}
+
+fn skills_hint(facts: &SkillFacts) -> String {
+    if facts.skills.is_empty() {
+        "- The official redis/agent-skills were not available at init time; only this skill is installed.".to_string()
+    } else {
+        format!(
+            "- Deep-dive skills installed alongside this one: {}. Use them when modeling data, writing queries, tuning connections, or securing the deployment.",
+            facts.skills.join(", ")
+        )
+    }
+}
+
+pub(crate) fn content(facts: &SkillFacts) -> String {
+    format!(
+        r#"---
+name: redis-project-setup
+description: >-
+  Use for any Redis-related work in this project - caching, sessions, queues,
+  streams, search, or anything touching a data store or Redis service: where
+  credentials live, which services this project uses (the database), client
+  setup, conventions, and available tooling.
+---
+
+# Redis setup in this project
+
+Set up by `redisctl init`; re-running it is safe and never clobbers existing content.
+Every credential lives in `.env` and nowhere else - not in code, not in a committed
+file.
+
+## Connection
+- The connection string is `REDIS_URL` in `.env` (placeholder in `.env.example`). Read it from the environment; never hardcode it and never commit `.env`.
+{client}
+{db}
+
+## Tooling
+{skills}
+
+## Conventions
+- Key naming: `<app>:<entity>:<id>` (for example `shop:product:42`), with `:` as the namespace separator.
+- Every cache key gets a TTL (`SET key value EX 60`); no unbounded cache writes.
+- Use `SCAN` for key iteration in application code, never `KEYS`.
+
+## Handy commands
+{handy}
+"#,
+        client = client_hint(facts),
+        db = db_hint(facts),
+        skills = skills_hint(facts),
+        handy = handy_commands(facts),
+    )
+}
+
+/// The plan-time line: the content depends on apply outcomes (which skills landed,
+/// whether the client installed), so the preview reports only what happens to the
+/// file.
+pub(crate) fn preview(cwd: &Path) -> Change {
+    let rel = format!("{SKILLS_DIR}/{NAME}/SKILL.md");
+    let status = if cwd.join(&rel).exists() {
+        Status::Updated
+    } else {
+        Status::Created
+    };
+    Change::new(rel, status, NOTE)
+}
+
+/// Write the skill and, for Claude Code, mirror the skills CLI's own layout with a
+/// per-skill `.claude/skills` symlink.
+pub(crate) fn generate(
+    cwd: &Path,
+    facts: &SkillFacts,
+    link_for_claude: bool,
+    also_link: &[String],
+) -> Result<Vec<Change>, InitError> {
+    let rel = format!("{SKILLS_DIR}/{NAME}/SKILL.md");
+    let content = content(facts);
+    let action = match read_for_planning(cwd, &rel)? {
+        Some(existing) if existing == content => FileAction::Unchanged { rel },
+        existing => FileAction::Write {
+            status: if existing.is_none() {
+                Status::Created
+            } else {
+                Status::Updated
+            },
+            rel,
+            content,
+            note: NOTE.to_string(),
+        },
+    };
+    let mut changes = vec![action.perform(cwd)?];
+    if link_for_claude {
+        changes.extend(link_claude_skill(cwd, NAME)?);
+        for name in also_link {
+            changes.extend(link_claude_skill(cwd, name)?);
+        }
+    }
+    Ok(changes)
+}
+
+/// Claude Code reads `.claude/skills`; the skills CLI symlinks its installs there per
+/// skill. Mirror that layout for skills the CLI did not place. No entry is reported
+/// when the whole directory is already a symlink - it exposes everything by itself.
+#[cfg(unix)]
+fn link_claude_skill(cwd: &Path, name: &str) -> Result<Option<Change>, InitError> {
+    let parent = cwd.join(".claude/skills");
+    if parent.is_symlink() {
+        return Ok(None);
+    }
+    let subject = format!(".claude/skills/{name}");
+    let link = parent.join(name);
+    let target = std::path::PathBuf::from("../..")
+        .join(SKILLS_DIR)
+        .join(name);
+    match std::fs::symlink_metadata(&link) {
+        Ok(meta) if meta.is_symlink() => {
+            if std::fs::read_link(&link).ok().as_deref() == Some(&target) {
+                return Ok(Some(Change::new(subject, Status::Unchanged, "")));
+            }
+            std::fs::remove_file(&link).map_err(|e| InitError::WriteFailed {
+                rel: subject.clone(),
+                message: e.to_string(),
+            })?;
+            std::os::unix::fs::symlink(&target, &link).map_err(|e| InitError::WriteFailed {
+                rel: subject.clone(),
+                message: e.to_string(),
+            })?;
+            Ok(Some(Change::new(
+                subject,
+                Status::Updated,
+                format!("symlink to {SKILLS_DIR}/{name}"),
+            )))
+        }
+        Ok(_) => Ok(Some(Change::new(
+            subject,
+            Status::Kept,
+            "existing entry left untouched",
+        ))),
+        Err(_) => {
+            std::fs::create_dir_all(&parent).map_err(|e| InitError::WriteFailed {
+                rel: subject.clone(),
+                message: e.to_string(),
+            })?;
+            std::os::unix::fs::symlink(&target, &link).map_err(|e| InitError::WriteFailed {
+                rel: subject.clone(),
+                message: e.to_string(),
+            })?;
+            Ok(Some(Change::new(
+                subject,
+                Status::Created,
+                format!("symlink to {SKILLS_DIR}/{name}"),
+            )))
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn link_claude_skill(_cwd: &Path, name: &str) -> Result<Option<Change>, InitError> {
+    Ok(Some(Change::new(
+        format!(".claude/skills/{name}"),
+        Status::Skipped,
+        "symlinks are unix-only; Claude Code reads .agents/skills via its own discovery",
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn facts<'a>(container: Option<&'a str>, skills: &'a [String]) -> SkillFacts<'a> {
+        SkillFacts {
+            runtime: Runtime::Node,
+            name: None,
+            container,
+            skills,
+            client_installed: true,
+            cli_available: true,
+            docker: true,
+        }
+    }
+
+    #[test]
+    fn content_adapts_to_the_container_and_skills() {
+        let skills = vec!["redis-core".to_string(), "redis-search".to_string()];
+        let text = content(&facts(Some("redis-init-demo"), &skills));
+        assert!(text.contains("docker start redis-init-demo"), "{text}");
+        assert!(text.contains("redis-core, redis-search"), "{text}");
+        assert!(text.contains("createClient({ url: process.env.REDIS_URL })"));
+        assert!(text.contains("redis-cli -u \"$REDIS_URL\" PING"));
+    }
+
+    #[test]
+    fn content_names_an_external_database_and_missing_skills() {
+        let mut f = facts(None, &[]);
+        f.name = Some("my-cloud-db");
+        f.cli_available = false;
+        f.docker = false;
+        let text = content(&f);
+        assert!(
+            text.contains("`my-cloud-db` (external, e.g. Redis Cloud)"),
+            "{text}"
+        );
+        assert!(text.contains("were not available at init time"), "{text}");
+        assert!(text.contains("redis-cli is not installed ("), "{text}");
+    }
+
+    #[test]
+    fn container_without_native_cli_offers_docker_exec() {
+        let mut f = facts(Some("redis-init-x"), &[]);
+        f.cli_available = false;
+        let text = content(&f);
+        assert!(
+            text.contains("docker exec -it redis-init-x redis-cli PING"),
+            "{text}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generate_writes_the_skill_links_claude_and_reruns_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let changes = generate(dir.path(), &facts(None, &[]), true, &[]).unwrap();
+        let statuses: Vec<_> = changes
+            .iter()
+            .map(|c| (c.subject.as_str(), c.status))
+            .collect();
+        assert_eq!(
+            statuses,
+            vec![
+                (
+                    ".agents/skills/redis-project-setup/SKILL.md",
+                    Status::Created
+                ),
+                (".claude/skills/redis-project-setup", Status::Created),
+            ]
+        );
+        let link = dir.path().join(".claude/skills/redis-project-setup");
+        assert!(link.is_symlink());
+        assert!(link.join("SKILL.md").exists(), "symlink resolves");
+
+        let rerun = generate(dir.path(), &facts(None, &[]), true, &[]).unwrap();
+        assert!(rerun.iter().all(|c| c.status == Status::Unchanged));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_real_directory_in_claude_skills_is_kept() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude/skills/redis-project-setup")).unwrap();
+        let changes = generate(dir.path(), &facts(None, &[]), true, &[]).unwrap();
+        let link_change = &changes[1];
+        assert_eq!(link_change.status, Status::Kept);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_whole_dir_symlink_reports_no_link_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::fs::create_dir_all(dir.path().join(".agents/skills")).unwrap();
+        std::os::unix::fs::symlink("../.agents/skills", dir.path().join(".claude/skills")).unwrap();
+        let changes = generate(dir.path(), &facts(None, &[]), true, &[]).unwrap();
+        assert_eq!(changes.len(), 1, "{changes:?}");
+    }
+}

--- a/crates/redisctl-init/src/skills.rs
+++ b/crates/redisctl-init/src/skills.rs
@@ -624,7 +624,7 @@ mod tests {
             global: false,
             repo: Some(repo.path().to_path_buf()),
         };
-        let changes = solo.perform(project.path(), &mut |_| {}).unwrap();
+        let changes = solo.perform(project.path(), &mut |_| {}).unwrap().changes;
         assert_eq!(changes[0].subject, ".claude/skills/redis-basics/");
         assert!(
             project
@@ -633,7 +633,7 @@ mod tests {
                 .exists()
         );
         let rerun = solo.perform(project.path(), &mut |_| {}).unwrap();
-        assert!(rerun.iter().all(|c| c.status == Status::Unchanged));
+        assert!(rerun.changes.iter().all(|c| c.status == Status::Unchanged));
     }
 
     #[test]

--- a/crates/redisctl-init/src/skills.rs
+++ b/crates/redisctl-init/src/skills.rs
@@ -17,10 +17,9 @@ use crate::project::Agent;
 use crate::util::{has_bin, read_if, sh_in};
 use crate::{Event, InitError};
 
-const SKILLS_DIR: &str = ".agents/skills";
+use crate::SKILLS_DIR;
+
 const LOCK_FILE: &str = "skills-lock.json";
-/// The skill this tool generates itself; never treated as a foreign collision.
-const GENERATED_SKILL: &str = "redis-project-setup";
 
 /// The skills CLI's identifiers for the agents redisctl init supports; passing them
 /// explicitly (instead of `--agent '*'`) keeps the layout to the directories the
@@ -58,7 +57,7 @@ fn installed_skill_path(cwd: &Path, global: bool, name: &str) -> Option<PathBuf>
 
 /// Where an install would land, named only when nothing was actually installed -
 /// which directory the skills CLI uses is its own layout choice.
-fn describe_target(global: bool) -> String {
+pub(crate) fn describe_target(global: bool) -> String {
     if global {
         format!(
             "{}/ or {}/",
@@ -159,7 +158,7 @@ fn unmanaged_collisions(cwd: &Path) -> BTreeMap<String, String> {
     let mut collisions = BTreeMap::new();
     for dir in target_dirs(cwd, false) {
         for name in skill_dirs(&dir) {
-            if name == GENERATED_SKILL || managed.contains_key(&name) {
+            if name == crate::project_skill::NAME || managed.contains_key(&name) {
                 continue;
             }
             if let Ok(content) = std::fs::read_to_string(dir.join(&name).join("SKILL.md")) {
@@ -232,6 +231,27 @@ fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// What the install actually did, read back from disk truth.
+pub(crate) struct SkillsOutcome {
+    pub(crate) changes: Vec<Change>,
+    pub(crate) installed: Vec<String>,
+    pub(crate) installed_dir: Option<PathBuf>,
+    /// The standard CLI managed the layout (and its own symlinks); a checkout copy
+    /// did not.
+    pub(crate) via_npx: bool,
+}
+
+impl SkillsOutcome {
+    fn skipped(change: Change) -> Self {
+        Self {
+            changes: vec![change],
+            installed: Vec::new(),
+            installed_dir: None,
+            via_npx: false,
+        }
+    }
+}
+
 /// The decided skills install, fixed at plan time; outcomes are disk truth read
 /// back at apply time.
 #[derive(Debug)]
@@ -279,15 +299,15 @@ impl SkillsAction {
         &self,
         cwd: &Path,
         on_event: &mut dyn FnMut(Event),
-    ) -> Result<Vec<Change>, InitError> {
+    ) -> Result<SkillsOutcome, InitError> {
         if let Some(repo) = &self.repo {
             let source = repo.join("skills");
             if !source.exists() {
-                return Ok(vec![Change::new(
+                return Ok(SkillsOutcome::skipped(Change::new(
                     describe_target(self.global),
                     Status::Skipped,
                     format!("{} has no skills/ directory", repo.display()),
-                )]);
+                )));
             }
             return self.copy_from(cwd, &source);
         }
@@ -333,18 +353,18 @@ impl SkillsAction {
                     self.report_project(cwd, &before_lock, &collisions)
                 });
             }
-            return Ok(vec![Change::new(
+            return Ok(SkillsOutcome::skipped(Change::new(
                 describe_target(self.global),
                 Status::Skipped,
                 failure_note(&r.stderr, &r.stdout, r.status),
-            )]);
+            )));
         }
 
-        Ok(vec![Change::new(
+        Ok(SkillsOutcome::skipped(Change::new(
             describe_target(self.global),
             Status::Skipped,
             "npx not found - install Node, or pass --skills-repo <a redis/agent-skills checkout>",
-        )])
+        )))
     }
 
     /// The npx project outcome, read from the lock the CLI maintains.
@@ -353,11 +373,19 @@ impl SkillsAction {
         cwd: &Path,
         before: &BTreeMap<String, String>,
         collisions: &BTreeMap<String, String>,
-    ) -> Vec<Change> {
+    ) -> SkillsOutcome {
         let after = read_lock_hashes(cwd);
         let mut changes = Vec::new();
+        let mut installed_dir = None;
         for (name, hash) in &after {
-            let subject = installed_skill_path(cwd, false, name)
+            let path = installed_skill_path(cwd, false, name);
+            if installed_dir.is_none() {
+                installed_dir = path
+                    .as_deref()
+                    .and_then(Path::parent)
+                    .map(Path::to_path_buf);
+            }
+            let subject = path
                 .map(|p| format!("{}/", display_relative(cwd, &p)))
                 .unwrap_or_else(|| name.clone());
             if let Some(previous_md) = collisions.get(name) {
@@ -386,7 +414,12 @@ impl SkillsAction {
             Status::Unchanged,
             "owned by the skills CLI",
         ));
-        changes
+        SkillsOutcome {
+            changes,
+            installed: after.into_keys().collect(),
+            installed_dir,
+            via_npx: true,
+        }
     }
 
     /// The npx global outcome: the global lock names what the CLI manages; a
@@ -398,25 +431,32 @@ impl SkillsAction {
         cwd: &Path,
         before_names: &BTreeSet<String>,
         before_signatures: &BTreeMap<String, Option<u64>>,
-    ) -> Vec<Change> {
+    ) -> SkillsOutcome {
         let after = global_skill_names();
         let managed: Vec<String> = read_global_lock_names()
             .unwrap_or_else(|| after.difference(before_names).cloned().collect())
             .into_iter()
             .filter(|name| after.contains(name))
             .collect();
-        managed
-            .into_iter()
+        let mut installed_dir = None;
+        let changes = managed
+            .iter()
             .map(|name| {
-                let path = installed_skill_path(cwd, true, &name);
+                let path = installed_skill_path(cwd, true, name);
+                if installed_dir.is_none() {
+                    installed_dir = path
+                        .as_deref()
+                        .and_then(Path::parent)
+                        .map(Path::to_path_buf);
+                }
                 let subject = path
                     .as_ref()
                     .map(|p| format!("{}/", p.display()))
                     .unwrap_or_else(|| name.clone());
-                let status = if !before_names.contains(&name) {
+                let status = if !before_names.contains(name) {
                     Status::Created
                 } else if path.as_deref().and_then(dir_signature)
-                    == before_signatures.get(&name).copied().flatten()
+                    == before_signatures.get(name).copied().flatten()
                 {
                     Status::Unchanged
                 } else {
@@ -424,13 +464,20 @@ impl SkillsAction {
                 };
                 Change::new(subject, status, "npx skills add")
             })
-            .collect()
+            .collect();
+        SkillsOutcome {
+            changes,
+            installed: managed,
+            installed_dir,
+            via_npx: true,
+        }
     }
 
     /// Copy every skill from a checkout into the layout the real CLI would use.
-    fn copy_from(&self, cwd: &Path, source: &Path) -> Result<Vec<Change>, InitError> {
+    fn copy_from(&self, cwd: &Path, source: &Path) -> Result<SkillsOutcome, InitError> {
         let destination = fallback_dir(cwd, self.global, &self.agents);
         let mut changes = Vec::new();
+        let mut installed = Vec::new();
         for name in skill_dirs(source) {
             let src = source.join(&name);
             let dst = destination.join(&name);
@@ -441,6 +488,7 @@ impl SkillsAction {
             };
             if dirs_equal(&src, &dst) {
                 changes.push(Change::new(subject, Status::Unchanged, ""));
+                installed.push(name);
                 continue;
             }
             let status = if dst.exists() {
@@ -458,15 +506,21 @@ impl SkillsAction {
                 status,
                 "redis/agent-skills (local checkout; run npx skills add redis/agent-skills to adopt standard management)",
             ));
+            installed.push(name);
         }
         if changes.is_empty() {
-            changes.push(Change::new(
+            return Ok(SkillsOutcome::skipped(Change::new(
                 describe_target(self.global),
                 Status::Skipped,
                 "no skills found in the checkout",
-            ));
+            )));
         }
-        Ok(changes)
+        Ok(SkillsOutcome {
+            changes,
+            installed_dir: Some(destination),
+            installed,
+            via_npx: false,
+        })
     }
 }
 
@@ -596,10 +650,13 @@ mod tests {
     fn explicit_checkout_copies_and_reruns_unchanged() {
         let repo = fake_checkout(&["redis-basics", "redis-search"]);
         let project = tempfile::tempdir().unwrap();
-        let changes = action(repo.path())
+        let outcome = action(repo.path())
             .perform(project.path(), &mut |_| {})
             .unwrap();
-        let summary: Vec<_> = changes
+        assert_eq!(outcome.installed, vec!["redis-basics", "redis-search"]);
+        assert!(!outcome.via_npx);
+        let summary: Vec<_> = outcome
+            .changes
             .iter()
             .map(|c| (c.subject.as_str(), c.status))
             .collect();
@@ -620,7 +677,8 @@ mod tests {
         let rerun = action(repo.path())
             .perform(project.path(), &mut |_| {})
             .unwrap();
-        assert!(rerun.iter().all(|c| c.status == Status::Unchanged));
+        assert!(rerun.changes.iter().all(|c| c.status == Status::Unchanged));
+        assert_eq!(rerun.installed.len(), 2);
     }
 
     #[test]
@@ -637,7 +695,8 @@ mod tests {
         .unwrap();
         let changes = action(repo.path())
             .perform(project.path(), &mut |_| {})
-            .unwrap();
+            .unwrap()
+            .changes;
         assert_eq!(changes[0].status, Status::Updated);
         assert_eq!(
             std::fs::read_to_string(project.path().join(".agents/skills/redis-basics/SKILL.md"))
@@ -652,7 +711,8 @@ mod tests {
         let project = tempfile::tempdir().unwrap();
         let changes = action(repo.path())
             .perform(project.path(), &mut |_| {})
-            .unwrap();
+            .unwrap()
+            .changes;
         assert_eq!(changes[0].status, Status::Skipped);
         assert!(changes[0].note.contains("no skills/ directory"));
     }
@@ -660,7 +720,7 @@ mod tests {
     #[test]
     fn unmanaged_collisions_ignore_the_lock_and_the_generated_skill() {
         let project = tempfile::tempdir().unwrap();
-        for name in ["mine", "managed", GENERATED_SKILL] {
+        for name in ["mine", "managed", crate::project_skill::NAME] {
             let dir = project.path().join(SKILLS_DIR).join(name);
             std::fs::create_dir_all(&dir).unwrap();
             std::fs::write(dir.join("SKILL.md"), "x").unwrap();
@@ -711,8 +771,10 @@ mod tests {
             global: false,
             repo: None,
         };
-        let changes = a.report_project(project.path(), &before, &collisions);
-        let by_subject: BTreeMap<_, _> = changes
+        let outcome = a.report_project(project.path(), &before, &collisions);
+        assert_eq!(outcome.installed.len(), 3);
+        let by_subject: BTreeMap<_, _> = outcome
+            .changes
             .iter()
             .map(|c| (c.subject.clone(), c.status))
             .collect();

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -44,6 +44,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
             path: ".".into(),
             message: e.to_string(),
         })?,
+        name: args.name.clone(),
         url_input: (!pasted.trim().is_empty()).then_some(pasted),
         agents: requested_agents(&args.agents),
         install_cli: !args.no_install_cli,
@@ -182,6 +183,21 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
             });
         }
     }
-    println!();
+
+    let suggestion = match (&plan.project.framework, plan.project.runtime) {
+        (Some(framework), _) => format!(
+            "Cache the slowest GET endpoint of this {framework} app in Redis with a 60-second TTL."
+        ),
+        (None, engine::Runtime::Unknown) => {
+            "Add a Redis-backed cache for the most expensive operation in this project.".to_string()
+        }
+        _ => "Cache the most expensive read path in Redis with a 60-second TTL.".to_string(),
+    };
+    println!(
+        "\n{}\n  1. Start your coding agent here ({names}) - it picks up the skills in {}.\n  2. Try asking it: {}\n",
+        bold("Next steps"),
+        report.skills_dir,
+        bold(&format!("\"{suggestion}\""))
+    );
     Ok(())
 }

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -387,6 +387,10 @@ fn an_explicit_checkout_installs_skills_offline() {
         skill.contains("(external, e.g. Redis Cloud)") || skill.contains("external (not managed"),
         "{skill}"
     );
+    assert!(!skill.contains("redis://"), "no URL in the skill: {skill}");
+    // Absent agent docs stay absent - the skill is the only artifact.
+    assert!(!dir.path().join("AGENTS.md").exists());
+    assert!(!dir.path().join("CLAUDE.md").exists());
 }
 
 #[test]

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -68,6 +68,9 @@ fn dry_run_detects_a_node_project_and_plans_the_env_wiring() {
         .stdout(predicate::str::contains("Plan"))
         .stdout(predicate::str::contains("created   .env"))
         .stdout(predicate::str::contains(".gitignore"))
+        .stdout(predicate::str::contains(
+            ".agents/skills/redis-project-setup/SKILL.md",
+        ))
         .stdout(predicate::str::contains("Dry run complete"));
     // Nothing written: the manifest is still the only file.
     assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
@@ -353,16 +356,70 @@ fn an_explicit_checkout_installs_skills_offline() {
             "init",
             "--url",
             "redis://127.0.0.1:9",
+            "--agent",
+            "claude,codex",
             "--skills-repo",
             repo.path().to_str().unwrap(),
         ])
         .assert()
         .code(10)
-        .stdout(predicate::str::contains(".agents/skills/redis-basics/"));
+        .stdout(predicate::str::contains(".agents/skills/redis-basics/"))
+        .stdout(predicate::str::contains(
+            ".agents/skills/redis-project-setup/SKILL.md",
+        ))
+        .stdout(predicate::str::contains(
+            ".claude/skills/redis-project-setup",
+        ))
+        // Checkout copies place no symlinks themselves, so the copied skill gets one.
+        .stdout(predicate::str::contains(".claude/skills/redis-basics"));
     assert!(
         dir.path()
             .join(".agents/skills/redis-basics/SKILL.md")
             .exists()
+    );
+    let skill = std::fs::read_to_string(
+        dir.path()
+            .join(".agents/skills/redis-project-setup/SKILL.md"),
+    )
+    .unwrap();
+    assert!(skill.contains("redis-basics"), "{skill}");
+    assert!(
+        skill.contains("(external, e.g. Redis Cloud)") || skill.contains("external (not managed"),
+        "{skill}"
+    );
+}
+
+#[test]
+fn preexisting_agents_and_claude_md_stay_byte_identical() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    std::fs::write(
+        dir.path().join("CLAUDE.md"),
+        "mine
+",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("AGENTS.md"),
+        "also mine
+",
+    )
+    .unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
+        .args(["init", "--url", "redis://127.0.0.1:9", "--no-install-cli"])
+        .assert()
+        .code(10);
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap(),
+        "mine
+"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("AGENTS.md")).unwrap(),
+        "also mine
+"
     );
 }
 

--- a/crates/redisctl/tests/init_docker_tests.rs
+++ b/crates/redisctl/tests/init_docker_tests.rs
@@ -75,7 +75,11 @@ fn full_run_provisions_validates_and_rerun_is_unchanged() {
         .success()
         .stdout(predicate::str::contains(&container))
         .stdout(predicate::str::contains(".agents/skills/redis-basics/"))
-        .stdout(predicate::str::contains("✓ PING  ✓ SET/GET"));
+        .stdout(predicate::str::contains(
+            ".agents/skills/redis-project-setup/SKILL.md",
+        ))
+        .stdout(predicate::str::contains("✓ PING  ✓ SET/GET"))
+        .stdout(predicate::str::contains("Next steps"));
     let env = std::fs::read_to_string(dir.join(".env")).unwrap();
     assert!(env.contains("REDIS_URL=\"redis://localhost:"), "{env}");
     let gitignore = std::fs::read_to_string(dir.join(".gitignore")).unwrap();


### PR DESCRIPTION
Stacked on #1102. The generated `redis-project-setup` skill - progressive disclosure: the skill's description is the trigger, and no AGENTS.md/CLAUDE.md is ever created or touched (regression-tested byte-identical).

- Generated at apply time from the run's real outcomes: per-runtime client hints, the database hint, the skills that actually landed, key-naming/TTL/SCAN conventions, and handy commands that degrade gracefully (native redis-cli → `docker exec` → throwaway container).
- `.claude/skills` per-skill symlinks mirror the skills CLI's own layout (unix-gated, honest skip elsewhere).
- Next-steps epilogue with the PoC's per-framework suggestions.
- A container only counts as this project's database while `.env` still points at it - a leftover from before a move to a remote URL can no longer poison the skill.

Interim wording for the MCP line and the Iris section is replaced by their owning slices.

Verify: run init in a node project, read `.agents/skills/redis-project-setup/SKILL.md`, re-run reads unchanged.