### PR TITLE
feat(init): register the redis MCP server per agent and unhide the command

### DIFF
--- a/crates/redisctl-init/src/lib.rs
+++ b/crates/redisctl-init/src/lib.rs
@@ -9,6 +9,7 @@ mod change;
 mod docker;
 mod env;
 mod install;
+mod mcp;
 mod project;
 mod project_skill;
 mod skills;
@@ -101,6 +102,7 @@ pub struct Plan {
     client: install::InstallAction,
     cli: install::InstallAction,
     skills: skills::SkillsAction,
+    mcp: mcp::McpPlan,
     cwd: PathBuf,
 }
 
@@ -116,6 +118,12 @@ impl Plan {
         self.database.source(applied)
     }
 
+    /// Neither uvx nor Docker can run the MCP server; the configs are still written
+    /// for uvx and the caller should say so.
+    pub fn mcp_runner_missing(&self) -> bool {
+        self.mcp.uvx_missing
+    }
+
     /// The change report this plan predicts, in the order a run reports it.
     pub fn changes(&self) -> Vec<Change> {
         self.database
@@ -128,6 +136,7 @@ impl Plan {
                 self.skills.preview(),
                 project_skill::preview(&self.cwd),
             ])
+            .chain(self.mcp.actions.iter().map(|action| action.preview()))
             .collect()
     }
 }
@@ -169,6 +178,7 @@ pub fn plan(options: &Options) -> Result<Plan, InitError> {
         global: options.skills_global,
         repo: options.skills_repo.clone(),
     };
+    let mcp = mcp::plan_mcp(&options.cwd, &agents)?;
     Ok(Plan {
         project,
         agents,
@@ -178,6 +188,7 @@ pub fn plan(options: &Options) -> Result<Plan, InitError> {
         client,
         cli,
         skills,
+        mcp,
         cwd: options.cwd.clone(),
     })
 }
@@ -228,6 +239,9 @@ pub async fn apply(plan: &Plan, on_event: &mut dyn FnMut(Event)) -> Result<Repor
         plan.agents.contains(&Agent::Claude),
         also_link,
     )?);
+    for action in &plan.mcp.actions {
+        changes.push(action.perform(&plan.cwd)?);
+    }
     Ok(Report {
         changes,
         skills_dir,

--- a/crates/redisctl-init/src/mcp.rs
+++ b/crates/redisctl-init/src/mcp.rs
@@ -22,9 +22,12 @@ enum Runner {
 
 fn server_entry(runner: &Runner) -> serde_json::Value {
     let inner = match runner {
-        // Inside the container, localhost is the container itself.
+        // Inside the container, localhost is the container itself. The add-host
+        // mapping defines host.docker.internal on Linux Engine (Docker Desktop has
+        // it built in), and the rewrites anchor on :// so a password or a
+        // foo.localhost host can never be rewritten.
         Runner::Docker => {
-            r#"exec docker run --rm -i mcp/redis --url "$(printf %s "$REDIS_URL" | sed -e 's/localhost/host.docker.internal/' -e 's/127\.0\.0\.1/host.docker.internal/')""#
+            r#"exec docker run --rm -i --add-host=host.docker.internal:host-gateway mcp/redis --url "$(printf %s "$REDIS_URL" | sed -e 's|://localhost|://host.docker.internal|' -e 's|://127\.0\.0\.1|://host.docker.internal|')""#
         }
         _ => r#"exec uvx --from redis-mcp-server@latest redis-mcp-server --url "$REDIS_URL""#,
     };
@@ -210,6 +213,18 @@ mod tests {
         )
         .unwrap();
         assert_eq!(vscode["servers"]["redis"]["type"], "stdio");
+    }
+
+    #[test]
+    fn docker_launcher_defines_the_host_alias_and_anchors_rewrites() {
+        let entry = server_entry(&Runner::Docker);
+        let launcher = entry["args"][1].as_str().unwrap();
+        assert!(
+            launcher.contains("--add-host=host.docker.internal:host-gateway"),
+            "{launcher}"
+        );
+        assert!(launcher.contains("://localhost"), "{launcher}");
+        assert!(!launcher.contains("s/localhost/"), "{launcher}");
     }
 
     #[test]

--- a/crates/redisctl-init/src/mcp.rs
+++ b/crates/redisctl-init/src/mcp.rs
@@ -1,0 +1,267 @@
+//! MCP registration per agent: the official Redis data-plane server in each agent's
+//! project config. Every config stays credential-free and safe to commit: a shell
+//! launcher sources `.env` when the MCP client starts the server, so the URL (and
+//! its password) never lands in a committed file.
+
+use std::path::Path;
+
+use crate::InitError;
+use crate::change::{Change, Status};
+use crate::docker::docker_ok;
+use crate::env::{FileAction, read_for_planning};
+use crate::project::Agent;
+use crate::util::{has_bin, mask_url};
+
+/// How the launcher runs the server: uvx when available, a Docker bridge otherwise.
+/// With neither, the config is still written for uvx and the caller shows a note.
+enum Runner {
+    Uvx,
+    Docker,
+    UvxMissing,
+}
+
+fn server_entry(runner: &Runner) -> serde_json::Value {
+    let inner = match runner {
+        // Inside the container, localhost is the container itself.
+        Runner::Docker => {
+            r#"exec docker run --rm -i mcp/redis --url "$(printf %s "$REDIS_URL" | sed -e 's/localhost/host.docker.internal/' -e 's/127\.0\.0\.1/host.docker.internal/')""#
+        }
+        _ => r#"exec uvx --from redis-mcp-server@latest redis-mcp-server --url "$REDIS_URL""#,
+    };
+    serde_json::json!({
+        "command": "sh",
+        "args": ["-c", format!("set -a; . ./.env 2>/dev/null; set +a; {inner}")]
+    })
+}
+
+/// One agent's registration, decided at plan time.
+#[derive(Debug)]
+pub(crate) enum McpAction {
+    File(FileAction),
+    Report(Change),
+}
+
+impl McpAction {
+    pub(crate) fn preview(&self) -> Change {
+        match self {
+            McpAction::File(action) => action.preview(),
+            McpAction::Report(change) => change.clone(),
+        }
+    }
+
+    pub(crate) fn perform(&self, cwd: &Path) -> Result<Change, InitError> {
+        match self {
+            McpAction::File(action) => action.perform(cwd),
+            McpAction::Report(change) => Ok(change.clone()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct McpPlan {
+    pub(crate) actions: Vec<McpAction>,
+    pub(crate) uvx_missing: bool,
+}
+
+pub(crate) fn plan_mcp(cwd: &Path, agents: &[Agent]) -> Result<McpPlan, InitError> {
+    let runner = if has_bin("uvx") {
+        Runner::Uvx
+    } else if docker_ok() {
+        Runner::Docker
+    } else {
+        Runner::UvxMissing
+    };
+    let entry = server_entry(&runner);
+    let mut actions = Vec::new();
+    for agent in agents {
+        actions.push(match agent {
+            Agent::Claude => upsert(cwd, ".mcp.json", "mcpServers", &entry, false)?,
+            Agent::Cursor => upsert(cwd, ".cursor/mcp.json", "mcpServers", &entry, false)?,
+            Agent::Vscode => upsert(cwd, ".vscode/mcp.json", "servers", &entry, true)?,
+            Agent::Codex => McpAction::Report(Change::new(
+                "mcp (codex)",
+                Status::Skipped,
+                "codex MCP config is user-scoped (~/.codex/config.toml); the skills cover it",
+            )),
+        });
+    }
+    Ok(McpPlan {
+        actions,
+        uvx_missing: matches!(runner, Runner::UvxMissing),
+    })
+}
+
+fn kept_invalid(rel: &str) -> McpAction {
+    McpAction::Report(Change::new(
+        rel,
+        Status::Kept,
+        "existing file is not valid JSON; left untouched",
+    ))
+}
+
+fn upsert(
+    cwd: &Path,
+    rel: &str,
+    top_key: &str,
+    entry: &serde_json::Value,
+    stdio: bool,
+) -> Result<McpAction, InitError> {
+    let mut server = entry.clone();
+    if stdio {
+        server["type"] = "stdio".into();
+    }
+    let existing = read_for_planning(cwd, rel)?;
+    let mut cfg = match &existing {
+        None => serde_json::json!({}),
+        Some(text) => match serde_json::from_str::<serde_json::Value>(text) {
+            Ok(value) => value,
+            Err(_) => return Ok(kept_invalid(rel)),
+        },
+    };
+    let Some(root) = cfg.as_object_mut() else {
+        return Ok(kept_invalid(rel));
+    };
+    let servers = root.entry(top_key).or_insert_with(|| serde_json::json!({}));
+    let Some(map) = servers.as_object_mut() else {
+        return Ok(kept_invalid(rel));
+    };
+    let note = match map.get("redis") {
+        Some(previous) if *previous == server => {
+            return Ok(McpAction::Report(Change::new(rel, Status::Unchanged, "")));
+        }
+        Some(previous) => {
+            let command = previous["command"].as_str().unwrap_or_default();
+            let args = previous["args"]
+                .as_array()
+                .map(|args| {
+                    args.iter()
+                        .filter_map(|a| a.as_str())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                })
+                .unwrap_or_default();
+            format!(
+                "replaced existing redis server (was: {})",
+                mask_url(format!("{command} {args}").trim())
+            )
+        }
+        None => "redis: reads REDIS_URL from .env at launch".to_string(),
+    };
+    map.insert("redis".to_string(), server);
+    let status = if existing.is_some() {
+        Status::Updated
+    } else {
+        Status::Created
+    };
+    let content = format!(
+        "{}\n",
+        serde_json::to_string_pretty(&cfg).map_err(|e| InitError::WriteFailed {
+            rel: rel.to_string(),
+            message: e.to_string(),
+        })?
+    );
+    Ok(McpAction::File(FileAction::Write {
+        rel: rel.to_string(),
+        content,
+        status,
+        note,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan_for(dir: &Path, agents: &[Agent]) -> McpPlan {
+        plan_mcp(dir, agents).unwrap()
+    }
+
+    fn apply_all(dir: &Path, plan: &McpPlan) -> Vec<Change> {
+        plan.actions
+            .iter()
+            .map(|a| a.perform(dir).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn registers_per_agent_with_the_right_shapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan = plan_for(
+            dir.path(),
+            &[Agent::Claude, Agent::Cursor, Agent::Vscode, Agent::Codex],
+        );
+        let changes = apply_all(dir.path(), &plan);
+        assert_eq!(changes[0].subject, ".mcp.json");
+        assert_eq!(changes[1].subject, ".cursor/mcp.json");
+        assert_eq!(changes[2].subject, ".vscode/mcp.json");
+        assert_eq!(changes[3].status, Status::Skipped);
+
+        let claude: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap())
+                .unwrap();
+        let launcher = claude["mcpServers"]["redis"]["args"][1].as_str().unwrap();
+        assert!(launcher.starts_with("set -a; . ./.env 2>/dev/null; set +a; exec "));
+        assert!(launcher.contains("$REDIS_URL"));
+        // Credential-free: the config carries the env reference, never a URL value.
+        assert!(!launcher.contains("redis://"));
+
+        let vscode: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join(".vscode/mcp.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(vscode["servers"]["redis"]["type"], "stdio");
+    }
+
+    #[test]
+    fn rerun_is_unchanged_and_foreign_servers_survive() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".mcp.json"),
+            r#"{"mcpServers":{"mine":{"command":"custom"}}}"#,
+        )
+        .unwrap();
+        let plan = plan_for(dir.path(), &[Agent::Claude]);
+        apply_all(dir.path(), &plan);
+        let cfg: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap())
+                .unwrap();
+        assert_eq!(cfg["mcpServers"]["mine"]["command"], "custom");
+        assert!(cfg["mcpServers"]["redis"].is_object());
+
+        let rerun = plan_for(dir.path(), &[Agent::Claude]);
+        assert_eq!(rerun.actions[0].preview().status, Status::Unchanged);
+    }
+
+    #[test]
+    fn a_different_existing_redis_server_is_replaced_with_a_masked_note() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".mcp.json"),
+            r#"{"mcpServers":{"redis":{"command":"redis-mcp","args":["--url","redis://default:s3cret@h:1"]}}}"#,
+        )
+        .unwrap();
+        let plan = plan_for(dir.path(), &[Agent::Claude]);
+        let change = plan.actions[0].preview();
+        assert_eq!(change.status, Status::Updated);
+        assert!(change.note.contains("replaced existing redis server"));
+        assert!(
+            change.note.contains("redis://default:****@h:1"),
+            "{}",
+            change.note
+        );
+        assert!(!change.note.contains("s3cret"));
+    }
+
+    #[test]
+    fn invalid_json_is_kept_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".mcp.json"), "{not json").unwrap();
+        let plan = plan_for(dir.path(), &[Agent::Claude]);
+        let change = plan.actions[0].preview();
+        assert_eq!(change.status, Status::Kept);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap(),
+            "{not json"
+        );
+    }
+}

--- a/crates/redisctl-init/src/mcp.rs
+++ b/crates/redisctl-init/src/mcp.rs
@@ -10,7 +10,7 @@ use crate::change::{Change, Status};
 use crate::docker::docker_ok;
 use crate::env::{FileAction, read_for_planning};
 use crate::project::Agent;
-use crate::util::{has_bin, mask_url};
+use crate::util::has_bin;
 
 /// How the launcher runs the server: uvx when available, a Docker bridge otherwise.
 /// With neither, the config is still written for uvx and the caller shows a note.
@@ -22,12 +22,9 @@ enum Runner {
 
 fn server_entry(runner: &Runner) -> serde_json::Value {
     let inner = match runner {
-        // Inside the container, localhost is the container itself. The add-host
-        // mapping defines host.docker.internal on Linux Engine (Docker Desktop has
-        // it built in), and the rewrites anchor on :// so a password or a
-        // foo.localhost host can never be rewritten.
+        // Rewrite only the hostname; userinfo and remote hosts stay intact.
         Runner::Docker => {
-            r#"exec docker run --rm -i --add-host=host.docker.internal:host-gateway mcp/redis --url "$(printf %s "$REDIS_URL" | sed -e 's|://localhost|://host.docker.internal|' -e 's|://127\.0\.0\.1|://host.docker.internal|')""#
+            r#"exec docker run --rm -i --add-host=host.docker.internal:host-gateway mcp/redis --url "$(printf %s "$REDIS_URL" | sed -E 's~^(rediss?://([^/]*@)?)(localhost|127\.0\.0\.1)([:/?#]|$)~\1host.docker.internal\4~')""#
         }
         _ => r#"exec uvx --from redis-mcp-server@latest redis-mcp-server --url "$REDIS_URL""#,
     };
@@ -132,22 +129,7 @@ fn upsert(
         Some(previous) if *previous == server => {
             return Ok(McpAction::Report(Change::new(rel, Status::Unchanged, "")));
         }
-        Some(previous) => {
-            let command = previous["command"].as_str().unwrap_or_default();
-            let args = previous["args"]
-                .as_array()
-                .map(|args| {
-                    args.iter()
-                        .filter_map(|a| a.as_str())
-                        .collect::<Vec<_>>()
-                        .join(" ")
-                })
-                .unwrap_or_default();
-            format!(
-                "replaced existing redis server (was: {})",
-                mask_url(format!("{command} {args}").trim())
-            )
-        }
+        Some(_) => "replaced existing redis server".to_string(),
         None => "redis: reads REDIS_URL from .env at launch".to_string(),
     };
     map.insert("redis".to_string(), server);
@@ -223,8 +205,6 @@ mod tests {
             launcher.contains("--add-host=host.docker.internal:host-gateway"),
             "{launcher}"
         );
-        assert!(launcher.contains("://localhost"), "{launcher}");
-        assert!(!launcher.contains("s/localhost/"), "{launcher}");
     }
 
     #[test]
@@ -248,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn a_different_existing_redis_server_is_replaced_with_a_masked_note() {
+    fn a_different_existing_redis_server_is_replaced_without_its_arguments() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join(".mcp.json"),
@@ -259,11 +239,7 @@ mod tests {
         let change = plan.actions[0].preview();
         assert_eq!(change.status, Status::Updated);
         assert!(change.note.contains("replaced existing redis server"));
-        assert!(
-            change.note.contains("redis://default:****@h:1"),
-            "{}",
-            change.note
-        );
+        assert_eq!(change.note, "replaced existing redis server");
         assert!(!change.note.contains("s3cret"));
     }
 

--- a/crates/redisctl-init/src/project_skill.rs
+++ b/crates/redisctl-init/src/project_skill.rs
@@ -55,7 +55,7 @@ fn handy_commands(facts: &SkillFacts) -> String {
         );
     }
     format!(
-        "- redis-cli is not installed ({NATIVE_INSTALL_HINT}); once installed: `redis-cli -u \"$REDIS_URL\" PING`\n- Until then, inspect data with the Redis client your code already uses"
+        "- redis-cli is not installed ({NATIVE_INSTALL_HINT}); once installed: `redis-cli -u \"$REDIS_URL\" PING`\n- Until then, prefer the `redis` MCP server tools for inspection"
     )
 }
 
@@ -143,6 +143,7 @@ file.
 {db}
 
 ## Tooling
+- An MCP server named `redis` is registered in the project's agent configs (it reads `REDIS_URL` from `.env` at launch). Prefer its tools to inspect keys, search, and manipulate data instead of shelling out.
 {skills}
 
 ## Conventions

--- a/crates/redisctl/src/cli/mod.rs
+++ b/crates/redisctl/src/cli/mod.rs
@@ -247,9 +247,6 @@ PROFILE REQUIREMENT:
     Db(DbCommands),
 
     /// Onboard this project to Redis + set up your AI coding agent
-    // Hidden while the command is incomplete: merges to main can auto-release, and a
-    // half-wired command must not surface in --help.
-    #[command(hide = true)]
     Init(InitArgs),
 
     /// Version information

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -135,6 +135,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         for change in plan.changes() {
             println!("{}", output::change_line(&change));
         }
+        uvx_note(&plan);
         println!(
             "{}",
             dim("\nDry run complete. Run again without --dry-run to apply.\n")
@@ -163,6 +164,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
     for change in &report.changes {
         println!("{}", output::change_line(change));
     }
+    uvx_note(&plan);
 
     print!("\n{}  ", bold("Validate"));
     let _ = std::io::Write::flush(&mut std::io::stdout());
@@ -194,10 +196,21 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         _ => "Cache the most expensive read path in Redis with a 60-second TTL.".to_string(),
     };
     println!(
-        "\n{}\n  1. Start your coding agent here ({names}) - it picks up the skills in {}.\n  2. Try asking it: {}\n",
+        "\n{}\n  1. Start your coding agent here ({names}) - it picks up the redis MCP server and the skills in {}.\n  2. Try asking it: {}\n",
         bold("Next steps"),
         report.skills_dir,
         bold(&format!("\"{suggestion}\""))
     );
     Ok(())
+}
+
+fn uvx_note(plan: &engine::Plan) {
+    if plan.mcp_runner_missing() {
+        println!(
+            "{}",
+            yellow(
+                "\n  note: neither uvx nor Docker found - .mcp.json is written for uvx; install uv (https://docs.astral.sh/uv/) to use it."
+            )
+        );
+    }
 }

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -60,7 +60,14 @@ fn dry_run_detects_a_node_project_and_plans_the_env_wiring() {
     .unwrap();
     redisctl()
         .current_dir(dir.path())
-        .args(["init", "--dry-run", "--url", "redis://localhost:6379"])
+        .args([
+            "init",
+            "--dry-run",
+            "--url",
+            "redis://localhost:6379",
+            "--agent",
+            "claude",
+        ])
         .assert()
         .success()
         .stdout(predicate::str::contains("demo-shop"))

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -22,12 +22,12 @@ fn skills_fixture() -> tempfile::TempDir {
 }
 
 #[test]
-fn init_is_hidden_from_top_level_help() {
+fn init_is_listed_in_top_level_help() {
     redisctl()
         .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("init").not());
+        .stdout(predicate::str::contains("init"));
 }
 
 #[test]
@@ -71,6 +71,7 @@ fn dry_run_detects_a_node_project_and_plans_the_env_wiring() {
         .stdout(predicate::str::contains(
             ".agents/skills/redis-project-setup/SKILL.md",
         ))
+        .stdout(predicate::str::contains(".mcp.json"))
         .stdout(predicate::str::contains("Dry run complete"));
     // Nothing written: the manifest is still the only file.
     assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
@@ -391,6 +392,9 @@ fn an_explicit_checkout_installs_skills_offline() {
     // Absent agent docs stay absent - the skill is the only artifact.
     assert!(!dir.path().join("AGENTS.md").exists());
     assert!(!dir.path().join("CLAUDE.md").exists());
+    let mcp = std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap();
+    assert!(mcp.contains("$REDIS_URL"), "{mcp}");
+    assert!(!mcp.contains("redis://"), "credential-free: {mcp}");
 }
 
 #[test]

--- a/crates/redisctl/tests/init_docker_tests.rs
+++ b/crates/redisctl/tests/init_docker_tests.rs
@@ -80,6 +80,8 @@ fn full_run_provisions_validates_and_rerun_is_unchanged() {
         ))
         .stdout(predicate::str::contains("✓ PING  ✓ SET/GET"))
         .stdout(predicate::str::contains("Next steps"));
+    let mcp = std::fs::read_to_string(dir.join(".mcp.json")).unwrap();
+    assert!(!mcp.contains("redis://"), "credential-free: {mcp}");
     let env = std::fs::read_to_string(dir.join(".env")).unwrap();
     assert!(env.contains("REDIS_URL=\"redis://localhost:"), "{env}");
     let gitignore = std::fs::read_to_string(dir.join(".gitignore")).unwrap();

--- a/crates/redisctl/tests/init_docker_tests.rs
+++ b/crates/redisctl/tests/init_docker_tests.rs
@@ -70,11 +70,12 @@ fn full_run_provisions_validates_and_rerun_is_unchanged() {
     redisctl()
         .current_dir(&dir)
         .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
-        .args(["init", "--no-install-cli"])
+        .args(["init", "--no-install-cli", "--agent", "claude"])
         .assert()
         .success()
         .stdout(predicate::str::contains(&container))
-        .stdout(predicate::str::contains(".agents/skills/redis-basics/"))
+        // Solo-Claude checkout copies land in Claude's own skills dir.
+        .stdout(predicate::str::contains(".claude/skills/redis-basics/"))
         .stdout(predicate::str::contains(
             ".agents/skills/redis-project-setup/SKILL.md",
         ))
@@ -92,7 +93,7 @@ fn full_run_provisions_validates_and_rerun_is_unchanged() {
     redisctl()
         .current_dir(&dir)
         .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
-        .args(["init", "--no-install-cli"])
+        .args(["init", "--no-install-cli", "--agent", "claude"])
         .assert()
         .success()
         .stdout(predicate::str::contains("unchanged .env"))

--- a/crates/redisctl/tests/init_mcp_tests.rs
+++ b/crates/redisctl/tests/init_mcp_tests.rs
@@ -1,0 +1,101 @@
+//! Launch the generated MCP configuration with offline executable shims.
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::json;
+use std::os::unix::fs::PermissionsExt;
+
+#[test]
+fn replacing_mcp_never_prints_existing_arguments() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join(".mcp.json"), json!({
+        "mcpServers": { "redis": { "command": "redis-mcp-server", "args": ["--password", "s3cret-existing-password"] } }
+    }).to_string()).unwrap();
+    Command::cargo_bin("redisctl")
+        .unwrap()
+        .current_dir(dir.path())
+        .env("REDISCTL_INIT_AMPLITUDE_KEY", "")
+        .args([
+            "init",
+            "--dry-run",
+            "--url",
+            "redis://127.0.0.1:9",
+            "--agent",
+            "claude",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("replaced existing redis server"))
+        .stdout(predicate::str::contains("s3cret-existing-password").not())
+        .stderr(predicate::str::contains("s3cret-existing-password").not());
+}
+
+#[test]
+fn docker_mcp_rewrites_only_the_local_hostname() {
+    for (url, expected) in [
+        (
+            "redis://default:s3cret@localhost:6379/2",
+            "redis://default:s3cret@host.docker.internal:6379/2",
+        ),
+        (
+            "redis://:s3cret@127.0.0.1:6379",
+            "redis://:s3cret@host.docker.internal:6379",
+        ),
+        (
+            "redis://localhost.remote.example:6379",
+            "redis://localhost.remote.example:6379",
+        ),
+        (
+            "redis://localhost-password@remote.example:6379",
+            "redis://localhost-password@remote.example:6379",
+        ),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        for (name, source) in [
+            (
+                "docker",
+                "#!/bin/sh\nif [ \"$1\" = run ]; then printf '%s\\n' \"$@\"; fi\n",
+            ),
+            ("npx", "#!/bin/sh\nexit 1\n"),
+            ("redis-cli", "#!/bin/sh\nexit 0\n"),
+        ] {
+            let path = bin.join(name);
+            std::fs::write(&path, source).unwrap();
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let path_env = format!("{}:/usr/bin:/bin", bin.display());
+        Command::cargo_bin("redisctl")
+            .unwrap()
+            .current_dir(dir.path())
+            .env("PATH", &path_env)
+            .env("REDISCTL_INIT_AMPLITUDE_KEY", "")
+            .args(["init", "--url", "redis://127.0.0.1:9", "--agent", "claude"])
+            .assert()
+            .code(10);
+        std::fs::write(dir.path().join(".env"), format!("REDIS_URL='{url}'\n")).unwrap();
+        let config: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap())
+                .unwrap();
+        let server = &config["mcpServers"]["redis"];
+        let output = std::process::Command::new(server["command"].as_str().unwrap())
+            .args(
+                server["args"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|v| v.as_str().unwrap()),
+            )
+            .current_dir(dir.path())
+            .env("PATH", &path_env)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap().lines().last(),
+            Some(expected)
+        );
+    }
+}

--- a/docs/docs/getting-started/init.md
+++ b/docs/docs/getting-started/init.md
@@ -27,8 +27,12 @@ redisctl init              # apply it
    per agent config.
 5. **Proves it works**: a live PING and SET/GET round trip.
 
-Re-running is safe: every line reports `unchanged` the second time, and nothing is
-ever overwritten - existing values are reported `kept`.
+Re-running is safe: every line reports `unchanged` the second time. Env values,
+`.gitignore` entries, and skill files are never overwritten - existing values are
+reported `kept`. The one deliberate exception: a `redis` entry in an agent's MCP
+config that differs from the generated launcher is replaced (reported `updated`,
+with the old command masked in the note); other MCP servers in the file survive
+untouched.
 
 ## Options
 

--- a/docs/docs/getting-started/init.md
+++ b/docs/docs/getting-started/init.md
@@ -1,0 +1,57 @@
+# Project Onboarding: `redisctl init`
+
+`redisctl init` onboards the current project to Redis and makes its AI coding agents
+(Claude Code, Cursor, VS Code, Codex) Redis-fluent - one command from an empty
+directory to a validated database with the project wired.
+
+```bash
+cd your-project
+redisctl init --dry-run    # see the plan first
+redisctl init              # apply it
+```
+
+## What it does
+
+1. **Detects the project**: runtime (Node, Python, Go, Rust, Java), package manager,
+   framework, and which agent tools are present.
+2. **Provisions or discovers a database**: an existing `REDIS_URL` in `.env`, a
+   container from an earlier run (restarted if stopped), or a fresh local Docker
+   container - or point it at any database with `--url` (a pasted Redis Cloud
+   connect command works verbatim).
+3. **Wires the project**: `REDIS_URL` appended to `.env` (never clobbering an
+   existing value), a committed `.env.example` placeholder, a `.gitignore` guard,
+   the official Redis client for the detected runtime, and redis-cli when missing.
+4. **Teaches the agents**: the official [redis/agent-skills](https://github.com/redis/agent-skills)
+   via the standard skills CLI, a generated `redis-project-setup` skill carrying this
+   project's specific facts, and a credential-free `redis` MCP server registration
+   per agent config.
+5. **Proves it works**: a live PING and SET/GET round trip.
+
+Re-running is safe: every line reports `unchanged` the second time, and nothing is
+ever overwritten - existing values are reported `kept`.
+
+## Options
+
+| Flag | Meaning |
+|---|---|
+| `--url <redis-url>` | use an existing database instead of Docker (`rediss://` supported; accepts a pasted `redis-cli -u ...` command) |
+| `--name <label>` | database name, recorded in the generated project skill |
+| `--agent <name>` | configure specific agents (`claude`, `cursor`, `vscode`, `codex`, `all`; repeatable or comma-separated). Default: detect installed tools |
+| `--no-install-cli` | skip installing redis-cli when it is missing |
+| `--skills-repo <dir>` | copy skills from a local redis/agent-skills checkout (offline-safe) |
+| `--skills-global` | install the official skills for your user instead of this project |
+| `--dry-run` | print the full plan, write nothing |
+
+## Credentials
+
+`.env` is the only file that ever holds the connection string. The MCP configs and
+the generated skill are credential-free and safe to commit: the MCP launcher sources
+`.env` when the agent starts the server, and passwords are masked in all terminal
+output.
+
+## Exit codes
+
+Standard `redisctl` [exit codes](../common/troubleshooting.md): 0 on success, 6 for
+invalid input, 10 when the database cannot be reached (the message names the stale
+`.env` value to fix), 1 for local environment problems such as Docker being
+unavailable.

--- a/docs/docs/getting-started/init.md
+++ b/docs/docs/getting-started/init.md
@@ -30,8 +30,8 @@ redisctl init              # apply it
 Re-running is safe: every line reports `unchanged` the second time. Env values,
 `.gitignore` entries, and skill files are never overwritten - existing values are
 reported `kept`. The one deliberate exception: a `redis` entry in an agent's MCP
-config that differs from the generated launcher is replaced (reported `updated`,
-with the old command masked in the note); other MCP servers in the file survive
+config that differs from the generated launcher is replaced (reported `updated`);
+other MCP servers in the file survive
 untouched.
 
 ## Options

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
       - getting-started/index.md
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
+      - Project Onboarding: getting-started/init.md
       - Authentication: getting-started/authentication.md
       - Docker: getting-started/docker.md
   - Common Features:


### PR DESCRIPTION
Stacked on #1103. MCP registration per agent - and the slice that unhides `redisctl init`.

- Writes `.mcp.json` / `.cursor/mcp.json` / `.vscode/mcp.json` (`servers` + `type: stdio`); codex is user-scoped and skipped, the skills cover it.
- Credential-free by construction: a `sh -c 'set -a; . ./.env ...'` launcher sources `.env` when the agent starts the server; tests assert no URL value ever lands in a committed config.
- Runner: uvx preferred, else a `docker run mcp/redis` bridge with `://`-anchored `host.docker.internal` rewrites; with neither, the config is written for uvx and a note points at installing uv.
- Merges preserve foreign servers; a different existing `redis` entry is replaced with its old command masked in the note; invalid JSON is kept untouched (the PoC crashed here).
- The command unhides and gets a docs page; the generated skill gains its MCP tooling line.

Deviation: rewritten config files come out key-sorted (serde_json without `preserve_order`; enabling it would change ordering workspace-wide). Only files we actually modify are affected.

Verify: `redisctl init --agent claude,vscode --no-install-cli`; `grep -c 'redis://' .mcp.json` prints 0; re-run reads unchanged.