### PR TITLE
feat(init): add the three-question wizard with a --defaults opt-out

### DIFF
--- a/crates/redisctl-init/src/docker.rs
+++ b/crates/redisctl-init/src/docker.rs
@@ -106,7 +106,7 @@ impl DatabaseAction {
     }
 }
 
-pub(crate) fn docker_ok() -> bool {
+pub fn docker_ok() -> bool {
     sh("docker", &["info", "--format", "{{.ServerVersion}}"]).status == 0
 }
 

--- a/crates/redisctl-init/src/lib.rs
+++ b/crates/redisctl-init/src/lib.rs
@@ -16,6 +16,8 @@ mod skills;
 mod util;
 
 pub use change::{Change, Status};
+pub use docker::docker_ok as docker_available;
+pub use project::{detect as detect_project, detect_agents};
 
 pub(crate) const SKILLS_DIR: &str = ".agents/skills";
 pub use docker::validate;
@@ -256,7 +258,9 @@ fn url_regex() -> &'static regex::Regex {
     RE.get_or_init(|| regex::Regex::new(r#"rediss?://[^\s"']+"#).expect("static regex"))
 }
 
-fn extract_url(input: &str) -> Result<String, InitError> {
+/// Pull the connection string out of raw input (a URL, or a pasted
+/// `redis-cli -u <url>` command). The error's echoed text is credential-masked.
+pub fn extract_url(input: &str) -> Result<String, InitError> {
     match url_regex().find(input) {
         Some(m) => Ok(m.as_str().to_string()),
         None => Err(InitError::NoUrlInInput {

--- a/crates/redisctl/src/cli/init.rs
+++ b/crates/redisctl/src/cli/init.rs
@@ -33,6 +33,11 @@ pub struct InitArgs {
     #[arg(long = "agent", value_enum, value_delimiter = ',', value_name = "NAME")]
     pub agents: Vec<AgentArg>,
 
+    /// Take the defaults instead of asking; the wizard only runs on a terminal,
+    /// so piped stdin never prompts either
+    #[arg(long)]
+    pub defaults: bool,
+
     /// Skip installing redis-cli when it is missing
     #[arg(long = "no-install-cli")]
     pub no_install_cli: bool,

--- a/crates/redisctl/src/cli/init.rs
+++ b/crates/redisctl/src/cli/init.rs
@@ -75,6 +75,7 @@ impl std::fmt::Debug for InitArgs {
             .field("url", &self.url.as_ref().map(|_| "<redacted>"))
             .field("name", &self.name)
             .field("agents", &self.agents)
+            .field("defaults", &self.defaults)
             .field("no_install_cli", &self.no_install_cli)
             .field("skills_repo", &self.skills_repo)
             .field("skills_global", &self.skills_global)
@@ -94,6 +95,7 @@ mod tests {
             url: Some("redis://default:s3cret@h:1".into()),
             name: Some("db".into()),
             agents: vec![AgentArg::Claude],
+            defaults: false,
             no_install_cli: false,
             skills_repo: None,
             skills_global: false,

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -323,6 +323,16 @@ impl RedisCtlError {
                 "Verify file permissions are correct".to_string(),
                 "Ensure file path is correct (use absolute path if needed)".to_string(),
             ],
+            // The init wizard has no --force; the wizard itself decides which
+            // prompts are its own, so destructive confirmations keep their tip.
+            RedisCtlError::Cancelled { prompt }
+                if crate::workflows::init::wizard::is_wizard_prompt(prompt) =>
+            {
+                vec![
+                    "Re-run with --defaults to take the defaults without prompts".to_string(),
+                    "Flags answer questions up front: --url, --agent, --skills-global".to_string(),
+                ]
+            }
             RedisCtlError::Cancelled { .. } => vec![
                 "Re-run with --force to skip the confirmation prompt".to_string(),
                 "Confirmation prompts require an interactive terminal".to_string(),

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -5,6 +5,7 @@
 //! rendering. The decisions live in the `redisctl-init` engine crate.
 
 mod output;
+mod wizard;
 
 use redisctl_init as engine;
 
@@ -39,19 +40,24 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         .chain(args.pasted.iter().cloned())
         .collect::<Vec<_>>()
         .join(" ");
-    let options = engine::Options {
-        cwd: std::env::current_dir().map_err(|e| RedisCtlError::FileError {
-            path: ".".into(),
-            message: e.to_string(),
-        })?,
+    // Validated before the banner: a rejected --url should not decorate first.
+    let url_input = match pasted.trim().is_empty() {
+        true => None,
+        false => Some(engine::extract_url(&pasted)?),
+    };
+    let cwd = std::env::current_dir().map_err(|e| RedisCtlError::FileError {
+        path: ".".into(),
+        message: e.to_string(),
+    })?;
+    let mut options = engine::Options {
+        cwd: cwd.clone(),
         name: args.name.clone(),
-        url_input: (!pasted.trim().is_empty()).then_some(pasted),
+        url_input,
         agents: requested_agents(&args.agents),
         install_cli: !args.no_install_cli,
         skills_repo: args.skills_repo.clone(),
         skills_global: args.skills_global,
     };
-    let plan = engine::plan(&options)?;
 
     output::banner();
     let dry = args.dry_run;
@@ -67,21 +73,43 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         ))
     );
 
-    let proj = &plan.project;
-    let mut descriptor = proj.runtime.as_str().to_string();
-    if let Some(pm) = proj.pm {
+    let project = engine::detect_project(&cwd);
+    let mut descriptor = project.runtime.as_str().to_string();
+    if let Some(pm) = project.pm {
         descriptor.push_str(&format!(", {pm}"));
     }
-    if let Some(framework) = &proj.framework {
+    if let Some(framework) = &project.framework {
         descriptor.push_str(&format!(", {framework}"));
     }
     println!(
         "{}   {} {}",
         bold("Project"),
-        proj.name,
+        project.name,
         dim(&format!("({descriptor})"))
     );
 
+    let pending = wizard::pending_questions(args, options.url_input.is_some());
+    let mut asked_agents = false;
+    if wizard::applies(args, &pending) {
+        let answers = wizard::run(
+            &pending,
+            &engine::detect_agents(&cwd),
+            engine::docker_available(),
+        )?;
+        if let Some(url) = answers.url {
+            options.url_input = Some(url);
+        }
+        if let Some(agents) = answers.agents {
+            options.agents = Some(agents);
+            asked_agents = true;
+        }
+        if let Some(global) = answers.skills_global {
+            options.skills_global = global;
+        }
+    }
+    let plan = engine::plan(&options)?;
+
+    let proj = &plan.project;
     let agent_bits = proj
         .agent_markers
         .iter()
@@ -98,7 +126,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         "{}    {}{}   {}\n",
         bold("Agents"),
         names,
-        if args.agents.is_empty() {
+        if args.agents.is_empty() && !asked_agents {
             dim(" (detected)")
         } else {
             String::new()

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -5,7 +5,7 @@
 //! rendering. The decisions live in the `redisctl-init` engine crate.
 
 mod output;
-mod wizard;
+pub(crate) mod wizard;
 
 use redisctl_init as engine;
 

--- a/crates/redisctl/src/workflows/init/output.rs
+++ b/crates/redisctl/src/workflows/init/output.rs
@@ -72,9 +72,15 @@ pub struct Progress {
     open: bool,
 }
 
+/// Status steps are rail entries, continuing the wizard's clack rail through the
+/// apply phase instead of dropping to plain indented text.
+fn progress_open_line(label: &str) -> String {
+    format!("{}  {}", brand_red("◇"), dim(&format!("{label}...")))
+}
+
 pub fn progress(label: &str) -> Progress {
     use std::io::Write;
-    print!("{}", dim(&format!("  {label}...")));
+    print!("{}", progress_open_line(label));
     let _ = std::io::stdout().flush();
     Progress { open: true }
 }
@@ -190,6 +196,16 @@ mod tests {
                 (RunKind::Edge, "╔═".to_string()),
                 (RunKind::Block, "██".to_string()),
             ]
+        );
+    }
+
+    #[test]
+    fn progress_lines_join_the_wizard_rail() {
+        // Piped output (tests are not a tty), so no colour codes - the rail glyph
+        // still leads the line, keeping status steps visually part of the wizard.
+        assert_eq!(
+            progress_open_line("installing skills (npx skills add)"),
+            "◇  installing skills (npx skills add)..."
         );
     }
 

--- a/crates/redisctl/src/workflows/init/wizard.rs
+++ b/crates/redisctl/src/workflows/init/wizard.rs
@@ -133,8 +133,24 @@ impl Theme for RedisTheme {
         prompt: &str,
         sel: &str,
     ) -> std::fmt::Result {
-        self.format_select_prompt_selection(f, prompt, sel)
+        // The pasted connection string carries a password; the confirmation line
+        // must not reprint it.
+        self.format_select_prompt_selection(f, prompt, &engine::mask_url(sel))
     }
+}
+
+const DATABASE_PROMPT: &str = "Where should the database come from?";
+const AGENTS_PROMPT: &str = "Which agent(s) should be configured?";
+const SKILLS_PROMPT: &str = "Where should the Redis skills be installed?";
+const INTERRUPTED: &str = "interrupted";
+
+/// Cancel tips are picked by prompt (see `error.rs`): the wizard's questions get
+/// `--defaults` guidance, while confirmation prompts elsewhere keep `--force`.
+pub(crate) fn is_wizard_prompt(prompt: &str) -> bool {
+    matches!(
+        prompt,
+        DATABASE_PROMPT | AGENTS_PROMPT | SKILLS_PROMPT | INTERRUPTED
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -181,7 +197,7 @@ fn prompt_failed(e: dialoguer::Error) -> RedisCtlError {
     let dialoguer::Error::IO(io) = e;
     if io.kind() == std::io::ErrorKind::Interrupted {
         RedisCtlError::Cancelled {
-            prompt: "interrupted".to_string(),
+            prompt: INTERRUPTED.to_string(),
         }
     } else {
         RedisCtlError::Other(format!("prompt failed: {io}"))
@@ -206,7 +222,7 @@ pub fn run(
 
 /// `Ok(None)` means the local Docker default; a paste comes back as the URL.
 fn ask_database(docker: bool) -> Result<Option<String>, RedisCtlError> {
-    const PROMPT: &str = "Where should the database come from?";
+    const PROMPT: &str = DATABASE_PROMPT;
     // An option that cannot work stays on the list carrying the reason - the same
     // information the error would deliver after the run, shown before it instead.
     let docker_item = if docker {
@@ -246,7 +262,7 @@ fn ask_database(docker: bool) -> Result<Option<String>, RedisCtlError> {
 /// Detection preselects, it does not decide: having Cursor installed is not consent
 /// to write .cursor/mcp.json into this repo.
 fn ask_agents(detected: &[engine::Agent]) -> Result<Vec<engine::Agent>, RedisCtlError> {
-    const PROMPT: &str = "Which agent(s) should be configured?";
+    const PROMPT: &str = AGENTS_PROMPT;
     const LABELS: [&str; 4] = ["Claude Code", "Cursor", "VS Code", "Codex"];
     let preselected: Vec<bool> = engine::KNOWN_AGENTS
         .iter()
@@ -273,7 +289,7 @@ fn ask_agents(detected: &[engine::Agent]) -> Result<Vec<engine::Agent>, RedisCtl
 }
 
 fn ask_skills_scope() -> Result<bool, RedisCtlError> {
-    const PROMPT: &str = "Where should the Redis skills be installed?";
+    const PROMPT: &str = SKILLS_PROMPT;
     let selection = Select::with_theme(&RedisTheme)
         .with_prompt(PROMPT)
         .items(&[
@@ -345,9 +361,58 @@ mod tests {
     }
 
     #[test]
-    fn piped_stdin_never_prompts() {
-        // Tests run with piped stdin, so this exercises the real guard.
-        let pending = pending_questions(&args(), false);
-        assert!(!applies(&args(), &pending));
+    fn wizard_cancel_tips_never_hijack_destructive_confirmations() {
+        use crate::error::RedisCtlError;
+        let wizard = RedisCtlError::Cancelled {
+            prompt: DATABASE_PROMPT.to_string(),
+        };
+        assert!(
+            wizard
+                .suggestions()
+                .iter()
+                .any(|t| t.contains("--defaults"))
+        );
+
+        let destructive = RedisCtlError::Cancelled {
+            prompt: "Delete user 5?".to_string(),
+        };
+        assert!(
+            destructive
+                .suggestions()
+                .iter()
+                .any(|t| t.contains("--force")),
+            "{:?}",
+            destructive.suggestions()
+        );
+    }
+
+    #[test]
+    fn defaults_flag_disables_the_wizard() {
+        let mut a = args();
+        a.defaults = true;
+        let pending = pending_questions(&a, false);
+        assert!(!applies(&a, &pending));
+    }
+
+    #[test]
+    fn nothing_pending_disables_the_wizard() {
+        assert!(!applies(&args(), &[]));
+    }
+
+    #[test]
+    fn pasted_url_confirmation_is_masked() {
+        let mut rendered = String::new();
+        RedisTheme
+            .format_input_prompt_selection(
+                &mut rendered,
+                "Paste the connection string",
+                "redis://default:s3cret@host:6379",
+            )
+            .unwrap();
+        assert!(
+            rendered.contains("redis://default:****@host:6379"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("s3cret"), "{rendered}");
     }
 }

--- a/crates/redisctl/src/workflows/init/wizard.rs
+++ b/crates/redisctl/src/workflows/init/wizard.rs
@@ -1,0 +1,226 @@
+//! The wizard: three questions, and only the three that change what happens. Each
+//! is skipped the moment a flag already answers it; `--defaults` takes the defaults
+//! instead, and piped stdin never prompts - an agent-invoked run never blocks.
+
+use std::io::IsTerminal;
+
+use dialoguer::{Input, MultiSelect, Select};
+use redisctl_init as engine;
+
+use crate::cli::InitArgs;
+use crate::error::RedisCtlError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Question {
+    Database,
+    Agents,
+    Skills,
+}
+
+/// A question is worth asking only when no flag has already answered it.
+pub fn pending_questions(args: &InitArgs, url_given: bool) -> Vec<Question> {
+    let mut pending = Vec::new();
+    if !url_given {
+        pending.push(Question::Database);
+    }
+    if args.agents.is_empty() {
+        pending.push(Question::Agents);
+    }
+    if !args.skills_global {
+        pending.push(Question::Skills);
+    }
+    pending
+}
+
+pub fn applies(args: &InitArgs, pending: &[Question]) -> bool {
+    std::io::stdin().is_terminal() && !args.defaults && !pending.is_empty()
+}
+
+/// What the wizard decided; `None` per field means the question was not asked.
+#[derive(Default)]
+pub struct Answers {
+    pub url: Option<String>,
+    pub agents: Option<Vec<engine::Agent>>,
+    pub skills_global: Option<bool>,
+}
+
+fn cancelled(prompt: &str) -> RedisCtlError {
+    RedisCtlError::Cancelled {
+        prompt: prompt.to_string(),
+    }
+}
+
+fn prompt_failed(e: dialoguer::Error) -> RedisCtlError {
+    let dialoguer::Error::IO(io) = e;
+    if io.kind() == std::io::ErrorKind::Interrupted {
+        RedisCtlError::Cancelled {
+            prompt: "interrupted".to_string(),
+        }
+    } else {
+        RedisCtlError::Other(format!("prompt failed: {io}"))
+    }
+}
+
+pub fn run(
+    pending: &[Question],
+    detected: &[engine::Agent],
+    docker: bool,
+) -> Result<Answers, RedisCtlError> {
+    let mut answers = Answers::default();
+    for question in pending {
+        match question {
+            Question::Database => answers.url = ask_database(docker)?,
+            Question::Agents => answers.agents = Some(ask_agents(detected)?),
+            Question::Skills => answers.skills_global = Some(ask_skills_scope()?),
+        }
+    }
+    Ok(answers)
+}
+
+/// `Ok(None)` means the local Docker default; a paste comes back as the URL.
+fn ask_database(docker: bool) -> Result<Option<String>, RedisCtlError> {
+    const PROMPT: &str = "Where should the database come from?";
+    // An option that cannot work stays on the list carrying the reason - the same
+    // information the error would deliver after the run, shown before it instead.
+    let docker_item = if docker {
+        "Local Docker container"
+    } else {
+        "Local Docker container  (Docker is not running)"
+    };
+    let items = [docker_item, "Paste a connection string"];
+    loop {
+        let selection = Select::new()
+            .with_prompt(PROMPT)
+            .items(&items)
+            .default(if docker { 0 } else { 1 })
+            .interact_opt()
+            .map_err(prompt_failed)?;
+        match selection {
+            None => return Err(cancelled(PROMPT)),
+            Some(0) if !docker => {
+                eprintln!("  Docker is not running - start it, or paste a connection string.");
+            }
+            Some(0) => return Ok(None),
+            _ => break,
+        }
+    }
+    let pasted: String = Input::new()
+        .with_prompt("Paste the connection string")
+        .validate_with(|input: &String| {
+            engine::extract_url(input)
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        })
+        .interact_text()
+        .map_err(prompt_failed)?;
+    Ok(Some(engine::extract_url(&pasted)?))
+}
+
+/// Detection preselects, it does not decide: having Cursor installed is not consent
+/// to write .cursor/mcp.json into this repo.
+fn ask_agents(detected: &[engine::Agent]) -> Result<Vec<engine::Agent>, RedisCtlError> {
+    const PROMPT: &str = "Which agent(s) should be configured?";
+    const LABELS: [&str; 4] = ["Claude Code", "Cursor", "VS Code", "Codex"];
+    let preselected: Vec<bool> = engine::KNOWN_AGENTS
+        .iter()
+        .map(|agent| detected.contains(agent))
+        .collect();
+    loop {
+        let picks = MultiSelect::new()
+            .with_prompt(format!("{PROMPT} (space toggles, enter confirms)"))
+            .items(&LABELS)
+            .defaults(&preselected)
+            .interact_opt()
+            .map_err(prompt_failed)?;
+        match picks {
+            None => return Err(cancelled(PROMPT)),
+            Some(picks) if picks.is_empty() => eprintln!("  pick at least one"),
+            Some(picks) => {
+                return Ok(picks
+                    .into_iter()
+                    .map(|index| engine::KNOWN_AGENTS[index])
+                    .collect());
+            }
+        }
+    }
+}
+
+fn ask_skills_scope() -> Result<bool, RedisCtlError> {
+    const PROMPT: &str = "Where should the Redis skills be installed?";
+    let selection = Select::new()
+        .with_prompt(PROMPT)
+        .items(&[
+            "This project only (.agents/skills)",
+            "Global (available in every project)",
+        ])
+        .default(0)
+        .interact_opt()
+        .map_err(prompt_failed)?;
+    match selection {
+        None => Err(cancelled(PROMPT)),
+        Some(choice) => Ok(choice == 1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::AgentArg;
+
+    fn args() -> InitArgs {
+        InitArgs {
+            url: None,
+            name: None,
+            agents: Vec::new(),
+            defaults: false,
+            no_install_cli: false,
+            skills_repo: None,
+            skills_global: false,
+            dry_run: false,
+            pasted: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn with_no_flags_all_three_questions_are_open() {
+        assert_eq!(
+            pending_questions(&args(), false),
+            vec![Question::Database, Question::Agents, Question::Skills]
+        );
+    }
+
+    #[test]
+    fn a_url_answers_the_database_question() {
+        assert_eq!(
+            pending_questions(&args(), true),
+            vec![Question::Agents, Question::Skills]
+        );
+    }
+
+    #[test]
+    fn agent_flags_answer_the_agents_question() {
+        let mut a = args();
+        a.agents = vec![AgentArg::Claude];
+        assert_eq!(
+            pending_questions(&a, false),
+            vec![Question::Database, Question::Skills]
+        );
+    }
+
+    #[test]
+    fn skills_global_answers_the_skills_question() {
+        let mut a = args();
+        a.skills_global = true;
+        assert_eq!(
+            pending_questions(&a, false),
+            vec![Question::Database, Question::Agents]
+        );
+    }
+
+    #[test]
+    fn piped_stdin_never_prompts() {
+        // Tests run with piped stdin, so this exercises the real guard.
+        let pending = pending_questions(&args(), false);
+        assert!(!applies(&args(), &pending));
+    }
+}

--- a/crates/redisctl/src/workflows/init/wizard.rs
+++ b/crates/redisctl/src/workflows/init/wizard.rs
@@ -4,11 +4,138 @@
 
 use std::io::IsTerminal;
 
+use dialoguer::console::Style;
+use dialoguer::theme::Theme;
 use dialoguer::{Input, MultiSelect, Select};
 use redisctl_init as engine;
 
 use crate::cli::InitArgs;
 use crate::error::RedisCtlError;
+
+/// A clack-style rail in brand red: `│` down the side, `◆` while a question is
+/// live, `◇` once answered. The colour index matches the banner's 256-colour
+/// fallback tone.
+struct RedisTheme;
+
+fn brand() -> Style {
+    Style::new().color256(203)
+}
+
+impl Theme for RedisTheme {
+    fn format_prompt(&self, f: &mut dyn std::fmt::Write, prompt: &str) -> std::fmt::Result {
+        write!(
+            f,
+            "{}  {}",
+            brand().apply_to('◆'),
+            Style::new().bold().apply_to(prompt)
+        )
+    }
+
+    fn format_error(&self, f: &mut dyn std::fmt::Write, err: &str) -> std::fmt::Result {
+        write!(
+            f,
+            "{}  {}",
+            brand().apply_to('└'),
+            Style::new().red().apply_to(err)
+        )
+    }
+
+    fn format_select_prompt_item(
+        &self,
+        f: &mut dyn std::fmt::Write,
+        text: &str,
+        active: bool,
+    ) -> std::fmt::Result {
+        let mark = if active {
+            brand().apply_to('●').to_string()
+        } else {
+            Style::new().dim().apply_to('○').to_string()
+        };
+        let label = if active {
+            text.to_string()
+        } else {
+            Style::new().dim().apply_to(text).to_string()
+        };
+        write!(f, "{}  {mark} {label}", brand().apply_to('│'))
+    }
+
+    fn format_multi_select_prompt_item(
+        &self,
+        f: &mut dyn std::fmt::Write,
+        text: &str,
+        checked: bool,
+        active: bool,
+    ) -> std::fmt::Result {
+        let mark = if checked {
+            brand().apply_to('■').to_string()
+        } else {
+            Style::new().dim().apply_to('□').to_string()
+        };
+        let label = if active {
+            text.to_string()
+        } else {
+            Style::new().dim().apply_to(text).to_string()
+        };
+        write!(f, "{}  {mark} {label}", brand().apply_to('│'))
+    }
+
+    fn format_select_prompt_selection(
+        &self,
+        f: &mut dyn std::fmt::Write,
+        prompt: &str,
+        sel: &str,
+    ) -> std::fmt::Result {
+        write!(
+            f,
+            "{}  {}\n{}  {}",
+            brand().apply_to('◇'),
+            Style::new().bold().apply_to(prompt),
+            brand().apply_to('│'),
+            Style::new().dim().apply_to(sel)
+        )
+    }
+
+    fn format_multi_select_prompt_selection(
+        &self,
+        f: &mut dyn std::fmt::Write,
+        prompt: &str,
+        selections: &[&str],
+    ) -> std::fmt::Result {
+        self.format_select_prompt_selection(f, prompt, &selections.join(", "))
+    }
+
+    fn format_input_prompt(
+        &self,
+        f: &mut dyn std::fmt::Write,
+        prompt: &str,
+        default: Option<&str>,
+    ) -> std::fmt::Result {
+        match default {
+            Some(default) => write!(
+                f,
+                "{}  {} {}",
+                brand().apply_to('◆'),
+                Style::new().bold().apply_to(prompt),
+                Style::new().dim().apply_to(format!("[{default}]"))
+            ),
+            None => write!(
+                f,
+                "{}  {}",
+                brand().apply_to('◆'),
+                Style::new().bold().apply_to(prompt)
+            ),
+        }
+    }
+
+    fn format_input_prompt_selection(
+        &self,
+        f: &mut dyn std::fmt::Write,
+        prompt: &str,
+        sel: &str,
+    ) -> std::fmt::Result {
+        self.format_select_prompt_selection(f, prompt, sel)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Question {
@@ -89,7 +216,7 @@ fn ask_database(docker: bool) -> Result<Option<String>, RedisCtlError> {
     };
     let items = [docker_item, "Paste a connection string"];
     loop {
-        let selection = Select::new()
+        let selection = Select::with_theme(&RedisTheme)
             .with_prompt(PROMPT)
             .items(&items)
             .default(if docker { 0 } else { 1 })
@@ -104,7 +231,7 @@ fn ask_database(docker: bool) -> Result<Option<String>, RedisCtlError> {
             _ => break,
         }
     }
-    let pasted: String = Input::new()
+    let pasted: String = Input::with_theme(&RedisTheme)
         .with_prompt("Paste the connection string")
         .validate_with(|input: &String| {
             engine::extract_url(input)
@@ -126,7 +253,7 @@ fn ask_agents(detected: &[engine::Agent]) -> Result<Vec<engine::Agent>, RedisCtl
         .map(|agent| detected.contains(agent))
         .collect();
     loop {
-        let picks = MultiSelect::new()
+        let picks = MultiSelect::with_theme(&RedisTheme)
             .with_prompt(format!("{PROMPT} (space toggles, enter confirms)"))
             .items(&LABELS)
             .defaults(&preselected)
@@ -147,7 +274,7 @@ fn ask_agents(detected: &[engine::Agent]) -> Result<Vec<engine::Agent>, RedisCtl
 
 fn ask_skills_scope() -> Result<bool, RedisCtlError> {
     const PROMPT: &str = "Where should the Redis skills be installed?";
-    let selection = Select::new()
+    let selection = Select::with_theme(&RedisTheme)
         .with_prompt(PROMPT)
         .items(&[
             "This project only (.agents/skills)",

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -458,3 +458,25 @@ fn npx_path_installs_the_official_skills_with_a_lock() {
         .code(10)
         .stdout(predicate::str::contains("unchanged .agents/skills/"));
 }
+
+#[test]
+fn defaults_flag_parses_and_stays_non_interactive() {
+    let dir = tempfile::tempdir().unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .args([
+            "init",
+            "--defaults",
+            "--dry-run",
+            "--url",
+            "redis://localhost:6379",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Dry run complete"));
+    redisctl()
+        .args(["init", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--defaults"));
+}

--- a/docs/docs/getting-started/init.md
+++ b/docs/docs/getting-started/init.md
@@ -44,6 +44,7 @@ untouched.
 | `--no-install-cli` | skip installing redis-cli when it is missing |
 | `--skills-repo <dir>` | copy skills from a local redis/agent-skills checkout (offline-safe) |
 | `--skills-global` | install the official skills for your user instead of this project |
+| `--defaults` | take the defaults instead of asking; piped stdin never prompts either |
 | `--dry-run` | print the full plan, write nothing |
 
 ## Credentials


### PR DESCRIPTION
Stacked on #1104. The wizard - strictly sugar over the flags.

- Three questions, each skipped when a flag already answers it; fully-flagged runs prompt for nothing; piped stdin never prompts (the whole existing suite would hang otherwise).
- Database: local Docker (an unavailable option carries its reason on the label and re-prompts) or paste a connection string (same secret-safe parser as `--url`; the confirmation line masks the password). Agents: multiselect with detection preselecting. Skills: project vs global.
- `--defaults` takes the defaults - named per the tree-wide `--yes` ban (long-only; the npm wrapper maps its own `-y`).
- Esc/interrupt exits 12 via the standard `Cancelled` taxonomy (deviation from the PoC's 130); wizard cancels get `--defaults` guidance while destructive confirmations elsewhere keep their `--force` tips.

Verified under a real pty: enter-through-defaults produces the identical plan a flagged run does; Esc exits 12 at every question. The pending-question matrix mirrors the PoC's wizard assertions as unit tests.

**Update:** status steps (docker start, client install, skills add) now render as rail entries continuing the wizard rail, matching the clack style end to end.
