### PR TITLE
feat(init): take the database from Redis Cloud with --cloud

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -437,6 +437,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,7 +582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -705,6 +716,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +788,21 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -951,7 +986,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1098,7 +1133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1363,9 +1398,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1440,6 +1487,76 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e7bd6a377435d568f652153e571b50970d7ccc1d1eeec0519f834632287e1"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.2",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2da0694c15b44c6f68a6b05e0233617008c54080e31d6eb848d858a9c5b38d"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4f9f4603319422d482738f3f6fe5aac03157fdbfed1cd85a3ff45adb09072f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.2",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration 0.7.0",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hmac"
@@ -1570,12 +1687,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
- "system-configuration",
+ "socket2 0.6.0",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
@@ -1752,10 +1869,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.0",
+ "widestring",
+ "windows-registry 0.6.1",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ipnetwork"
@@ -1781,7 +1914,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1832,7 +1965,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1840,10 +1973,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2170,6 +2352,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "nanoid"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2393,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nom"
@@ -2299,6 +2504,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2626,6 +2835,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,7 +2889,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2707,7 +2927,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2728,6 +2948,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2972,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2785,6 +3022,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2909,6 +3152,7 @@ dependencies = [
  "files-sdk",
  "flate2",
  "futures",
+ "hickory-resolver",
  "indicatif",
  "jpx-core",
  "keyring",
@@ -3169,6 +3413,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,7 +3525,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3345,7 +3595,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -3355,7 +3605,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3622,7 +3872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3639,7 +3889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3687,6 +3937,22 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3796,6 +4062,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
 name = "system-configuration-sys"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3832,6 +4109,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3852,7 +4135,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4746,6 +5029,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4767,7 +5056,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4832,6 +5121,17 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 # Standards-compliant OAuth2/OIDC (device grant, auth-code+PKCE, refresh); rustls to match reqwest.
 oauth2 = { version = "5", default-features = false, features = ["reqwest", "rustls-tls"] }
 url = "2.5"
+hickory-resolver = "0.26"
 base64 = "0.22"
 sha2 = "0.10"
 getrandom = "0.3"

--- a/crates/redisctl-init/src/change.rs
+++ b/crates/redisctl-init/src/change.rs
@@ -33,7 +33,7 @@ pub struct Change {
 }
 
 impl Change {
-    pub(crate) fn new(subject: impl Into<String>, status: Status, note: impl Into<String>) -> Self {
+    pub fn new(subject: impl Into<String>, status: Status, note: impl Into<String>) -> Self {
         Self {
             subject: subject.into(),
             status,

--- a/crates/redisctl-init/src/env.rs
+++ b/crates/redisctl-init/src/env.rs
@@ -70,7 +70,7 @@ pub(crate) fn read_for_planning(dir: &Path, rel: &str) -> Result<Option<String>,
 
 /// Read one key out of a dotenv-style file: `KEY=value`, optional `export`, optional
 /// quotes.
-pub(crate) fn read_env_key(dir: &Path, rel: &str, key: &str) -> Option<String> {
+pub fn read_env_key(dir: &Path, rel: &str, key: &str) -> Option<String> {
     let content = read_if(dir, rel)?;
     let re = regex::Regex::new(&format!(
         r"^\s*(?:export\s+)?{}\s*=\s*(.*)$",

--- a/crates/redisctl-init/src/lib.rs
+++ b/crates/redisctl-init/src/lib.rs
@@ -21,8 +21,9 @@ pub use project::{detect as detect_project, detect_agents};
 
 pub(crate) const SKILLS_DIR: &str = ".agents/skills";
 pub use docker::validate;
+pub use env::read_env_key;
 pub use project::{Agent, KNOWN_AGENTS, Project, Runtime};
-pub use util::mask_url;
+pub use util::{mask_url, slug};
 
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -82,6 +83,9 @@ pub struct Options {
     /// Raw connection input: a URL, or a pasted `redis-cli -u <url>` command.
     /// `None` means no input was given (not blank input).
     pub url_input: Option<String>,
+    /// The Redis Cloud database behind `url_input`, when the caller provisioned or
+    /// picked one. Plain data - the engine makes no cloud calls.
+    pub cloud: Option<CloudFacts>,
     /// `None` detects installed tools; detecting none still configures all agents.
     pub agents: Option<Vec<Agent>>,
     /// Install redis-cli when it is missing (`--no-install-cli` turns this off).
@@ -92,6 +96,43 @@ pub struct Options {
     pub skills_global: bool,
 }
 
+/// A Redis Cloud database the caller resolved before planning; flows into the
+/// generated skill's facts and the control-plane MCP entry.
+#[derive(Debug, Clone)]
+pub struct CloudFacts {
+    pub name: String,
+    pub subscription_id: String,
+    pub database_id: String,
+    pub tier: CloudTier,
+    /// The redisctl profile the control-plane hints should name, when not the default.
+    pub profile: Option<String>,
+    /// Freshly created this run (as opposed to reusing an existing database).
+    pub created: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloudTier {
+    Essentials,
+    Flexible,
+}
+
+impl CloudTier {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CloudTier::Essentials => "Essentials",
+            CloudTier::Flexible => "Flexible",
+        }
+    }
+
+    /// The CAPI path family this tier's databases live under.
+    pub fn api_base(self) -> &'static str {
+        match self {
+            CloudTier::Essentials => "/fixed/subscriptions",
+            CloudTier::Flexible => "/subscriptions",
+        }
+    }
+}
+
 /// What a run works with: the facts detected, the database it targets, and the
 /// mutations decided. Rendering a plan is the dry run; [`apply`] performs it.
 #[derive(Debug)]
@@ -99,6 +140,7 @@ pub struct Plan {
     pub project: Project,
     pub agents: Vec<Agent>,
     name: Option<String>,
+    cloud: Option<CloudFacts>,
     database: docker::DatabaseAction,
     file_actions: Vec<env::FileAction>,
     client: install::InstallAction,
@@ -117,7 +159,12 @@ impl Plan {
     /// for a real run over the planned one ("new Docker container" vs
     /// "Docker (planned)").
     pub fn database_source(&self, applied: bool) -> &'static str {
-        self.database.source(applied)
+        match &self.cloud {
+            Some(cloud) if cloud.created && applied => "Redis Cloud (new database)",
+            Some(cloud) if cloud.created => "Redis Cloud (planned)",
+            Some(_) => "Redis Cloud (existing database)",
+            None => self.database.source(applied),
+        }
     }
 
     /// Neither uvx nor Docker can run the MCP server; the configs are still written
@@ -180,11 +227,19 @@ pub fn plan(options: &Options) -> Result<Plan, InitError> {
         global: options.skills_global,
         repo: options.skills_repo.clone(),
     };
-    let mcp = mcp::plan_mcp(&options.cwd, &agents)?;
+    let mcp = mcp::plan_mcp(
+        &options.cwd,
+        &agents,
+        options
+            .cloud
+            .as_ref()
+            .map(|cloud| (cloud, util::has_bin("redisctl-mcp"))),
+    )?;
     Ok(Plan {
         project,
         agents,
         name: options.name.clone(),
+        cloud: options.cloud.clone(),
         database,
         file_actions,
         client,
@@ -222,6 +277,7 @@ pub async fn apply(plan: &Plan, on_event: &mut dyn FnMut(Event)) -> Result<Repor
     let facts = project_skill::SkillFacts {
         runtime: plan.project.runtime,
         name: plan.name.as_deref(),
+        cloud: plan.cloud.as_ref(),
         container: plan.database.container(),
         skills: &skills.installed,
         client_installed,
@@ -322,6 +378,7 @@ mod tests {
             cwd: dir.path().to_path_buf(),
             name: None,
             url_input: Some("redis-cli -u redis://h:1".into()),
+            cloud: None,
             agents: Some(vec![Agent::Claude]),
             install_cli: false,
             skills_repo: None,
@@ -341,6 +398,7 @@ mod tests {
             cwd: dir.path().to_path_buf(),
             name: None,
             url_input: Some("redis://h:1".into()),
+            cloud: None,
             agents: Some(vec![Agent::Codex]),
             install_cli: false,
             skills_repo: None,
@@ -371,6 +429,7 @@ mod tests {
             cwd: cwd.to_path_buf(),
             name: None,
             url_input: Some("redis-cli -u redis://h:1".into()),
+            cloud: None,
             agents: Some(vec![Agent::Codex]),
             install_cli: false,
             skills_repo: Some(repo.path().to_path_buf()),

--- a/crates/redisctl-init/src/mcp.rs
+++ b/crates/redisctl-init/src/mcp.rs
@@ -63,7 +63,21 @@ pub(crate) struct McpPlan {
     pub(crate) uvx_missing: bool,
 }
 
-pub(crate) fn plan_mcp(cwd: &Path, agents: &[Agent]) -> Result<McpPlan, InitError> {
+/// The control-plane server: credentials stay in the redisctl profile, so the
+/// committed config carries only the launch command.
+fn control_plane_entry(cloud: &crate::CloudFacts) -> serde_json::Value {
+    let args: Vec<String> = match &cloud.profile {
+        Some(profile) => vec!["--profile".into(), profile.clone()],
+        None => vec![],
+    };
+    serde_json::json!({ "command": "redisctl-mcp", "args": args })
+}
+
+pub(crate) fn plan_mcp(
+    cwd: &Path,
+    agents: &[Agent],
+    cloud: Option<(&crate::CloudFacts, bool)>,
+) -> Result<McpPlan, InitError> {
     let runner = if has_bin("uvx") {
         Runner::Uvx
     } else if docker_ok() {
@@ -71,19 +85,37 @@ pub(crate) fn plan_mcp(cwd: &Path, agents: &[Agent]) -> Result<McpPlan, InitErro
     } else {
         Runner::UvxMissing
     };
-    let entry = server_entry(&runner);
+    let mut servers = vec![(
+        "redis",
+        server_entry(&runner),
+        "redis: reads REDIS_URL from .env at launch".to_string(),
+    )];
+    if let Some((cloud, true)) = cloud {
+        servers.push((
+            "redisctl",
+            control_plane_entry(cloud),
+            "redisctl: control plane, credentials stay in the redisctl profile".to_string(),
+        ));
+    }
     let mut actions = Vec::new();
     for agent in agents {
         actions.push(match agent {
-            Agent::Claude => upsert(cwd, ".mcp.json", "mcpServers", &entry, false)?,
-            Agent::Cursor => upsert(cwd, ".cursor/mcp.json", "mcpServers", &entry, false)?,
-            Agent::Vscode => upsert(cwd, ".vscode/mcp.json", "servers", &entry, true)?,
+            Agent::Claude => upsert(cwd, ".mcp.json", "mcpServers", &servers, false)?,
+            Agent::Cursor => upsert(cwd, ".cursor/mcp.json", "mcpServers", &servers, false)?,
+            Agent::Vscode => upsert(cwd, ".vscode/mcp.json", "servers", &servers, true)?,
             Agent::Codex => McpAction::Report(Change::new(
                 "mcp (codex)",
                 Status::Skipped,
                 "codex MCP config is user-scoped (~/.codex/config.toml); the skills cover it",
             )),
         });
+    }
+    if let Some((_, false)) = cloud {
+        actions.push(McpAction::Report(Change::new(
+            "mcp (redisctl)",
+            Status::Skipped,
+            "redisctl-mcp not on PATH (cargo install redisctl-mcp) - the CLI still works",
+        )));
     }
     Ok(McpPlan {
         actions,
@@ -103,13 +135,9 @@ fn upsert(
     cwd: &Path,
     rel: &str,
     top_key: &str,
-    entry: &serde_json::Value,
+    servers: &[(&str, serde_json::Value, String)],
     stdio: bool,
 ) -> Result<McpAction, InitError> {
-    let mut server = entry.clone();
-    if stdio {
-        server["type"] = "stdio".into();
-    }
     let existing = read_for_planning(cwd, rel)?;
     let mut cfg = match &existing {
         None => serde_json::json!({}),
@@ -121,18 +149,32 @@ fn upsert(
     let Some(root) = cfg.as_object_mut() else {
         return Ok(kept_invalid(rel));
     };
-    let servers = root.entry(top_key).or_insert_with(|| serde_json::json!({}));
-    let Some(map) = servers.as_object_mut() else {
+    let entries = root.entry(top_key).or_insert_with(|| serde_json::json!({}));
+    let Some(map) = entries.as_object_mut() else {
         return Ok(kept_invalid(rel));
     };
-    let note = match map.get("redis") {
-        Some(previous) if *previous == server => {
-            return Ok(McpAction::Report(Change::new(rel, Status::Unchanged, "")));
+    let mut notes = Vec::new();
+    for (name, entry, fresh_note) in servers {
+        let mut server = entry.clone();
+        if stdio {
+            server["type"] = "stdio".into();
         }
-        Some(_) => "replaced existing redis server".to_string(),
-        None => "redis: reads REDIS_URL from .env at launch".to_string(),
-    };
-    map.insert("redis".to_string(), server);
+        match map.get(*name) {
+            Some(previous) if *previous == server => {}
+            Some(_) => {
+                notes.push(format!("replaced existing {name} server"));
+                map.insert((*name).to_string(), server);
+            }
+            None => {
+                notes.push(fresh_note.clone());
+                map.insert((*name).to_string(), server);
+            }
+        }
+    }
+    if notes.is_empty() {
+        return Ok(McpAction::Report(Change::new(rel, Status::Unchanged, "")));
+    }
+    let note = notes.join("; ");
     let status = if existing.is_some() {
         Status::Updated
     } else {
@@ -158,7 +200,69 @@ mod tests {
     use super::*;
 
     fn plan_for(dir: &Path, agents: &[Agent]) -> McpPlan {
-        plan_mcp(dir, agents).unwrap()
+        plan_mcp(dir, agents, None).unwrap()
+    }
+
+    fn cloud_facts(profile: Option<&str>) -> crate::CloudFacts {
+        crate::CloudFacts {
+            name: "cloud-db".to_string(),
+            subscription_id: "1".to_string(),
+            database_id: "9".to_string(),
+            tier: crate::CloudTier::Essentials,
+            profile: profile.map(str::to_string),
+            created: false,
+        }
+    }
+
+    #[test]
+    fn cloud_registers_the_control_plane_server_alongside_redis() {
+        let dir = tempfile::tempdir().unwrap();
+        let cloud = cloud_facts(Some("qa"));
+        let plan = plan_mcp(
+            dir.path(),
+            &[Agent::Claude, Agent::Vscode],
+            Some((&cloud, true)),
+        )
+        .unwrap();
+        apply_all(dir.path(), &plan);
+
+        let claude: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap())
+                .unwrap();
+        assert_eq!(claude["mcpServers"]["redisctl"]["command"], "redisctl-mcp");
+        assert_eq!(claude["mcpServers"]["redisctl"]["args"][1], "qa");
+        assert!(claude["mcpServers"]["redis"].is_object());
+        // Credentials stay in the redisctl profile; the committed file has none.
+        let raw = std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap();
+        assert!(
+            !raw.contains("api-key") && !raw.contains("api_secret"),
+            "{raw}"
+        );
+
+        let vscode: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join(".vscode/mcp.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(vscode["servers"]["redisctl"]["type"], "stdio");
+    }
+
+    #[test]
+    fn cloud_without_the_mcp_binary_reports_a_skip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cloud = cloud_facts(None);
+        let plan = plan_mcp(dir.path(), &[Agent::Claude], Some((&cloud, false))).unwrap();
+        let last = plan.actions.last().unwrap().preview();
+        assert_eq!(last.status, Status::Skipped);
+        assert_eq!(last.subject, "mcp (redisctl)");
+        assert!(
+            last.note.contains("cargo install redisctl-mcp"),
+            "{}",
+            last.note
+        );
+        // And the data-plane entry alone lands in the config.
+        apply_all(dir.path(), &plan);
+        let raw = std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap();
+        assert!(!raw.contains("redisctl-mcp"), "{raw}");
     }
 
     fn apply_all(dir: &Path, plan: &McpPlan) -> Vec<Change> {

--- a/crates/redisctl-init/src/project_skill.rs
+++ b/crates/redisctl-init/src/project_skill.rs
@@ -16,6 +16,7 @@ const NOTE: &str = "project-specific facts, loaded only for Redis-related prompt
 pub(crate) struct SkillFacts<'a> {
     pub(crate) runtime: Runtime,
     pub(crate) name: Option<&'a str>,
+    pub(crate) cloud: Option<&'a crate::CloudFacts>,
     pub(crate) container: Option<&'a str>,
     pub(crate) skills: &'a [String],
     pub(crate) client_installed: bool,
@@ -98,6 +99,15 @@ fn client_hint(facts: &SkillFacts) -> &'static str {
 }
 
 fn db_hint(facts: &SkillFacts) -> String {
+    if let (Some(cloud), None) = (facts.cloud, facts.container) {
+        return format!(
+            "- The database is `{name}` on Redis Cloud: {tier} subscription `{sub}`, database `{db}`; credentials live only in `.env`.",
+            name = cloud.name,
+            tier = cloud.tier.as_str(),
+            sub = cloud.subscription_id,
+            db = cloud.database_id,
+        );
+    }
     match (facts.container, facts.name) {
         (Some(container), _) => format!(
             "- Local database in Docker container `{container}` - `docker start {container}` if it is down; `docker exec -it {container} redis-cli` for a REPL."
@@ -107,6 +117,24 @@ fn db_hint(facts: &SkillFacts) -> String {
         ),
         (None, None) => "- The database is external (not managed by this project); credentials live only in `.env`.".to_string(),
     }
+}
+
+/// The control-plane bullet under Tooling; empty for non-cloud databases.
+fn control_plane_hint(facts: &SkillFacts) -> String {
+    let Some(cloud) = facts.cloud else {
+        return String::new();
+    };
+    let profile = cloud
+        .profile
+        .as_deref()
+        .map(|p| format!(" -p {p}"))
+        .unwrap_or_default();
+    format!(
+        "\n- Control plane (subscription, plan, memory use, modules): `redisctl api cloud get {base}/{sub}/databases/{db}{profile}`. That response contains the database password - never copy it into a file, a log, or chat; `.env` already has it.",
+        base = cloud.tier.api_base(),
+        sub = cloud.subscription_id,
+        db = cloud.database_id,
+    )
 }
 
 fn skills_hint(facts: &SkillFacts) -> String {
@@ -143,7 +171,7 @@ file.
 {db}
 
 ## Tooling
-- An MCP server named `redis` is registered in the project's agent configs (it reads `REDIS_URL` from `.env` at launch). Prefer its tools to inspect keys, search, and manipulate data instead of shelling out.
+- An MCP server named `redis` is registered in the project's agent configs (it reads `REDIS_URL` from `.env` at launch). Prefer its tools to inspect keys, search, and manipulate data instead of shelling out.{control_plane}
 {skills}
 
 ## Conventions
@@ -156,6 +184,7 @@ file.
 "#,
         client = client_hint(facts),
         db = db_hint(facts),
+        control_plane = control_plane_hint(facts),
         skills = skills_hint(facts),
         handy = handy_commands(facts),
     )
@@ -280,12 +309,56 @@ mod tests {
         SkillFacts {
             runtime: Runtime::Node,
             name: None,
+            cloud: None,
             container,
             skills,
             client_installed: true,
             cli_available: true,
             docker: true,
         }
+    }
+
+    fn cloud_facts(tier: crate::CloudTier, profile: Option<&str>) -> crate::CloudFacts {
+        crate::CloudFacts {
+            name: "cloud-db".to_string(),
+            subscription_id: "1".to_string(),
+            database_id: "9".to_string(),
+            tier,
+            profile: profile.map(str::to_string),
+            created: false,
+        }
+    }
+
+    #[test]
+    fn cloud_facts_carry_ids_and_the_control_plane_command() {
+        let cloud = cloud_facts(crate::CloudTier::Essentials, None);
+        let mut f = facts(None, &[]);
+        f.cloud = Some(&cloud);
+        let text = content(&f);
+        assert!(
+            text.contains("`cloud-db` on Redis Cloud: Essentials subscription `1`, database `9`"),
+            "{text}"
+        );
+        assert!(
+            text.contains("redisctl api cloud get /fixed/subscriptions/1/databases/9`"),
+            "{text}"
+        );
+        assert!(text.contains("never copy it into a file"), "{text}");
+        // Credential-free invariant holds on the cloud path too.
+        assert!(!text.contains("redis://"), "{text}");
+    }
+
+    #[test]
+    fn flexible_databases_use_the_pro_api_path_and_name_the_profile() {
+        let cloud = cloud_facts(crate::CloudTier::Flexible, Some("qa"));
+        let mut f = facts(None, &[]);
+        f.cloud = Some(&cloud);
+        let text = content(&f);
+        assert!(text.contains("Flexible subscription `1`"), "{text}");
+        assert!(
+            text.contains("redisctl api cloud get /subscriptions/1/databases/9 -p qa`"),
+            "{text}"
+        );
     }
 
     #[test]

--- a/crates/redisctl-init/src/util.rs
+++ b/crates/redisctl-init/src/util.rs
@@ -52,7 +52,7 @@ fn run(command: &mut std::process::Command) -> ShOutput {
 }
 
 /// Lowercase, runs of anything non-alphanumeric collapsed to one dash, edges trimmed.
-pub(crate) fn slug(s: &str) -> String {
+pub fn slug(s: &str) -> String {
     let mut out = String::new();
     for c in s.to_lowercase().chars() {
         if c.is_ascii_alphanumeric() {

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 rpassword = { workspace = true }
 url = { workspace = true }
+hickory-resolver = { workspace = true }
 urlencoding = { workspace = true }
 dialoguer = "0.11"
 colored = "2.1"

--- a/crates/redisctl/src/cli/init.rs
+++ b/crates/redisctl/src/cli/init.rs
@@ -24,7 +24,17 @@ pub struct InitArgs {
     #[arg(long, value_name = "REDIS_URL")]
     pub url: Option<String>,
 
-    /// Database name, recorded in the generated project skill
+    /// Take the database from Redis Cloud instead of local Docker: reuse the
+    /// database named by --name, or create one on the free Essentials plan
+    #[arg(long, conflicts_with = "url")]
+    pub cloud: bool,
+
+    /// Create in this Essentials subscription instead of the free plan
+    #[arg(long, value_name = "ID", requires = "cloud")]
+    pub cloud_subscription: Option<i32>,
+
+    /// Database name, recorded in the generated project skill; with --cloud it is
+    /// also the reuse key: a database already carrying it is connected, not created
     #[arg(long, value_name = "LABEL")]
     pub name: Option<String>,
 
@@ -73,6 +83,8 @@ impl std::fmt::Debug for InitArgs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InitArgs")
             .field("url", &self.url.as_ref().map(|_| "<redacted>"))
+            .field("cloud", &self.cloud)
+            .field("cloud_subscription", &self.cloud_subscription)
             .field("name", &self.name)
             .field("agents", &self.agents)
             .field("defaults", &self.defaults)
@@ -93,6 +105,8 @@ mod tests {
     fn debug_never_prints_url_or_paste_content() {
         let args = InitArgs {
             url: Some("redis://default:s3cret@h:1".into()),
+            cloud: false,
+            cloud_subscription: None,
             name: Some("db".into()),
             agents: vec![AgentArg::Claude],
             defaults: false,

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -564,7 +564,9 @@ async fn execute_command(cli: &Cli, conn_mgr: &ConnectionManager) -> Result<(), 
 
         Commands::Db(db_cmd) => commands::db::handle_db_command(db_cmd, conn_mgr, cli.output).await,
 
-        Commands::Init(init_args) => workflows::init::run(init_args).await,
+        Commands::Init(init_args) => {
+            workflows::init::run(init_args, conn_mgr, cli.profile.as_deref()).await
+        }
     };
 
     let duration = start.elapsed();

--- a/crates/redisctl/src/workflows/init/cloud.rs
+++ b/crates/redisctl/src/workflows/init/cloud.rs
@@ -1,0 +1,673 @@
+//! The `--cloud` path: resolve a Redis Cloud database before the engine plans.
+//!
+//! Inventory spans both tiers and reuse is strictly by name; the picker and the
+//! free-tier bookkeeping live here. Creation is delegated to the shared
+//! `quick_database` engine (which manages its own `redisctl-<name>` marker
+//! subscription), except under a `--cloud-subscription` pin, which creates
+//! directly in the pinned subscription.
+
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use dialoguer::Select;
+use redis_cloud::CloudClient;
+use redisctl_core::cloud::quick_database::{self, QuickDatabaseError, QuickDatabaseParams};
+use redisctl_init::{self as engine, Change, CloudFacts, CloudTier, Status};
+
+use super::output;
+use super::wizard::RedisTheme;
+use crate::error::RedisCtlError;
+
+/// Nothing real yet: the placeholder a dry run plans .env around, masked like a URL.
+const PLANNED_URL: &str = "redis://default:<generated>@<endpoint-assigned-by-redis-cloud>";
+
+pub(crate) struct CloudOutcome {
+    pub url: String,
+    pub facts: CloudFacts,
+    /// Ledger entries to lead the Changes block with.
+    pub changes: Vec<Change>,
+}
+
+struct Candidate {
+    sub_id: i32,
+    db_id: i32,
+    name: String,
+    tier: CloudTier,
+    endpoint: Option<String>,
+}
+
+struct Inventory {
+    candidates: Vec<Candidate>,
+    /// Where a create would land: the pin, or the free subscription with room.
+    target: Option<i32>,
+    /// The full free subscription (id, database names), when that is why there is no target.
+    free_full: Option<(i32, Vec<String>)>,
+}
+
+fn api_err(e: impl std::fmt::Display) -> RedisCtlError {
+    RedisCtlError::ApiError {
+        message: format!("Redis Cloud: {e}"),
+    }
+}
+
+fn other(message: String) -> RedisCtlError {
+    RedisCtlError::Other(message)
+}
+
+pub(crate) async fn resolve(
+    client: &CloudClient,
+    cwd: &Path,
+    name: Option<&str>,
+    pin: Option<i32>,
+    profile: Option<&str>,
+    dry: bool,
+    defaults: bool,
+) -> Result<CloudOutcome, RedisCtlError> {
+    let mut db_name = name.map(str::to_string).unwrap_or_else(|| {
+        engine::slug(
+            &cwd.file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+        )
+    });
+    let inv = inventory(client, pin).await?;
+
+    // Reuse strictly by name, across both tiers: a database already carrying the
+    // name is connected, never recreated. Live even under --dry-run (reads only).
+    if let Some(name) = name
+        && let Some(cand) = inv.candidates.iter().find(|c| c.name == name)
+    {
+        return connect(client, cand, profile).await;
+    }
+
+    // No name, databases exist: report the question (dry), ask (tty), refuse (piped).
+    if name.is_none() && !inv.candidates.is_empty() {
+        if dry {
+            let offered = inv
+                .candidates
+                .iter()
+                .map(|c| format!("\"{}\"", c.name))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Ok(planned(
+                &db_name,
+                inv.target,
+                profile,
+                Change::new(
+                    "cloud:choice",
+                    Status::Planned,
+                    format!("would offer {offered} or a new free database \"{db_name}\""),
+                ),
+            ));
+        }
+        // --defaults promised no prompts; there is no safe default among existing
+        // databases, so it gets the same listing the non-interactive path does.
+        if defaults || !std::io::stdin().is_terminal() {
+            return Err(other(listing(&inv)));
+        }
+        match pick(&inv, &db_name)? {
+            Pick::Existing(cand) => return connect(client, cand, profile).await,
+            Pick::Create(name) => db_name = name,
+        }
+    }
+
+    if dry {
+        let note = match inv.target {
+            Some(target) => {
+                format!("would create database \"{db_name}\" in Essentials subscription {target}")
+            }
+            None => format!("would create a free Essentials subscription + database \"{db_name}\""),
+        };
+        return Ok(planned(
+            &db_name,
+            inv.target,
+            profile,
+            Change::new(format!("cloud:{db_name}"), Status::Planned, note),
+        ));
+    }
+
+    // The free tier being used up has ways out; say them instead of relaying the
+    // create call's rejection.
+    if inv.target.is_none()
+        && let Some((id, names)) = &inv.free_full
+    {
+        let held = names
+            .iter()
+            .map(|n| format!("\"{n}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let first = names.first().map(String::as_str).unwrap_or("<name>");
+        return Err(other(format!(
+            "the free Essentials subscription ({id}) is full - it holds {held}, and Redis Cloud allows one free subscription per account.\n  Share that database:  --cloud --name {first}\n  Use a paid one:       --cloud-subscription <id>   (redisctl api cloud get /fixed/subscriptions lists them)\n  Stay local instead:   drop --cloud to provision Docker"
+        )));
+    }
+
+    match pin {
+        Some(pin) => create_pinned(client, &db_name, pin, profile).await,
+        None => create_free(client, &db_name, profile).await,
+    }
+}
+
+/// Record the reuse (before the endpoint poll, so a timeout still reports it),
+/// then wait for a usable URL.
+async fn connect(
+    client: &CloudClient,
+    cand: &Candidate,
+    profile: Option<&str>,
+) -> Result<CloudOutcome, RedisCtlError> {
+    let change = Change::new(
+        format!("cloud:{}", cand.name),
+        Status::Unchanged,
+        format!(
+            "database {} in {} subscription {}",
+            cand.db_id,
+            cand.tier.as_str(),
+            cand.sub_id
+        ),
+    );
+    let url = database_url(client, cand).await?;
+    Ok(CloudOutcome {
+        url,
+        facts: CloudFacts {
+            name: cand.name.clone(),
+            subscription_id: cand.sub_id.to_string(),
+            database_id: cand.db_id.to_string(),
+            tier: cand.tier,
+            profile: profile.map(str::to_string),
+            created: false,
+        },
+        changes: vec![change],
+    })
+}
+
+fn planned(
+    db_name: &str,
+    target: Option<i32>,
+    profile: Option<&str>,
+    change: Change,
+) -> CloudOutcome {
+    CloudOutcome {
+        url: PLANNED_URL.to_string(),
+        facts: CloudFacts {
+            name: db_name.to_string(),
+            subscription_id: target
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "<new>".to_string()),
+            database_id: "<new>".to_string(),
+            tier: CloudTier::Essentials,
+            profile: profile.map(str::to_string),
+            created: true,
+        },
+        changes: vec![change],
+    }
+}
+
+async fn inventory(client: &CloudClient, pin: Option<i32>) -> Result<Inventory, RedisCtlError> {
+    // A pinned subscription is the entire inventory, addressed as Essentials (the
+    // tier init creates in); free-tier bookkeeping never applies to it.
+    if let Some(pin) = pin {
+        return Ok(Inventory {
+            candidates: fixed_candidates(client, pin).await?,
+            target: Some(pin),
+            free_full: None,
+        });
+    }
+    let mut inv = Inventory {
+        candidates: Vec::new(),
+        target: None,
+        free_full: None,
+    };
+    let subs = client.fixed_subscriptions().list().await.map_err(api_err)?;
+    for sub in subs.subscriptions.unwrap_or_default() {
+        let Some(id) = sub.id else { continue };
+        let dbs = fixed_candidates(client, id).await?;
+        if sub.price == Some(0) {
+            if (dbs.len() as i32) < sub.maximum_databases.unwrap_or(1) {
+                inv.target = inv.target.or(Some(id));
+            } else if inv.free_full.is_none() {
+                inv.free_full = Some((id, dbs.iter().map(|c| c.name.clone()).collect()));
+            }
+        }
+        inv.candidates.extend(dbs);
+    }
+    let pro = client
+        .subscriptions()
+        .get_all_subscriptions()
+        .await
+        .map_err(api_err)?;
+    for sub in pro.subscriptions.unwrap_or_default() {
+        let Some(id) = sub.id else { continue };
+        inv.candidates.extend(pro_candidates(client, id).await?);
+    }
+    Ok(inv)
+}
+
+async fn fixed_candidates(
+    client: &CloudClient,
+    sub_id: i32,
+) -> Result<Vec<Candidate>, RedisCtlError> {
+    let payload = client
+        .fixed_databases()
+        .list(sub_id, None, None)
+        .await
+        .map_err(api_err)?;
+    Ok(payload
+        .subscription
+        .map(|info| info.databases)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|db| {
+            Some(Candidate {
+                sub_id,
+                db_id: db.database_id?,
+                name: db.name.clone().unwrap_or_default(),
+                tier: CloudTier::Essentials,
+                endpoint: db.public_endpoint.clone(),
+            })
+        })
+        .collect())
+}
+
+async fn pro_candidates(
+    client: &CloudClient,
+    sub_id: i32,
+) -> Result<Vec<Candidate>, RedisCtlError> {
+    let payload = client
+        .databases()
+        .get_subscription_databases(sub_id, None, None)
+        .await
+        .map_err(api_err)?;
+    Ok(payload
+        .subscription
+        .into_iter()
+        .flat_map(|info| info.databases)
+        .map(|db| Candidate {
+            sub_id,
+            db_id: db.database_id,
+            name: db.name.clone().unwrap_or_default(),
+            tier: CloudTier::Flexible,
+            endpoint: db.public_endpoint.clone(),
+        })
+        .collect())
+}
+
+fn describe(cand: &Candidate) -> String {
+    format!(
+        "{}  {}  {} subscription {}",
+        cand.name,
+        cand.endpoint.as_deref().unwrap_or("endpoint pending"),
+        cand.tier.as_str(),
+        cand.sub_id
+    )
+}
+
+/// The non-interactive answer to "which database?": name them and the flag to pick one.
+fn listing(inv: &Inventory) -> String {
+    let plural = if inv.candidates.len() == 1 { "" } else { "s" };
+    let mut lines = vec![format!(
+        "this account already has {} Redis Cloud database{plural}:",
+        inv.candidates.len()
+    )];
+    for (i, cand) in inv.candidates.iter().enumerate() {
+        lines.push(format!("  {}) {}", i + 1, describe(cand)));
+    }
+    lines.push("  Connect to one:  --cloud --name <its name>".to_string());
+    let mut create = "  Create another:  --cloud --name <a new name>".to_string();
+    if inv.target.is_none() {
+        create.push_str("   (the free plan is already used up)");
+    }
+    lines.push(create);
+    lines.join("\n")
+}
+
+/// `Ok(None)` means "create a new one"; Esc means no answer, which has a flag.
+enum Pick<'a> {
+    Existing(&'a Candidate),
+    Create(String),
+}
+
+/// Mirrors `quick_database`'s private `validate_name` (PRD §5.1.1): 3-40 chars of
+/// `[a-z0-9-]`, starting with a lowercase letter, ending alphanumeric, no `--`.
+fn valid_db_name(name: &str) -> Result<(), String> {
+    let bytes = name.as_bytes();
+    let ok = (3..=40).contains(&name.len())
+        && bytes[0].is_ascii_lowercase()
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[bytes.len() - 1].is_ascii_alphanumeric()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && !name.contains("--");
+    if ok {
+        Ok(())
+    } else {
+        Err(
+            "3-40 lowercase letters, digits or hyphens; starts with a letter, ends alphanumeric, no \"--\""
+                .to_string(),
+        )
+    }
+}
+
+/// Registered with `wizard::is_wizard_prompt`, so cancelling gets wizard tips.
+pub(crate) const PICKER_PROMPT: &str = "Redis Cloud - this account already has databases";
+
+fn pick<'a>(inv: &'a Inventory, db_name: &str) -> Result<Pick<'a>, RedisCtlError> {
+    let mut items: Vec<String> = inv.candidates.iter().map(describe).collect();
+    // An unavailable create stays on the list carrying the reason (the wizard's
+    // pattern); choosing it re-prompts instead of aborting the session.
+    let mut create = "create a new free database".to_string();
+    if inv.target.is_none() {
+        create.push_str("   (unavailable: the free plan is already used up)");
+    }
+    items.push(create);
+    loop {
+        let selection = Select::with_theme(&RedisTheme)
+            .with_prompt(PICKER_PROMPT)
+            .items(&items)
+            .default(0)
+            .interact_opt()
+            .map_err(|e| RedisCtlError::Other(format!("prompt failed: {e}")))?;
+        match selection {
+            None => {
+                return Err(RedisCtlError::Cancelled {
+                    prompt: PICKER_PROMPT.to_string(),
+                });
+            }
+            Some(i) if i < inv.candidates.len() => return Ok(Pick::Existing(&inv.candidates[i])),
+            Some(_) if inv.target.is_none() => {
+                eprintln!(
+                    "  The free plan is already used up - connect to an existing database, or press Esc and re-run with --cloud-subscription <id>."
+                );
+            }
+            Some(_) => {
+                let name: String = dialoguer::Input::with_theme(&RedisTheme)
+                    .with_prompt("Name for the new database")
+                    .default(db_name.to_string())
+                    .validate_with(|input: &String| valid_db_name(input))
+                    .interact_text()
+                    .map_err(|e| RedisCtlError::Other(format!("prompt failed: {e}")))?;
+                return Ok(Pick::Create(name));
+            }
+        }
+    }
+}
+
+/// Poll the single-database endpoint (the only response carrying the password)
+/// until it is usable. The create task reports success seconds before the endpoint
+/// exists, hence the wait.
+async fn database_url(client: &CloudClient, cand: &Candidate) -> Result<String, RedisCtlError> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(180);
+    let mut progress: Option<output::Progress> = None;
+    loop {
+        let (endpoint, password, tls, default_disabled, status) = match cand.tier {
+            CloudTier::Essentials => {
+                let db = client
+                    .fixed_databases()
+                    .get_by_id(cand.sub_id, cand.db_id)
+                    .await
+                    .map_err(api_err)?;
+                let sec = db.security.as_ref();
+                (
+                    db.public_endpoint.clone(),
+                    sec.and_then(|s| s.password.clone()),
+                    sec.and_then(|s| s.enable_tls),
+                    sec.and_then(|s| s.default_user_enabled) == Some(false),
+                    db.status.clone(),
+                )
+            }
+            CloudTier::Flexible => {
+                let db = client
+                    .databases()
+                    .get_subscription_database_by_id(cand.sub_id, cand.db_id)
+                    .await
+                    .map_err(api_err)?;
+                let sec = db.security.as_ref();
+                (
+                    db.public_endpoint.clone(),
+                    sec.and_then(|s| s.password.clone()),
+                    sec.and_then(|s| s.enable_tls),
+                    sec.and_then(|s| s.enable_default_user) == Some(false),
+                    db.status.clone(),
+                )
+            }
+        };
+        if let Some(endpoint) = &endpoint
+            && (password.is_some() || default_disabled)
+        {
+            if let Some(progress) = progress.as_mut() {
+                progress.done(" ready");
+            }
+            let scheme = if tls == Some(true) { "rediss" } else { "redis" };
+            return Ok(match password {
+                Some(password) => format!(
+                    "{scheme}://default:{}@{endpoint}",
+                    urlencoding::encode(&password)
+                ),
+                None => format!("{scheme}://{endpoint}"),
+            });
+        }
+        let last_status = status.unwrap_or_else(|| "unknown".to_string());
+        if progress.is_none() {
+            progress = Some(output::progress("waiting for the endpoint to come up"));
+        }
+        if std::time::Instant::now() >= deadline {
+            if let Some(progress) = progress.as_mut() {
+                progress.done("");
+            }
+            return Err(other(format!(
+                "Redis Cloud database {}{}/databases/{} exposed no endpoint within 180s (status: {last_status}).\n  It is provisioned - re-run the same command once it is active.",
+                cand.tier.api_base(),
+                cand.sub_id,
+                cand.db_id
+            )));
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+}
+
+/// The engine writes credentials to a file and never returns them; hand it a
+/// private scratch file and read the URL back.
+struct TempCredentials(PathBuf);
+
+impl TempCredentials {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!("redisctl-init-{}.env", std::process::id()));
+        // A leftover from a crashed run would fail the engine's create_new open.
+        let _ = std::fs::remove_file(&path);
+        Self(path)
+    }
+
+    fn read_url(&self) -> Result<String, RedisCtlError> {
+        let text = std::fs::read_to_string(&self.0)
+            .map_err(|e| other(format!("could not read provisioned credentials back: {e}")))?;
+        text.lines()
+            .find_map(|line| line.strip_prefix("REDIS_URL="))
+            .map(str::to_string)
+            .ok_or_else(|| other("provisioned credentials carry no REDIS_URL".to_string()))
+    }
+}
+
+impl Drop for TempCredentials {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+async fn marker_subscription(
+    client: &CloudClient,
+    db_name: &str,
+) -> Result<Option<i32>, RedisCtlError> {
+    let marker = format!("redisctl-{db_name}");
+    let subs = client.fixed_subscriptions().list().await.map_err(api_err)?;
+    Ok(subs
+        .subscriptions
+        .unwrap_or_default()
+        .into_iter()
+        .find(|s| {
+            s.name
+                .as_deref()
+                .is_some_and(|n| n.eq_ignore_ascii_case(&marker))
+        })
+        .and_then(|s| s.id))
+}
+
+fn quick_err(e: QuickDatabaseError) -> RedisCtlError {
+    match e {
+        QuickDatabaseError::InvalidName(msg) => RedisCtlError::InvalidInput { message: msg },
+        other_err => other(other_err.to_string()),
+    }
+}
+
+/// Free-plan creation, delegated to the shared engine (idempotent via its
+/// `redisctl-<name>` subscription marker).
+async fn create_free(
+    client: &CloudClient,
+    db_name: &str,
+    profile: Option<&str>,
+) -> Result<CloudOutcome, RedisCtlError> {
+    let sub_existed = marker_subscription(client, db_name).await?;
+    let temp = TempCredentials::new();
+    let params = QuickDatabaseParams {
+        output_credentials: temp.0.clone(),
+        ..QuickDatabaseParams::new(db_name)
+    };
+    let mut progress = output::progress(&format!(
+        "creating free Essentials database \"{db_name}\" on Redis Cloud"
+    ));
+    let report = match quick_database::provision(client, &params).await {
+        Ok(report) => {
+            progress.done(" done");
+            report
+        }
+        Err(e) => {
+            progress.done(" failed");
+            return Err(quick_err(e));
+        }
+    };
+    let url = temp.read_url()?;
+    let sub_id = marker_subscription(client, db_name)
+        .await?
+        .ok_or_else(|| other("the created subscription is not listed yet - re-run".to_string()))?;
+    let mut changes = Vec::new();
+    if sub_existed.is_none() {
+        changes.push(Change::new(
+            format!("cloud:subscription/{sub_id}"),
+            Status::Created,
+            "free Essentials plan",
+        ));
+    }
+    let created = report.status != "reused";
+    changes.push(Change::new(
+        format!("cloud:{db_name}"),
+        if created {
+            Status::Created
+        } else {
+            Status::Unchanged
+        },
+        format!(
+            "database {} in Essentials subscription {sub_id}",
+            report.database.id
+        ),
+    ));
+    Ok(CloudOutcome {
+        url,
+        facts: CloudFacts {
+            name: db_name.to_string(),
+            subscription_id: sub_id.to_string(),
+            database_id: report.database.id.clone(),
+            tier: CloudTier::Essentials,
+            profile: profile.map(str::to_string),
+            created,
+        },
+        changes,
+    })
+}
+
+/// A pinned subscription is created into directly; the engine only manages its own
+/// marker subscription.
+async fn create_pinned(
+    client: &CloudClient,
+    db_name: &str,
+    pin: i32,
+    profile: Option<&str>,
+) -> Result<CloudOutcome, RedisCtlError> {
+    let mut progress = output::progress(&format!(
+        "creating database \"{db_name}\" in subscription {pin}"
+    ));
+    let request = redis_cloud::fixed::databases::FixedDatabaseCreateRequest::builder()
+        .name(db_name)
+        .build();
+    let result: Result<i32, RedisCtlError> = async {
+        let task = client
+            .fixed_databases()
+            .create(pin, &request)
+            .await
+            .map_err(api_err)?;
+        let task_id = task
+            .task_id
+            .ok_or_else(|| other("Redis Cloud returned no task id for the create".to_string()))?;
+        let completed = redisctl_core::poll_task(
+            client,
+            &task_id,
+            Duration::from_secs(600),
+            Duration::from_secs(5),
+            None,
+        )
+        .await
+        .map_err(|e| other(format!("create task failed: {e}")))?;
+        completed
+            .response
+            .and_then(|r| r.resource_id)
+            .ok_or_else(|| other("Redis Cloud created no database id".to_string()))
+    }
+    .await;
+    let db_id = match result {
+        Ok(id) => {
+            progress.done(" done");
+            id
+        }
+        Err(e) => {
+            progress.done(" failed");
+            return Err(e);
+        }
+    };
+    let cand = Candidate {
+        sub_id: pin,
+        db_id,
+        name: db_name.to_string(),
+        tier: CloudTier::Essentials,
+        endpoint: None,
+    };
+    let url = database_url(client, &cand).await?;
+    Ok(CloudOutcome {
+        url,
+        facts: CloudFacts {
+            name: db_name.to_string(),
+            subscription_id: pin.to_string(),
+            database_id: db_id.to_string(),
+            tier: CloudTier::Essentials,
+            profile: profile.map(str::to_string),
+            created: true,
+        },
+        changes: vec![Change::new(
+            format!("cloud:{db_name}"),
+            Status::Created,
+            format!("database {db_id} in Essentials subscription {pin}"),
+        )],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::valid_db_name;
+
+    #[test]
+    fn name_rule_mirror_accepts_and_rejects_like_the_engine() {
+        assert!(valid_db_name("ask-bot-3").is_ok());
+        for bad in ["ab", "3abc", "Abc", "ab_c", "a--b", "abc-"] {
+            assert!(valid_db_name(bad).is_err(), "{bad} should be rejected");
+        }
+        assert!(valid_db_name(&"a".repeat(41)).is_err());
+    }
+}

--- a/crates/redisctl/src/workflows/init/cloud.rs
+++ b/crates/redisctl/src/workflows/init/cloud.rs
@@ -3,8 +3,7 @@
 //! Inventory spans both tiers and reuse is strictly by name; the picker and the
 //! free-tier bookkeeping live here. Creation is delegated to the shared
 //! `quick_database` engine (which manages its own `redisctl-<name>` marker
-//! subscription), except under a `--cloud-subscription` pin, which creates
-//! directly in the pinned subscription.
+//! subscription). A pinned or available free subscription is created into directly.
 
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
@@ -143,8 +142,8 @@ pub(crate) async fn resolve(
         )));
     }
 
-    match pin {
-        Some(pin) => create_pinned(client, &db_name, pin, profile).await,
+    match inv.target {
+        Some(target) => create_pinned(client, &db_name, target, profile).await,
         None => create_free(client, &db_name, profile).await,
     }
 }
@@ -314,7 +313,7 @@ fn listing(inv: &Inventory) -> String {
     }
     lines.push("  Connect to one:  --cloud --name <its name>".to_string());
     let mut create = "  Create another:  --cloud --name <a new name>".to_string();
-    if inv.target.is_none() {
+    if inv.target.is_none() && inv.free_full.is_some() {
         create.push_str("   (the free plan is already used up)");
     }
     lines.push(create);
@@ -357,7 +356,7 @@ fn pick<'a>(inv: &'a Inventory, db_name: &str) -> Result<Pick<'a>, RedisCtlError
     // An unavailable create stays on the list carrying the reason (the wizard's
     // pattern); choosing it re-prompts instead of aborting the session.
     let mut create = "create a new free database".to_string();
-    if inv.target.is_none() {
+    if inv.target.is_none() && inv.free_full.is_some() {
         create.push_str("   (unavailable: the free plan is already used up)");
     }
     items.push(create);
@@ -375,7 +374,7 @@ fn pick<'a>(inv: &'a Inventory, db_name: &str) -> Result<Pick<'a>, RedisCtlError
                 });
             }
             Some(i) if i < inv.candidates.len() => return Ok(Pick::Existing(&inv.candidates[i])),
-            Some(_) if inv.target.is_none() => {
+            Some(_) if inv.target.is_none() && inv.free_full.is_some() => {
                 eprintln!(
                     "  The free plan is already used up - connect to an existing database, or press Esc and re-run with --cloud-subscription <id>."
                 );
@@ -584,8 +583,7 @@ async fn create_free(
     })
 }
 
-/// A pinned subscription is created into directly; the engine only manages its own
-/// marker subscription.
+/// Create directly in the selected Essentials subscription.
 async fn create_pinned(
     client: &CloudClient,
     db_name: &str,

--- a/crates/redisctl/src/workflows/init/dns.rs
+++ b/crates/redisctl/src/workflows/init/dns.rs
@@ -1,0 +1,184 @@
+//! DNS readiness for freshly published cloud endpoints.
+//!
+//! A new database's hostname can lag its API "active" status by a minute, and the
+//! cloud zones tell resolvers to cache a failed lookup for up to 30 minutes - so a
+//! single premature lookup through the OS resolver poisons every later attempt.
+//! This gate asks the zone's authoritative server directly (no cache anywhere in
+//! the path) and only lets the run proceed to a normal connect once the record
+//! exists. Any infrastructure hiccup here degrades to proceeding; validation still
+//! reports the truth.
+
+use std::net::IpAddr;
+use std::time::Duration;
+
+use hickory_resolver::TokioResolver;
+use hickory_resolver::config::{ConnectionConfig, NameServerConfig, ResolverConfig};
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
+use hickory_resolver::proto::rr::{RData, RecordType};
+
+use super::output;
+
+const DEADLINE: Duration = Duration::from_secs(150);
+const POLL: Duration = Duration::from_secs(3);
+
+/// Loopback and literal addresses never need a record.
+fn needs_gate(host: &str) -> bool {
+    host.parse::<IpAddr>().is_err() && host != "localhost"
+}
+
+/// The candidate zones a host could live in, most specific first, never shorter
+/// than two labels ("db-qa.redis.io" -> ["db-qa.redis.io", "redis.io"]).
+fn zone_candidates(host: &str) -> Vec<String> {
+    let labels: Vec<&str> = host.split('.').filter(|l| !l.is_empty()).collect();
+    (1..labels.len().saturating_sub(1))
+        .map(|i| labels[i..].join("."))
+        .collect()
+}
+
+fn host_of(url: &str) -> Option<String> {
+    Some(url::Url::parse(url).ok()?.host_str()?.to_string())
+}
+
+/// Whether a validation failure is a name-resolution failure (as opposed to a
+/// refused/timed-out connection): Rust's lookup errors carry this prefix on every
+/// platform.
+pub(crate) fn is_dns_error(error: &str) -> bool {
+    error.contains("failed to lookup address")
+        || error.contains("nodename nor servname")
+        || error.contains("Name or service not known")
+}
+
+/// A resolver pointed straight at one of the zone's authoritative servers, with
+/// caching off - answers reflect the zone right now. Discovery goes through NS
+/// records, not SOA: filtering resolvers (observed on a corporate network) drop
+/// SOA queries but answer NS.
+async fn authoritative_resolver(host: &str) -> Option<TokioResolver> {
+    let system = TokioResolver::builder_tokio().ok()?.build().ok()?;
+    for zone in zone_candidates(host) {
+        let Ok(ns) = system.lookup(zone.as_str(), RecordType::NS).await else {
+            continue;
+        };
+        let Some(ns_name) = ns.answers().iter().find_map(|record| match &record.data {
+            RData::NS(name) => Some(name.0.to_utf8()),
+            _ => None,
+        }) else {
+            continue;
+        };
+        // IPv4 only: v6 routes are absent on enough networks that a v6-first
+        // answer would read as the record not existing.
+        let ns_ip = system
+            .lookup_ip(ns_name.as_str())
+            .await
+            .ok()?
+            .iter()
+            .find(|ip| ip.is_ipv4())?;
+        let config = ResolverConfig::from_parts(
+            None,
+            Vec::new(),
+            vec![NameServerConfig::new(
+                ns_ip,
+                false,
+                vec![ConnectionConfig::udp()],
+            )],
+        );
+        let mut builder =
+            TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
+        builder.options_mut().cache_size = 0;
+        builder.options_mut().attempts = 1;
+        return builder.build().ok();
+    }
+    None
+}
+
+/// Any answer counts as published - an A record directly (what the cloud zones
+/// serve), or a CNAME the recursive resolvers will chase once it exists.
+async fn resolves(resolver: &TokioResolver, host: &str) -> bool {
+    resolver
+        .lookup(host, RecordType::A)
+        .await
+        .map(|answer| !answer.answers().is_empty())
+        .unwrap_or(false)
+}
+
+/// Block until the endpoint's DNS record is visible on the authoritative server,
+/// bounded by [`DEADLINE`]. Called on cloud-resolved URLs only: a user-pasted URL
+/// must keep failing fast when its host is stale.
+pub(crate) async fn wait_for_endpoint_dns(url: &str) {
+    let Some(host) = host_of(url) else { return };
+    if !needs_gate(&host) {
+        return;
+    }
+    let Some(resolver) = authoritative_resolver(&host).await else {
+        return;
+    };
+    if resolves(&resolver, &host).await {
+        return;
+    }
+    let mut progress =
+        output::progress("waiting for the database's DNS record (new endpoints take a moment)");
+    let deadline = tokio::time::Instant::now() + DEADLINE;
+    loop {
+        tokio::time::sleep(POLL).await;
+        if resolves(&resolver, &host).await {
+            progress.done(" ready");
+            return;
+        }
+        if tokio::time::Instant::now() > deadline {
+            progress.done(" still not visible - validation may fail");
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn literal_addresses_and_localhost_skip_the_gate() {
+        assert!(!needs_gate("127.0.0.1"));
+        assert!(!needs_gate("::1"));
+        assert!(!needs_gate("localhost"));
+        assert!(needs_gate("brand-new-63625.db-qa.redis.io"));
+    }
+
+    #[test]
+    fn zone_candidates_walk_up_but_stop_above_the_tld() {
+        assert_eq!(
+            zone_candidates("db-1.db-qa.redis.io"),
+            vec!["db-qa.redis.io", "redis.io"]
+        );
+        assert!(zone_candidates("redis.io").is_empty());
+    }
+
+    #[test]
+    fn hosts_come_out_of_credentialed_urls() {
+        assert_eq!(
+            host_of("redis://default:pw@x-1.db-qa.redis.io:12871").as_deref(),
+            Some("x-1.db-qa.redis.io")
+        );
+        assert_eq!(host_of("redis://127.0.0.1:9").as_deref(), Some("127.0.0.1"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network (live authoritative DNS query)"]
+    async fn a_published_record_passes_the_gate_quickly() {
+        // A host with a direct A record at its zone's authority - the same shape
+        // the cloud endpoint zones serve.
+        let resolver = authoritative_resolver("www.cloudflare.com")
+            .await
+            .expect("resolver");
+        assert!(resolves(&resolver, "www.cloudflare.com").await);
+    }
+
+    #[test]
+    fn dns_errors_are_told_apart_from_refused_connections() {
+        assert!(is_dns_error(
+            "failed to lookup address information: nodename nor servname provided, or not known"
+        ));
+        assert!(is_dns_error(
+            "failed to lookup address information: Name or service not known"
+        ));
+        assert!(!is_dns_error("Connection refused (os error 61)"));
+    }
+}

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -5,6 +5,7 @@
 //! rendering. The decisions live in the `redisctl-init` engine crate.
 
 mod cloud;
+mod dns;
 mod output;
 pub(crate) mod wizard;
 
@@ -155,6 +156,9 @@ pub async fn run(
             args.defaults,
         )
         .await?;
+        // A freshly published endpoint's DNS can lag the API; gate before any
+        // OS-resolver lookup so a premature failure never gets negative-cached.
+        dns::wait_for_endpoint_dns(&outcome.url).await;
         options.url_input = Some(outcome.url);
         options.cloud = Some(outcome.facts);
         cloud_changes = outcome.changes;
@@ -257,9 +261,16 @@ pub async fn run(
         ),
         Err(e) => {
             println!("{} {e}", output::red("✗"));
+            // A name that does not resolve is almost never stale input - it is a
+            // record still propagating, or an OS cache remembering the gap.
+            let remedy = if dns::is_dns_error(&e) {
+                "The endpoint's DNS record may still be propagating (new databases can take a minute) - wait a moment and re-run.\n  macOS caches failed lookups; clear with: sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder"
+            } else {
+                "If this URL is stale, remove REDIS_URL from .env and re-run, or pass --url."
+            };
             return Err(RedisCtlError::ConnectionError {
                 message: format!(
-                    "could not talk to Redis at {}\n  If this URL is stale, remove REDIS_URL from .env and re-run, or pass --url.",
+                    "could not talk to Redis at {}\n  {remedy}",
                     engine::mask_url(plan.database_url())
                 ),
             });

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -4,6 +4,7 @@
 //! This module owns only the CLI surface: argument shaping, banner, colours, and
 //! rendering. The decisions live in the `redisctl-init` engine crate.
 
+mod cloud;
 mod output;
 pub(crate) mod wizard;
 
@@ -34,7 +35,11 @@ fn requested_agents(flags: &[AgentArg]) -> Option<Vec<engine::Agent>> {
     )
 }
 
-pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
+pub async fn run(
+    args: &InitArgs,
+    conn_mgr: &crate::connection::ConnectionManager,
+    profile: Option<&str>,
+) -> Result<(), RedisCtlError> {
     let pasted = [args.url.clone().unwrap_or_default()]
         .into_iter()
         .chain(args.pasted.iter().cloned())
@@ -53,6 +58,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         cwd: cwd.clone(),
         name: args.name.clone(),
         url_input,
+        cloud: None,
         agents: requested_agents(&args.agents),
         install_cli: !args.no_install_cli,
         skills_repo: args.skills_repo.clone(),
@@ -90,6 +96,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
 
     let pending = wizard::pending_questions(args, options.url_input.is_some());
     let mut asked_agents = false;
+    let mut wants_cloud = args.cloud;
     if wizard::applies(args, &pending) {
         let answers = wizard::run(
             &pending,
@@ -99,6 +106,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         if let Some(url) = answers.url {
             options.url_input = Some(url);
         }
+        wants_cloud = wants_cloud || answers.cloud;
         if let Some(agents) = answers.agents {
             options.agents = Some(agents);
             asked_agents = true;
@@ -106,6 +114,50 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         if let Some(global) = answers.skills_global {
             options.skills_global = global;
         }
+    }
+    // Never-clobber means a freshly provisioned database could never be recorded
+    // in .env; keep the existing value instead of creating one the project would
+    // not use (and burning the free-plan slot).
+    if wants_cloud && engine::read_env_key(&cwd, ".env", "REDIS_URL").is_some() {
+        println!(
+            "{}",
+            yellow(
+                "  note: .env already carries REDIS_URL - keeping it (init never overwrites credentials). Remove that line to take the database from Redis Cloud.\n"
+            )
+        );
+        wants_cloud = false;
+    }
+    let mut cloud_changes = Vec::new();
+    if wants_cloud {
+        // A missing profile has one fix worth naming here; other client errors
+        // keep their own classification.
+        let client = conn_mgr.create_cloud_client(profile).await.map_err(|e| {
+            if matches!(
+                e,
+                RedisCtlError::NoProfileConfigured { .. }
+                    | RedisCtlError::MissingCredentials { .. }
+                    | RedisCtlError::ProfileNotFound { .. }
+            ) {
+                RedisCtlError::Other(format!(
+                    "{e}\n  Sign in first: redisctl cloud auth login   (or pass -p <profile> with API keys)"
+                ))
+            } else {
+                e
+            }
+        })?;
+        let outcome = cloud::resolve(
+            &client,
+            &cwd,
+            args.name.as_deref(),
+            args.cloud_subscription,
+            profile,
+            dry,
+            args.defaults,
+        )
+        .await?;
+        options.url_input = Some(outcome.url);
+        options.cloud = Some(outcome.facts);
+        cloud_changes = outcome.changes;
     }
     let plan = engine::plan(&options)?;
 
@@ -160,7 +212,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
             bold("Plan"),
             dim(&format!("({})", subject(false)))
         );
-        for change in plan.changes() {
+        for change in cloud_changes.iter().cloned().chain(plan.changes()) {
             println!("{}", output::change_line(&change));
         }
         uvx_note(&plan);
@@ -189,7 +241,7 @@ pub async fn run(args: &InitArgs) -> Result<(), RedisCtlError> {
         bold("Changes"),
         dim(&format!("({})", subject(true)))
     );
-    for change in &report.changes {
+    for change in cloud_changes.iter().chain(report.changes.iter()) {
         println!("{}", output::change_line(change));
     }
     uvx_note(&plan);

--- a/crates/redisctl/src/workflows/init/wizard.rs
+++ b/crates/redisctl/src/workflows/init/wizard.rs
@@ -15,7 +15,7 @@ use crate::error::RedisCtlError;
 /// A clack-style rail in brand red: `│` down the side, `◆` while a question is
 /// live, `◇` once answered. The colour index matches the banner's 256-colour
 /// fallback tone.
-struct RedisTheme;
+pub(crate) struct RedisTheme;
 
 fn brand() -> Style {
     Style::new().color256(203)
@@ -150,7 +150,7 @@ pub(crate) fn is_wizard_prompt(prompt: &str) -> bool {
     matches!(
         prompt,
         DATABASE_PROMPT | AGENTS_PROMPT | SKILLS_PROMPT | INTERRUPTED
-    )
+    ) || prompt == super::cloud::PICKER_PROMPT
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -163,7 +163,7 @@ pub enum Question {
 /// A question is worth asking only when no flag has already answered it.
 pub fn pending_questions(args: &InitArgs, url_given: bool) -> Vec<Question> {
     let mut pending = Vec::new();
-    if !url_given {
+    if !url_given && !args.cloud {
         pending.push(Question::Database);
     }
     if args.agents.is_empty() {
@@ -183,6 +183,7 @@ pub fn applies(args: &InitArgs, pending: &[Question]) -> bool {
 #[derive(Default)]
 pub struct Answers {
     pub url: Option<String>,
+    pub cloud: bool,
     pub agents: Option<Vec<engine::Agent>>,
     pub skills_global: Option<bool>,
 }
@@ -212,7 +213,11 @@ pub fn run(
     let mut answers = Answers::default();
     for question in pending {
         match question {
-            Question::Database => answers.url = ask_database(docker)?,
+            Question::Database => match ask_database(docker)? {
+                DatabaseChoice::Docker => {}
+                DatabaseChoice::Cloud => answers.cloud = true,
+                DatabaseChoice::Url(url) => answers.url = Some(url),
+            },
             Question::Agents => answers.agents = Some(ask_agents(detected)?),
             Question::Skills => answers.skills_global = Some(ask_skills_scope()?),
         }
@@ -220,8 +225,15 @@ pub fn run(
     Ok(answers)
 }
 
-/// `Ok(None)` means the local Docker default; a paste comes back as the URL.
-fn ask_database(docker: bool) -> Result<Option<String>, RedisCtlError> {
+enum DatabaseChoice {
+    Docker,
+    Cloud,
+    Url(String),
+}
+
+/// Docker is the default; Redis Cloud routes into the cloud flow; a paste comes
+/// back as the URL.
+fn ask_database(docker: bool) -> Result<DatabaseChoice, RedisCtlError> {
     const PROMPT: &str = DATABASE_PROMPT;
     // An option that cannot work stays on the list carrying the reason - the same
     // information the error would deliver after the run, shown before it instead.
@@ -230,12 +242,14 @@ fn ask_database(docker: bool) -> Result<Option<String>, RedisCtlError> {
     } else {
         "Local Docker container  (Docker is not running)"
     };
-    let items = [docker_item, "Paste a connection string"];
+    // No tier qualifier: the cloud flow connects to existing databases on any
+    // plan; only creating a new one defaults to the free Essentials plan.
+    let items = [docker_item, "Redis Cloud", "Paste a connection string"];
     loop {
         let selection = Select::with_theme(&RedisTheme)
             .with_prompt(PROMPT)
             .items(&items)
-            .default(if docker { 0 } else { 1 })
+            .default(if docker { 0 } else { 2 })
             .interact_opt()
             .map_err(prompt_failed)?;
         match selection {
@@ -243,7 +257,8 @@ fn ask_database(docker: bool) -> Result<Option<String>, RedisCtlError> {
             Some(0) if !docker => {
                 eprintln!("  Docker is not running - start it, or paste a connection string.");
             }
-            Some(0) => return Ok(None),
+            Some(0) => return Ok(DatabaseChoice::Docker),
+            Some(1) => return Ok(DatabaseChoice::Cloud),
             _ => break,
         }
     }
@@ -256,7 +271,7 @@ fn ask_database(docker: bool) -> Result<Option<String>, RedisCtlError> {
         })
         .interact_text()
         .map_err(prompt_failed)?;
-    Ok(Some(engine::extract_url(&pasted)?))
+    Ok(DatabaseChoice::Url(engine::extract_url(&pasted)?))
 }
 
 /// Detection preselects, it does not decide: having Cursor installed is not consent
@@ -313,6 +328,8 @@ mod tests {
     fn args() -> InitArgs {
         InitArgs {
             url: None,
+            cloud: false,
+            cloud_subscription: None,
             name: None,
             agents: Vec::new(),
             defaults: false,
@@ -322,6 +339,22 @@ mod tests {
             dry_run: false,
             pasted: Vec::new(),
         }
+    }
+
+    #[test]
+    fn the_cloud_picker_cancel_gets_wizard_tips() {
+        assert!(is_wizard_prompt(super::super::cloud::PICKER_PROMPT));
+        assert!(!is_wizard_prompt("Delete user 5?"));
+    }
+
+    #[test]
+    fn cloud_answers_the_database_question() {
+        let mut a = args();
+        a.cloud = true;
+        assert_eq!(
+            pending_questions(&a, false),
+            vec![Question::Agents, Question::Skills]
+        );
     }
 
     #[test]

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -217,6 +217,31 @@ fn dead_url_writes_env_then_fails_validation_with_the_stale_hint() {
 }
 
 #[test]
+fn a_dns_failure_gets_the_propagation_hint_not_the_stale_one() {
+    // .invalid is RFC-reserved: resolution always fails, distinguishing the DNS
+    // remedy from the refused-port stale-URL remedy the test above pins.
+    let dir = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    redisctl()
+        .current_dir(dir.path())
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
+        .args([
+            "init",
+            "--url",
+            "redis://no-such-host.invalid:6379",
+            "--no-install-cli",
+            "--agent",
+            "claude",
+        ])
+        .assert()
+        .code(10)
+        .stderr(predicate::str::contains(
+            "DNS record may still be propagating",
+        ))
+        .stderr(predicate::str::contains("remove REDIS_URL from .env").not());
+}
+
+#[test]
 fn rerun_with_a_url_reports_env_unchanged() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(

--- a/crates/redisctl/tests/init_cloud_tests.rs
+++ b/crates/redisctl/tests/init_cloud_tests.rs
@@ -1,0 +1,512 @@
+//! Hermetic tests for `redisctl init --cloud`: a wiremock CAPI plays Redis Cloud,
+//! and a minimal in-test RESP responder plays the provisioned database so the
+//! validation step exercises a real socket. No Docker, no network.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::json;
+use tempfile::TempDir;
+use wiremock::matchers::{body_partial_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const MOCK_PASSWORD: &str = "s3cr3t-mock-pw";
+
+fn write_cloud_profile(dir: &TempDir, api_url: &str) {
+    let config = format!(
+        r#"
+[profiles.test]
+deployment_type = "cloud"
+api_key = "test-api-key"
+api_secret = "test-api-secret"
+api_url = "{api_url}"
+
+default_cloud = "test"
+"#
+    );
+    std::fs::write(dir.path().join("config.toml"), config).unwrap();
+}
+
+fn skills_fixture() -> TempDir {
+    let repo = tempfile::tempdir().unwrap();
+    let skill = repo.path().join("skills/redis-basics");
+    std::fs::create_dir_all(&skill).unwrap();
+    std::fs::write(skill.join("SKILL.md"), "# basics\n").unwrap();
+    repo
+}
+
+/// Just enough RESP to pass init's validation (AUTH, PING, SET, GET, DEL).
+/// Returns the loopback port it serves on.
+fn fake_redis() -> u16 {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        use std::io::{BufRead, BufReader, Write};
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { break };
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut stream = stream;
+            let mut stored = String::new();
+            let mut line = String::new();
+            loop {
+                line.clear();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                if !line.starts_with('*') {
+                    continue;
+                }
+                let argc: usize = line[1..].trim().parse().unwrap_or(0);
+                let mut args = Vec::with_capacity(argc);
+                for _ in 0..argc {
+                    let mut len = String::new();
+                    let mut arg = String::new();
+                    if reader.read_line(&mut len).unwrap_or(0) == 0
+                        || reader.read_line(&mut arg).unwrap_or(0) == 0
+                    {
+                        break;
+                    }
+                    args.push(arg.trim_end().to_string());
+                }
+                let reply = match args.first().map(|c| c.to_ascii_uppercase()) {
+                    Some(cmd) if cmd == "PING" => "+PONG\r\n".to_string(),
+                    Some(cmd) if cmd == "SET" => {
+                        stored = args.get(2).cloned().unwrap_or_default();
+                        "+OK\r\n".to_string()
+                    }
+                    Some(cmd) if cmd == "GET" => {
+                        format!("${}\r\n{}\r\n", stored.len(), stored)
+                    }
+                    Some(cmd) if cmd == "DEL" => ":1\r\n".to_string(),
+                    _ => "+OK\r\n".to_string(),
+                };
+                if stream.write_all(reply.as_bytes()).is_err() {
+                    break;
+                }
+            }
+        }
+    });
+    port
+}
+
+/// Mount the account inventory: one free Essentials sub (1) holding
+/// `essentials-db` (9), one Flexible sub (2) holding `flexible-db` (42).
+async fn mount_both_tiers(server: &MockServer, endpoint: &str) {
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscriptions": [
+                { "id": 1, "name": "free", "price": 0, "maximumDatabases": 1 }
+            ]
+        })))
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions/1/databases"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscription": {
+                "subscriptionId": 1,
+                "databases": [
+                    { "databaseId": 9, "name": "essentials-db", "publicEndpoint": endpoint }
+                ]
+            }
+        })))
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions/1/databases/9"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "databaseId": 9, "name": "essentials-db", "publicEndpoint": endpoint,
+            "security": { "enableTls": false, "password": MOCK_PASSWORD }
+        })))
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscriptions": [ { "id": 2, "name": "paid" } ]
+        })))
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/subscriptions/2/databases"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscription": [ {
+                "subscriptionId": 2,
+                "databases": [
+                    { "databaseId": 42, "name": "flexible-db", "publicEndpoint": endpoint }
+                ]
+            } ]
+        })))
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/subscriptions/2/databases/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "databaseId": 42, "name": "flexible-db", "publicEndpoint": endpoint,
+            "security": { "enableTls": false, "password": MOCK_PASSWORD }
+        })))
+        .mount(server)
+        .await;
+}
+
+/// `redisctl --config-file <cfg> init --cloud <extra..>` in `dir`, offline-safe.
+fn run_init_cloud(cfg: &TempDir, dir: &std::path::Path, repo: &TempDir, extra: &[&str]) -> Command {
+    let mut cmd = Command::cargo_bin("redisctl").unwrap();
+    for var in [
+        "REDIS_CLOUD_API_KEY",
+        "REDIS_CLOUD_SECRET_KEY",
+        "REDIS_CLOUD_API_URL",
+        "REDISCTL_PROFILE",
+    ] {
+        cmd.env_remove(var);
+    }
+    cmd.current_dir(dir)
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
+        .arg("--config-file")
+        .arg(cfg.path().join("config.toml"))
+        .args(["init", "--cloud", "--no-install-cli"])
+        .args(extra);
+    cmd
+}
+
+#[test]
+fn cloud_and_url_are_mutually_exclusive() {
+    Command::cargo_bin("redisctl")
+        .unwrap()
+        .args(["init", "--cloud", "--url", "redis://h:1"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicates::str::contains("--url"));
+}
+
+#[test]
+fn cloud_subscription_requires_cloud() {
+    Command::cargo_bin("redisctl")
+        .unwrap()
+        .args(["init", "--cloud-subscription", "7"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicates::str::contains("--cloud"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reuse_by_name_connects_validates_and_creates_nothing() {
+    let cfg = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    let server = MockServer::start().await;
+    write_cloud_profile(&cfg, &server.uri());
+    let endpoint = format!("127.0.0.1:{}", fake_redis());
+    mount_both_tiers(&server, &endpoint).await;
+
+    // A PATH shim provides redisctl-mcp, so the control-plane entry is written.
+    let shim = tempfile::tempdir().unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let bin = shim.path().join("redisctl-mcp");
+        std::fs::write(&bin, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let path_env = format!(
+        "{}:{}",
+        shim.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let output = run_init_cloud(
+        &cfg,
+        project.path(),
+        &repo,
+        &["--name", "essentials-db", "--defaults", "--agent", "claude"],
+    )
+    .env("PATH", &path_env)
+    .assert()
+    .success()
+    .stdout(predicates::str::contains(
+        "database 9 in Essentials subscription 1",
+    ))
+    .stdout(predicates::str::contains("✓ PING"))
+    .stdout(predicates::str::contains(MOCK_PASSWORD).not())
+    .get_output()
+    .clone();
+    assert!(String::from_utf8_lossy(&output.stdout).contains("Redis Cloud (existing database)"));
+
+    let env = std::fs::read_to_string(project.path().join(".env")).unwrap();
+    assert!(
+        env.contains(&format!("redis://default:{MOCK_PASSWORD}@{endpoint}")),
+        "{env}"
+    );
+
+    let skill = std::fs::read_to_string(
+        project
+            .path()
+            .join(".claude/skills/redis-project-setup/SKILL.md"),
+    )
+    .or_else(|_| {
+        std::fs::read_to_string(
+            project
+                .path()
+                .join(".agents/skills/redis-project-setup/SKILL.md"),
+        )
+    })
+    .unwrap();
+    assert!(skill.contains("Essentials subscription `1`"), "{skill}");
+    assert!(skill.contains("database `9`"), "{skill}");
+    assert!(
+        skill.contains("redisctl api cloud get /fixed/subscriptions/1/databases/9"),
+        "{skill}"
+    );
+    assert!(!skill.contains(MOCK_PASSWORD), "{skill}");
+
+    // The shim (and so the control-plane entry) exists on unix only.
+    #[cfg(unix)]
+    {
+        let mcp: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(project.path().join(".mcp.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(mcp["mcpServers"]["redisctl"]["command"], "redisctl-mcp");
+        assert!(mcp["mcpServers"]["redis"].is_object());
+        let raw = std::fs::read_to_string(project.path().join(".mcp.json")).unwrap();
+        assert!(
+            !raw.contains("api-key") && !raw.contains("api_secret"),
+            "{raw}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flexible_reuse_reads_the_pro_path_into_the_skill() {
+    let cfg = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    let server = MockServer::start().await;
+    write_cloud_profile(&cfg, &server.uri());
+    let endpoint = format!("127.0.0.1:{}", fake_redis());
+    mount_both_tiers(&server, &endpoint).await;
+
+    run_init_cloud(
+        &cfg,
+        project.path(),
+        &repo,
+        &["--name", "flexible-db", "--defaults", "--agent", "claude"],
+    )
+    .assert()
+    .success()
+    .stdout(predicates::str::contains(
+        "database 42 in Flexible subscription 2",
+    ));
+
+    let skill = std::fs::read_to_string(
+        project
+            .path()
+            .join(".claude/skills/redis-project-setup/SKILL.md"),
+    )
+    .unwrap();
+    assert!(
+        skill.contains("redisctl api cloud get /subscriptions/2/databases/42"),
+        "{skill}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn exhausted_free_tier_fails_with_the_ways_out_writing_nothing() {
+    let cfg = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    let server = MockServer::start().await;
+    write_cloud_profile(&cfg, &server.uri());
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscriptions": [ { "id": 3, "name": "free", "price": 0, "maximumDatabases": 1 } ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions/3/databases"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscription": { "subscriptionId": 3, "databases": [
+                { "databaseId": 5, "name": "someone-elses", "publicEndpoint": "h:1" }
+            ] }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "subscriptions": [] })))
+        .mount(&server)
+        .await;
+
+    run_init_cloud(&cfg, project.path(), &repo, &["--name", "second-project"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--cloud --name someone-elses"))
+        .stderr(predicates::str::contains("--cloud-subscription"));
+    assert!(!project.path().join(".env").exists());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn piped_stdin_without_a_name_lists_both_tiers_and_refuses() {
+    let cfg = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    let server = MockServer::start().await;
+    write_cloud_profile(&cfg, &server.uri());
+    mount_both_tiers(&server, "h:1").await;
+
+    run_init_cloud(&cfg, project.path(), &repo, &[])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("essentials-db"))
+        .stderr(predicates::str::contains("Flexible subscription 2"))
+        .stderr(predicates::str::contains("--cloud --name <its name>"));
+    assert!(!project.path().join(".env").exists());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dry_run_reports_the_choice_it_would_offer() {
+    let cfg = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    let server = MockServer::start().await;
+    write_cloud_profile(&cfg, &server.uri());
+    mount_both_tiers(&server, "h:1").await;
+
+    run_init_cloud(&cfg, project.path(), &repo, &["--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(
+            "would offer \"essentials-db\", \"flexible-db\" or a new free database",
+        ));
+    assert!(!project.path().join(".env").exists());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_account_creates_a_free_subscription_and_database() {
+    let cfg = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    let server = MockServer::start().await;
+    write_cloud_profile(&cfg, &server.uri());
+    let endpoint = format!("127.0.0.1:{}", fake_redis());
+
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "subscriptions": [] })))
+        .up_to_n_times(3)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "subscriptions": [] })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/fixed/plans"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "plans": [ { "id": 12, "name": "Free", "price": 0 } ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/fixed/subscriptions"))
+        .and(body_partial_json(json!({ "name": "redisctl-brand-new" })))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({ "taskId": "t-sub" })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/tasks/t-sub"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "t-sub", "status": "processing-completed",
+            "response": { "resourceId": 501 }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/fixed/subscriptions/501/databases"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({ "taskId": "t-db" })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/tasks/t-db"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "t-db", "status": "processing-completed",
+            "response": { "resourceId": 9001 }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions/501/databases/9001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "databaseId": 9001, "name": "brand-new", "publicEndpoint": endpoint,
+            "security": { "enableTls": false, "password": MOCK_PASSWORD }
+        })))
+        .mount(&server)
+        .await;
+    // After provisioning, the marker subscription is listed.
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscriptions": [ { "id": 501, "name": "redisctl-brand-new", "price": 0, "maximumDatabases": 1 } ]
+        })))
+        .mount(&server)
+        .await;
+
+    run_init_cloud(
+        &cfg,
+        project.path(),
+        &repo,
+        &["--name", "brand-new", "--defaults", "--agent", "claude"],
+    )
+    .assert()
+    .success()
+    .stdout(predicates::str::contains("cloud:subscription/501"))
+    .stdout(predicates::str::contains(
+        "database 9001 in Essentials subscription 501",
+    ))
+    .stdout(predicates::str::contains("Redis Cloud (new database)"))
+    .stdout(predicates::str::contains(MOCK_PASSWORD).not());
+    let env = std::fs::read_to_string(project.path().join(".env")).unwrap();
+    assert!(env.contains("REDIS_URL=\""), "{env}");
+}
+
+#[test]
+fn existing_env_url_wins_over_cloud_and_provisions_nothing() {
+    let project = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    let endpoint = format!("127.0.0.1:{}", fake_redis());
+    std::fs::write(
+        project.path().join(".env"),
+        format!("REDIS_URL=\"redis://{endpoint}\"\n"),
+    )
+    .unwrap();
+    let before = std::fs::read_to_string(project.path().join(".env")).unwrap();
+
+    // No cloud profile and no CAPI mock exist: reaching the cloud client at all
+    // would fail this run, so success proves the existing value short-circuits.
+    let mut cmd = Command::cargo_bin("redisctl").unwrap();
+    cmd.current_dir(project.path())
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
+        .args([
+            "init",
+            "--cloud",
+            "--name",
+            "brand-new",
+            "--defaults",
+            "--no-install-cli",
+            "--agent",
+            "claude",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("already carries REDIS_URL"))
+        .stdout(predicate::str::contains("existing .env"));
+    assert_eq!(
+        std::fs::read_to_string(project.path().join(".env")).unwrap(),
+        before
+    );
+}

--- a/crates/redisctl/tests/init_cloud_tests.rs
+++ b/crates/redisctl/tests/init_cloud_tests.rs
@@ -180,6 +180,96 @@ fn cloud_and_url_are_mutually_exclusive() {
         .stderr(predicates::str::contains("--url"));
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn creates_in_the_available_free_subscription() {
+    let cfg = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    let server = MockServer::start().await;
+    write_cloud_profile(&cfg, &server.uri());
+    let endpoint = format!("127.0.0.1:{}", fake_redis());
+    for (route, body) in [
+        (
+            "/fixed/subscriptions",
+            json!({"subscriptions": [{"id": 7, "name": "my-free-subscription", "price": 0, "maximumDatabases": 1}]}),
+        ),
+        (
+            "/fixed/subscriptions/7/databases",
+            json!({"subscription": {"subscriptionId": 7, "databases": []}}),
+        ),
+        ("/subscriptions", json!({"subscriptions": []})),
+        (
+            "/tasks/create-db",
+            json!({"taskId": "create-db", "status": "processing-completed", "response": {"resourceId": 9}}),
+        ),
+        (
+            "/fixed/subscriptions/7/databases/9",
+            json!({"databaseId": 9, "name": "my-project", "publicEndpoint": endpoint, "security": {"enableTls": false, "password": MOCK_PASSWORD}}),
+        ),
+    ] {
+        Mock::given(method("GET"))
+            .and(path(route))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+    }
+    Mock::given(method("POST"))
+        .and(path("/fixed/subscriptions/7/databases"))
+        .and(body_partial_json(json!({"name": "my-project"})))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({"taskId": "create-db"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(400))
+        .expect(0)
+        .mount(&server)
+        .await;
+    run_init_cloud(
+        &cfg,
+        project.path(),
+        &repo,
+        &["--name", "my-project", "--defaults"],
+    )
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(
+        "database 9 in Essentials subscription 7",
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn paid_databases_do_not_exhaust_the_free_plan() {
+    let cfg = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    let server = MockServer::start().await;
+    write_cloud_profile(&cfg, &server.uri());
+    for (route, body) in [
+        ("/fixed/subscriptions", json!({"subscriptions": []})),
+        (
+            "/subscriptions",
+            json!({"subscriptions": [{"id": 2, "name": "paid"}]}),
+        ),
+        (
+            "/subscriptions/2/databases",
+            json!({"subscription": [{"subscriptionId": 2, "databases": [{"databaseId": 42, "name": "paid-db"}]}]}),
+        ),
+    ] {
+        Mock::given(method("GET"))
+            .and(path(route))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+    }
+    run_init_cloud(&cfg, project.path(), &repo, &[])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Create another:"))
+        .stderr(predicate::str::contains("the free plan is already used up").not());
+}
+
 #[test]
 fn cloud_subscription_requires_cloud() {
     Command::cargo_bin("redisctl")

--- a/docs/docs/getting-started/init.md
+++ b/docs/docs/getting-started/init.md
@@ -39,7 +39,9 @@ untouched.
 | Flag | Meaning |
 |---|---|
 | `--url <redis-url>` | use an existing database instead of Docker (`rediss://` supported; accepts a pasted `redis-cli -u ...` command) |
-| `--name <label>` | database name, recorded in the generated project skill |
+| `--cloud` | take the database from Redis Cloud: connect to an existing database by `--name`, pick one interactively, or create one on the free Essentials plan |
+| `--cloud-subscription <id>` | create in this Essentials subscription instead of the free plan (requires `--cloud`) |
+| `--name <label>` | database name, recorded in the generated project skill; with `--cloud` it is also the reuse key |
 | `--agent <name>` | configure specific agents (`claude`, `cursor`, `vscode`, `codex`, `all`; repeatable or comma-separated). Default: detect installed tools |
 | `--no-install-cli` | skip installing redis-cli when it is missing |
 | `--skills-repo <dir>` | copy skills from a local redis/agent-skills checkout (offline-safe) |


### PR DESCRIPTION
Stacked on #1105. Slice 9: `--cloud` takes the database from Redis Cloud.

- Creation delegates to `redisctl_core::cloud::quick_database::provision` (its `redisctl-<name>` marker subscription). The engine writes credentials to a private scratch file that init reads back, so `.env` keeps init's never-clobber contract and single writer.
- Init keeps the PoC-parity logic: inventory across Essentials and Flexible, reuse strictly by `--name`, the TTY picker (choosing "create" prompts for a name; an exhausted free plan re-prompts instead of aborting), the piped-stdin listing error, the free-tier ways-out error, and `--cloud-subscription` pinning (creates directly in the pinned subscription).
- An existing `.env` `REDIS_URL` wins over `--cloud` with a note - never-clobber means a fresh database could never be recorded, so provisioning one would burn the free slot for nothing. Deviation from the PoC, which provisioned and then discarded.
- The skill gains subscription/database facts and the control-plane `redisctl api cloud get ...` command with the never-copy-the-password instruction; agent configs gain a `redisctl-mcp` entry when the binary is on PATH.
- Missing credentials point at `redisctl cloud auth login`.

Other deviations: clap-standard exit 2 for the flag exclusions; a dialoguer picker instead of a numbered readline; the engine's wording and marker naming on creates.

Tests: 9 hermetic - wiremock plays the CAPI and an in-test RESP responder plays the database, so validation hits a real socket. Reuse on both tiers, exhausted tier writes nothing, piped listing, dry-run "would offer", create-through-engine, skill facts, credential-free MCP config, existing-env guard.

**Update:** after resolving a cloud database, init now polls the zone's authoritative DNS server directly and only connects once the endpoint's record exists - a fresh database's DNS lags the API's "active" status, and one premature OS-resolver lookup used to fail the run AND get negative-cached for up to 30 minutes. Name-resolution failures also get their own remedy now instead of the stale-URL hint. Adds `hickory-resolver`.
