### PR TITLE
feat(core): populate the built-in production login endpoints

### DIFF
--- a/crates/redisctl-core/src/config/config.rs
+++ b/crates/redisctl-core/src/config/config.rs
@@ -77,14 +77,14 @@ fn default_prod_capi_url() -> String {
 }
 
 impl CloudAuthConfig {
-    /// Built-in production defaults. The Okta issuer/client id and SM host are filled in when
-    /// IT/IAM provisions the prod app; until then [`CloudAuthConfig::is_complete`] reports
-    /// what's missing.
+    /// Built-in production defaults, so `cloud auth login` works against production without a
+    /// `[cloud_auth.<profile>]` section. The client id is a public OIDC identifier (the app is a
+    /// public client with no secret), so it ships in the binary.
     pub fn prod_defaults() -> Self {
         Self {
-            okta_issuer: String::new(),
-            okta_client_id: String::new(),
-            sm_api_url: String::new(),
+            okta_issuer: "https://auth.redis.com/oauth2/default".to_string(),
+            okta_client_id: "0oaw90hjzrLoATW0q5d7".to_string(),
+            sm_api_url: "https://cloud.redis.io/api/v1".to_string(),
             capi_url: default_prod_capi_url(),
         }
     }

--- a/crates/redisctl-core/tests/cloud_auth_config.rs
+++ b/crates/redisctl-core/tests/cloud_auth_config.rs
@@ -81,9 +81,15 @@ fn resolve_cloud_auth_falls_back_to_prod_defaults() {
     let config = Config::default();
     let resolved = config.resolve_cloud_auth("anything");
     assert_eq!(resolved, CloudAuthConfig::prod_defaults());
-    // Prod endpoints aren't provisioned yet, so it isn't complete, but the CAPI base is known.
-    assert!(!resolved.is_complete());
+    // Production endpoints are built in, so a profile with no `[cloud_auth]` section can log in.
+    assert!(resolved.is_complete());
     assert_eq!(resolved.capi_url, "https://api.redislabs.com/v1");
+    assert_eq!(
+        resolved.okta_issuer,
+        "https://auth.redis.com/oauth2/default"
+    );
+    assert!(!resolved.okta_client_id.is_empty());
+    assert_eq!(resolved.sm_api_url, "https://cloud.redis.io/api/v1");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`CloudAuthConfig::prod_defaults()` returned empty strings, so a profile with no
`[cloud_auth.<profile>]` section could not run `cloud auth login` at all — it failed the
`is_complete()` check and reported "login endpoints are not configured". This fills them in, so
production works with no configuration.

The endpoints are all public values a browser already sees during a normal Redis Cloud sign-in:
the OIDC issuer, the public (PKCE, no secret) client id, the SM API base, and the existing CAPI
default.

> [!IMPORTANT]
> End-to-end production sign-in is **not yet complete** — some of it depends on configuration
> outside this repo. This is correct and tested in isolation, but it should not reach `main` until
> a production login has been verified end to end, or users of an unconfigured profile will be
> sent somewhere they cannot yet authenticate.

## Scope

- Affected areas: `crates/redisctl-core/src/config/config.rs`, `crates/redisctl-core/tests/cloud_auth_config.rs`
- API surface changes: none — `prod_defaults()` already existed and is already the fallback in `resolve_cloud_auth()`
- Docs/tests updates: the existing round-trip test now asserts the resolved defaults are complete

## Testing

```bash
cargo test -p redisctl-core --test cloud_auth_config
```

`resolve_cloud_auth_falls_back_to_prod_defaults` now asserts `is_complete()` and pins each endpoint,
so an accidental blanking of any field fails the build.

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated (no user-facing change — the docs already describe the fallback)
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [x] Ready for review
- [x] Squash and merge when approved