### PR TITLE
fix(cli): correct the device-flow instructions and its documented sequence

### DIFF
--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -140,6 +140,23 @@ async fn login(
     emit_signed_in(&creds, &profile_name, output)
 }
 
+/// Sign-in instructions for the device flow. `verification_uri_complete` pre-fills the code on the
+/// activation page, so the user confirms it rather than typing it — RFC 8628 §3.3.1 still requires
+/// that explicit confirmation, so the step itself can't be skipped.
+fn device_instructions(authz: &DeviceAuthorization) -> String {
+    match authz.verification_uri_complete() {
+        Some(complete) => format!(
+            "\nTo sign in, open:\n  {complete}\nand confirm the code:  {}  (already filled in)\n",
+            authz.user_code(),
+        ),
+        None => format!(
+            "\nTo sign in, open:\n  {}\nand enter the code:  {}\n",
+            authz.verification_uri(),
+            authz.user_code(),
+        ),
+    }
+}
+
 /// Start the device flow, save a pending record, and return the device code to the caller
 /// (agent) without blocking. Completion happens later via `auth status --wait`.
 async fn initiate_device_login(
@@ -154,10 +171,6 @@ async fn initiate_device_login(
         .start(&SCOPES)
         .await
         .map_err(auth_err)?;
-    let verify = authz
-        .verification_uri_complete()
-        .unwrap_or_else(|| authz.verification_uri());
-
     save_pending(
         conn_mgr,
         &PendingAuth {
@@ -168,9 +181,8 @@ async fn initiate_device_login(
     )?;
 
     eprintln!(
-        "\nTo sign in, open:\n  {verify}\nand confirm the code:  {}\nThen run: redisctl cloud \
-         auth status --wait   (or wait for the agent to poll)",
-        authz.user_code()
+        "{}Then run: redisctl cloud auth status --wait   (or wait for the agent to poll)",
+        device_instructions(&authz),
     );
     print_formatted_output(
         serde_json::json!({
@@ -189,13 +201,7 @@ async fn initiate_device_login(
 async fn run_device_flow_blocking(auth: &CloudAuthenticator) -> CliResult<TokenSet> {
     let client = auth.device();
     let authz = client.start(&SCOPES).await.map_err(auth_err)?;
-    let verify = authz
-        .verification_uri_complete()
-        .unwrap_or_else(|| authz.verification_uri());
-    eprintln!(
-        "\nTo sign in, open:\n  {verify}\nand confirm the code:  {}\n(waiting for approval…)",
-        authz.user_code()
-    );
+    eprintln!("{}(waiting for approval…)", device_instructions(&authz));
 
     // oauth2 owns the poll loop (honoring the server's interval / slow_down); `None` polls until
     // the device code's own lifetime expires, which surfaces as `device_code_expired` via auth_err.

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -79,6 +79,7 @@ sequenceDiagram
     participant CLI as redisctl
     participant OK as Okta (OIDC)
     participant SM as Redis Cloud API
+    participant CFG as profile and keyring
     A->>CLI: cloud auth login --device
     CLI->>OK: request device authorization
     OK-->>CLI: user_code, verification_uri, device_code
@@ -90,6 +91,7 @@ sequenceDiagram
     OK-->>CLI: access and refresh tokens
     CLI->>SM: sign in, enable access, mint an API key
     SM-->>CLI: account API key and user secret
+    CLI->>CFG: write cloud profile (secrets to keyring)
     CLI-->>A: authenticated and account_id
 ```
 


### PR DESCRIPTION
## Summary

Two inaccuracies about the same flow.

**The printed instructions were wrong about the code.** `login --device` prints
`verification_uri_complete`, which already carries the user code — the identity provider pre-fills
the field from that link. The message nonetheless said "confirm the code: XXXX" as though it had to
be typed. It now says the code is already filled in, while the bare-URI fallback keeps "enter the
code", because that path genuinely does require typing it.

The confirmation step itself cannot be removed: [RFC 8628 §3.3.1](https://www.rfc-editor.org/rfc/rfc8628#section-3.3.1)
requires explicit user confirmation when the code travels in the URI, which is what stops someone
being socially engineered into approving an attacker's device.

**The device-flow sequence diagram omitted persistence entirely.** It ended at
`authenticated and account_id` with no `profile and keyring` participant, reading as though the
device flow hands the key back and forgets it. Both flows converge on the same exchange and persist
identically. The genuine difference — the pending record, which only the device flow writes — was
already shown correctly.

## Scope

- Affected areas: `crates/redisctl/src/commands/cloud/auth.rs`, `docs/docs/cloud/commands/auth.md`
- API surface changes: none; the JSON envelope still emits both `verification_uri` and `verification_uri_complete`
- Docs/tests updates: the device-flow diagram gains the persistence step

## Testing

```bash
cargo test -p redisctl --test cloud_auth_tests
```

The instruction text goes to stderr and is not asserted on; the JSON contract is, and is unchanged.

```bash
cargo run --bin redisctl -- --profile <env> cloud auth login --device
```

The printed link should be the `?user_code=…` form, with the code named as already filled in.

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [x] Ready for review
- [x] Squash and merge when approved