### PR TITLE
feat(core): report redisctl attribution on the SM login exchange

### DIFF
--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -9,7 +9,7 @@
 
 use url::Url;
 
-use super::sm_api::{SmAccount, SmApiClient};
+use super::sm_api::{LoginFlow, SmAccount, SmApiClient};
 use super::{AuthError, DeviceFlowClient, LoopbackFlowClient, TokenSet, default_http_client};
 
 /// Result of a completed login: a Redis Cloud CAPI key pair plus context, ready to persist.
@@ -108,8 +108,10 @@ impl CloudAuthenticator {
         &self,
         tokens: &TokenSet,
         key_name: &str,
+        flow: LoginFlow,
     ) -> Result<MintedCredentials, AuthError> {
-        let mut sm = SmApiClient::with_http_client(self.sm_api_url.clone(), self.http.clone());
+        let mut sm =
+            SmApiClient::with_http_client(self.sm_api_url.clone(), self.http.clone(), flow);
         // Google/GitHub logins must not send Sm-Id-Token (SSO-only); see sm_api docs.
         sm.login(&tokens.access_token, None).await?;
         let user = sm.fetch_current_user().await?;
@@ -283,7 +285,10 @@ mod tests {
             expires_in: 3600,
         };
 
-        let creds = auth.complete_login(&tokens, "redisctl-test").await.unwrap();
+        let creds = auth
+            .complete_login(&tokens, "redisctl-test", LoginFlow::Loopback)
+            .await
+            .unwrap();
         assert_eq!(creds.api_key, "ACCT-KEY");
         assert_eq!(creds.api_secret, "SECRET");
         assert_eq!(creds.api_url, "https://capi.example/v1");
@@ -316,7 +321,7 @@ mod tests {
             expires_in: 3600,
         };
         assert!(matches!(
-            auth.complete_login(&tokens, "k").await,
+            auth.complete_login(&tokens, "k", LoginFlow::Loopback).await,
             Err(AuthError::Protocol(_))
         ));
     }

--- a/crates/redisctl-core/src/auth/mod.rs
+++ b/crates/redisctl-core/src/auth/mod.rs
@@ -23,7 +23,7 @@ pub use auth_code_loopback::LoopbackFlowClient;
 pub use authenticator::{CloudAuthenticator, MintedCredentials};
 pub use device_flow::{DeviceAuthorization, DeviceFlowClient};
 pub use oidc::{AuthError, TokenSet};
-pub use sm_api::{CapiKey, SmAccount, SmApiClient, SmUser};
+pub use sm_api::{CapiKey, LoginFlow, SmAccount, SmApiClient, SmUser};
 
 // Crate-private OIDC plumbing shared by the SM exchange (referenced as `super::*`). The flow
 // clients pull their `oauth2` helpers directly from `super::oidc`.

--- a/crates/redisctl-core/src/auth/sm_api.rs
+++ b/crates/redisctl-core/src/auth/sm_api.rs
@@ -18,11 +18,39 @@ use url::Url;
 
 use super::{AuthError, default_http_client, endpoint, truncate};
 
+/// Attribution sent on `POST /login`, mirroring what RedisInsight sends. SM records these on the
+/// signup path (`registerOktaUser` → `buildRegistrationItem`), so without them a user whose first
+/// contact with Redis Cloud is `cloud auth login` is registered with no originating tool.
+const UTM_SOURCE: &str = "redisctl";
+/// Coarse channel, kept stable so dashboards can group on it; the flow goes in `utm_campaign`.
+const UTM_MEDIUM: &str = "cli";
+
+/// Which login flow produced the tokens. Reported as `utm_campaign`, so interactive and
+/// agent-driven sign-ins can be told apart in analytics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoginFlow {
+    /// Browser on the same machine, redirect caught on loopback.
+    Loopback,
+    /// Device-authorization grant — headless machines and agents.
+    Device,
+}
+
+impl LoginFlow {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Loopback => "loopback",
+            Self::Device => "device",
+        }
+    }
+}
+
 /// SM API client. Stateless until [`SmApiClient::login`] establishes a session.
 pub struct SmApiClient {
     base_url: Url,
     http: reqwest::Client,
     session: Option<Session>,
+    /// Which flow produced the tokens, reported to SM as `utm_campaign`.
+    flow: LoginFlow,
 }
 
 struct Session {
@@ -99,20 +127,22 @@ struct AccountsEnvelope {
 
 impl SmApiClient {
     /// Build a client for the SM API base (e.g. `https://<sm-api-host>/api/v1`).
-    pub fn new(base_url: Url) -> Self {
+    pub fn new(base_url: Url, flow: LoginFlow) -> Self {
         Self {
             base_url,
             http: default_http_client(),
             session: None,
+            flow,
         }
     }
 
     /// Build with a caller-provided reqwest client (tests / shared client).
-    pub fn with_http_client(base_url: Url, http: reqwest::Client) -> Self {
+    pub fn with_http_client(base_url: Url, http: reqwest::Client, flow: LoginFlow) -> Self {
         Self {
             base_url,
             http,
             session: None,
+            flow,
         }
     }
 
@@ -131,7 +161,14 @@ impl SmApiClient {
                 format!("Bearer {access_token}"),
             )
             .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .body("{}");
+            .body(
+                serde_json::json!({
+                    "utm_source": UTM_SOURCE,
+                    "utm_medium": UTM_MEDIUM,
+                    "utm_campaign": self.flow.as_str(),
+                })
+                .to_string(),
+            );
         if let Some(id) = sm_id_token {
             req = req.header("sm-id-token", id);
         }
@@ -316,7 +353,7 @@ fn extract_jsessionid(resp: &reqwest::Response) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::{header, method, path};
+    use wiremock::matchers::{body_string_contains, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     async fn mount_login_and_csrf(server: &MockServer) {
@@ -338,7 +375,7 @@ mod tests {
     }
 
     fn client(server: &MockServer) -> SmApiClient {
-        SmApiClient::new(Url::parse(&server.uri()).unwrap())
+        SmApiClient::new(Url::parse(&server.uri()).unwrap(), LoginFlow::Loopback)
     }
 
     async fn logged_in(server: &MockServer) -> SmApiClient {
@@ -521,6 +558,40 @@ mod tests {
             c.login("ACCESS", None).await,
             Err(AuthError::Protocol(_))
         ));
+    }
+
+    /// SM records `utm_*` on the signup path, so a first-ever login through redisctl must carry
+    /// attribution or the tool is invisible in signup analytics. The mock matches only if all three
+    /// fields are present, and `utm_campaign` distinguishes the two flows.
+    #[tokio::test]
+    async fn login_sends_utm_attribution_per_flow() {
+        for (flow, campaign) in [
+            (LoginFlow::Loopback, "loopback"),
+            (LoginFlow::Device, "device"),
+        ] {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/login"))
+                .and(body_string_contains("\"utm_source\":\"redisctl\""))
+                .and(body_string_contains("\"utm_medium\":\"cli\""))
+                .and(body_string_contains(format!(
+                    "\"utm_campaign\":\"{campaign}\""
+                )))
+                .respond_with(
+                    ResponseTemplate::new(200).append_header("Set-Cookie", "JSESSIONID=S"),
+                )
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/csrf"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "csrfToken": { "csrf_token": "CSRF", "csrf_enabled": true, "errors": [] }
+                })))
+                .mount(&server)
+                .await;
+            let mut c = SmApiClient::new(Url::parse(&server.uri()).unwrap(), flow);
+            c.login("ACCESS", None).await.unwrap();
+        }
     }
 
     #[tokio::test]

--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -18,7 +18,7 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use redisctl_core::auth::{CloudAuthenticator, MintedCredentials};
+use redisctl_core::auth::{CloudAuthenticator, LoginFlow, MintedCredentials};
 use redisctl_core::{CloudAuthConfig, Config, CredentialStore, DeviceAuthorization, TokenSet};
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -135,6 +135,11 @@ async fn login(
         &tokens,
         allow_plaintext,
         auth_cfg,
+        if use_device {
+            LoginFlow::Device
+        } else {
+            LoginFlow::Loopback
+        },
     )
     .await?;
     emit_signed_in(&creds, &profile_name, output)
@@ -228,9 +233,10 @@ async fn complete_and_persist(
     tokens: &TokenSet,
     allow_plaintext: bool,
     auth_cfg: CloudAuthConfig,
+    flow: LoginFlow,
 ) -> CliResult<MintedCredentials> {
     let creds = authenticator
-        .complete_login(tokens, &default_key_name())
+        .complete_login(tokens, &default_key_name(), flow)
         .await
         .map_err(auth_err)?;
 
@@ -312,6 +318,7 @@ async fn status(
                     &tokens,
                     pending.allow_plaintext,
                     auth_cfg,
+                    LoginFlow::Device,
                 )
                 .await?;
                 clear_pending(conn_mgr, &profile_name);


### PR DESCRIPTION
## Summary

`POST /login` doubles as the signup path: when no Redis Cloud user exists yet for the authenticated
identity, that request is what creates one, and the account is registered from the request's `utm_*`
fields. We sent an empty body — so anyone whose first ever contact with Redis Cloud was
`cloud auth login` got registered with **no originating tool**, and the CLI did not appear in signup
attribution at all.

Sends the same shape RedisInsight already sends on its own login call:

```
utm_source   = redisctl
utm_medium   = cli                  stable, so dashboards can group on it
utm_campaign = loopback | device    the flow
```

`utm_medium` deliberately stays coarse and the varying part goes in `utm_campaign`, rather than
putting the flow in `medium`. That keeps the channel stable for existing reporting while still
separating interactive sign-ins from agent-driven ones — which is a genuinely useful signal, since
the device flow is what agents use.

## Scope

- Affected areas: `crates/redisctl-core/src/auth/sm_api.rs` (the request body, new `LoginFlow`), `crates/redisctl-core/src/auth/authenticator.rs` and `crates/redisctl/src/commands/cloud/auth.rs` (thread the flow through), `crates/redisctl-core/src/auth/mod.rs` (re-export)
- API surface changes: `SmApiClient::new` / `with_http_client` and `CloudAuthenticator::complete_login` take a `LoginFlow`; `redisctl_core::auth::LoginFlow` is new and public
- Docs/tests updates: new test asserting all three fields are present, per flow

## Why the flow is a parameter

The CLI is the only layer that knows which flow ran, so it is passed down rather than inferred.
`status --wait` only ever completes a pending device login, so it reports `device`.

## Testing

```bash
cargo test -p redisctl-core --lib auth::sm_api
```

`login_sends_utm_attribution_per_flow` mounts a mock that matches **only** if `utm_source`,
`utm_medium` and the flow-specific `utm_campaign` are all present, and runs it for both variants —
so dropping a field, or reporting the wrong flow, fails the test rather than silently degrading
attribution.

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated (no user-facing behaviour change)
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [x] Ready for review
- [x] Squash and merge when approved