### PR TITLE
docs(cloud): document which accounts cloud auth login supports

### DIFF
--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -130,6 +130,28 @@ preserving the `[cloud_auth.<profile>]` login endpoints so you can log in again.
     The minted API key still exists in the Redis Cloud console until you revoke it there —
     server-side revocation on logout is a planned follow-up.
 
+## Who can use `cloud auth login`
+
+`cloud auth login` signs in through Redis Cloud's identity provider, so it works for accounts whose
+sign-in the identity provider can perform:
+
+| Account type | Supported | Notes |
+|---|---|---|
+| Google | ✅ | both flows |
+| GitHub | ✅ | both flows |
+| SSO / SAML | ❌ | the CLI cannot select an organization's own identity provider — use an API key |
+| Email + password | after linking | link the account to Google or GitHub once, in the console |
+| Marketplace (Heroku, GCP, Azure) | ❌ | sign-in is initiated by the marketplace; there is no Redis-side credential |
+
+For anything unsupported — and for **unattended automation** of any kind — create an API key in the
+[Redis Cloud console](https://app.redislabs.com) and configure it directly:
+
+```bash
+redisctl profile set prod --deployment cloud --api-key "$KEY" --api-secret "$SECRET"
+```
+
+or set `REDIS_CLOUD_API_KEY` / `REDIS_CLOUD_API_SECRET` in the environment.
+
 ## Configuration
 
 `cloud auth login` reads its OIDC endpoints from a `[cloud_auth.<profile>]` section, falling back


### PR DESCRIPTION
## Summary

`cloud auth login` signs in through Redis Cloud's identity provider, which cannot authenticate every
kind of Redis Cloud account — and none of that was written down. The only way to discover that your
Heroku-provisioned account can't use the command was to run it and read an error.

Adds a table of which account types work, and points everything else at the API-key path, which is
also the correct answer for unattended automation.

| Account type | Supported |
|---|---|
| Google, GitHub | yes, both flows |
| SSO / SAML | no — the CLI cannot select an organization's own identity provider |
| Email + password | after linking the account to Google or GitHub once, in the console |
| Marketplace (Heroku, GCP, Azure) | no — sign-in is initiated by the marketplace, so there is no Redis-side credential to present |

The marketplace row is the one worth stating explicitly: those users authenticate by clicking through
from their marketplace dashboard, so there is nothing a CLI could hold. It is not a gap that any
sign-in mechanism could close.

## Scope

- Affected areas: `docs/docs/cloud/commands/auth.md` (one new section)
- API surface changes: none
- Docs/tests updates: docs only — no behaviour change

## Testing

```bash
cd docs && mkdocs build --strict
```

Note `--strict` validates page links but **not** in-page anchors, so the section deliberately avoids
cross-references that a future edit could silently break.

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated (n/a — docs only)
- [x] Docs updated
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [x] Ready for review
- [x] Squash and merge when approved