### PR TITLE
feat(init): detect a running local Redis and lead the wizard with Redis Cloud

### DIFF
--- a/crates/redisctl-init/src/docker.rs
+++ b/crates/redisctl-init/src/docker.rs
@@ -371,6 +371,52 @@ async fn wait_for_ping(url: &str, timeout: Duration) -> Result<(), InitError> {
     }
 }
 
+/// The default endpoint a native local Redis listens on.
+pub const LOCAL_REDIS_URL: &str = "redis://localhost:6379";
+
+/// What answers (or does not) at a local Redis endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalRedis {
+    Ready,
+    NeedsAuth,
+    NotFound,
+}
+
+/// A quick look before the wizard offers to reuse a running server: PONG means
+/// usable as-is, an auth error still counts as running, anything else (refused,
+/// timeout, non-Redis chatter) reads as absent.
+pub async fn probe_local_redis(url: &str) -> LocalRedis {
+    const PROBE_TIMEOUT: Duration = Duration::from_millis(1500);
+    let Ok(client) = redis::Client::open(url) else {
+        return LocalRedis::NotFound;
+    };
+    let mut conn = match tokio::time::timeout(
+        PROBE_TIMEOUT,
+        client.get_multiplexed_async_connection(),
+    )
+    .await
+    {
+        Ok(Ok(conn)) => conn,
+        Ok(Err(e)) if is_auth_error(&e) => return LocalRedis::NeedsAuth,
+        _ => return LocalRedis::NotFound,
+    };
+    match tokio::time::timeout(
+        PROBE_TIMEOUT,
+        redis::cmd("PING").query_async::<String>(&mut conn),
+    )
+    .await
+    {
+        Ok(Ok(_)) => LocalRedis::Ready,
+        Ok(Err(e)) if is_auth_error(&e) => LocalRedis::NeedsAuth,
+        _ => LocalRedis::NotFound,
+    }
+}
+
+fn is_auth_error(e: &redis::RedisError) -> bool {
+    e.kind() == redis::ErrorKind::AuthenticationFailed
+        || matches!(e.code(), Some("NOAUTH") | Some("WRONGPASS"))
+}
+
 /// Prove the database actually works: a PING and a SET/GET round trip on a
 /// short-lived key.
 pub async fn validate(url: &str) -> Result<(), String> {
@@ -406,6 +452,59 @@ pub async fn validate(url: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A fake Redis that answers every incoming command with `reply` - the client
+    /// pipelines CLIENT SETINFO during setup before the PING the probe cares about,
+    /// so one reply per `*`-led command keeps the protocol in sync.
+    fn fake_redis(reply: &'static [u8]) -> String {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let url = format!(
+            "redis://127.0.0.1:{}",
+            listener.local_addr().unwrap().port()
+        );
+        std::thread::spawn(move || {
+            if let Ok((mut sock, _)) = listener.accept() {
+                use std::io::{Read, Write};
+                let _ = sock.set_read_timeout(Some(Duration::from_secs(3)));
+                let mut buf = [0u8; 4096];
+                while let Ok(n) = sock.read(&mut buf) {
+                    if n == 0 {
+                        break;
+                    }
+                    let commands = buf[..n].iter().filter(|b| **b == b'*').count().max(1);
+                    for _ in 0..commands {
+                        let _ = sock.write_all(reply);
+                    }
+                    let _ = sock.flush();
+                }
+            }
+        });
+        url
+    }
+
+    #[tokio::test]
+    async fn probe_finds_a_ready_local_redis() {
+        let url = fake_redis(b"+PONG\r\n");
+        assert_eq!(probe_local_redis(&url).await, LocalRedis::Ready);
+    }
+
+    #[tokio::test]
+    async fn probe_reads_an_auth_error_as_a_running_server() {
+        let url = fake_redis(b"-NOAUTH Authentication required.\r\n");
+        assert_eq!(probe_local_redis(&url).await, LocalRedis::NeedsAuth);
+    }
+
+    #[tokio::test]
+    async fn probe_reports_nothing_listening() {
+        // A bound-then-dropped listener guarantees a refused port.
+        let port = std::net::TcpListener::bind(("127.0.0.1", 0))
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        let url = format!("redis://127.0.0.1:{port}");
+        assert_eq!(probe_local_redis(&url).await, LocalRedis::NotFound);
+    }
 
     #[test]
     fn parse_container_info_reads_running_and_port() {

--- a/crates/redisctl-init/src/lib.rs
+++ b/crates/redisctl-init/src/lib.rs
@@ -22,7 +22,7 @@ pub use docker::docker_ok as docker_available;
 pub use project::{detect as detect_project, detect_agents};
 
 pub(crate) const SKILLS_DIR: &str = ".agents/skills";
-pub use docker::validate;
+pub use docker::{LOCAL_REDIS_URL, LocalRedis, probe_local_redis, validate};
 pub use env::read_env_key;
 pub use products::{
     ProductKey, ProductRequest, SECRET_PLACEHOLDER, WiredProduct, validate_product,

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -217,10 +217,18 @@ async fn run_inner(
     telemetry.props.wizard_questions_asked = if interactive { pending.len() } else { 0 };
     if interactive {
         telemetry.step("wizard");
+        // Probed only when the database question will actually be asked: the
+        // wizard offers to reuse a server that is already running locally.
+        let local = if pending.contains(&wizard::Question::Database) {
+            engine::probe_local_redis(engine::LOCAL_REDIS_URL).await
+        } else {
+            engine::LocalRedis::NotFound
+        };
         let answers = wizard::run(
             &pending,
             &engine::detect_agents(&cwd),
             engine::docker_available(),
+            local,
         )?;
         if let Some(url) = answers.url {
             options.url_input = Some(url);

--- a/crates/redisctl/src/workflows/init/wizard.rs
+++ b/crates/redisctl/src/workflows/init/wizard.rs
@@ -140,6 +140,9 @@ impl Theme for RedisTheme {
 }
 
 const DATABASE_PROMPT: &str = "Where should the database come from?";
+const DATABASE_ITEMS: [&str; 3] = ["Redis Cloud", "Local Redis", "Paste a connection string"];
+const LOCAL_FOUND_PROMPT: &str = "Found a local Redis at localhost:6379 - use it?";
+const LOCAL_NONE_PROMPT: &str = "No local Redis found - create one?";
 const AGENTS_PROMPT: &str = "Which agent(s) should be configured?";
 const SKILLS_PROMPT: &str = "Where should the Redis skills be installed?";
 const INTERRUPTED: &str = "interrupted";
@@ -149,7 +152,12 @@ const INTERRUPTED: &str = "interrupted";
 pub(crate) fn is_wizard_prompt(prompt: &str) -> bool {
     matches!(
         prompt,
-        DATABASE_PROMPT | AGENTS_PROMPT | SKILLS_PROMPT | INTERRUPTED
+        DATABASE_PROMPT
+            | LOCAL_FOUND_PROMPT
+            | LOCAL_NONE_PROMPT
+            | AGENTS_PROMPT
+            | SKILLS_PROMPT
+            | INTERRUPTED
     ) || prompt == super::cloud::PICKER_PROMPT
 }
 
@@ -216,11 +224,12 @@ pub fn run(
     pending: &[Question],
     detected: &[engine::Agent],
     docker: bool,
+    local: engine::LocalRedis,
 ) -> Result<Answers, RedisCtlError> {
     let mut answers = Answers::default();
     for question in pending {
         match question {
-            Question::Database => match ask_database(docker)? {
+            Question::Database => match ask_database(docker, local)? {
                 DatabaseChoice::Docker => {}
                 DatabaseChoice::Cloud => answers.cloud = true,
                 DatabaseChoice::Url(url) => answers.url = Some(url),
@@ -238,37 +247,86 @@ enum DatabaseChoice {
     Url(String),
 }
 
-/// Docker is the default; Redis Cloud routes into the cloud flow; a paste comes
-/// back as the URL.
-fn ask_database(docker: bool) -> Result<DatabaseChoice, RedisCtlError> {
+/// Redis Cloud leads and is the default; "Local Redis" reuses a server that is
+/// already running (asking for credentials when it wants them) and only falls back
+/// to creating a Docker container; a paste comes back as the URL.
+fn ask_database(docker: bool, local: engine::LocalRedis) -> Result<DatabaseChoice, RedisCtlError> {
     const PROMPT: &str = DATABASE_PROMPT;
+    // No tier qualifier on Redis Cloud: the cloud flow connects to existing
+    // databases on any plan; only creating a new one defaults to the free plan.
+    let selection = Select::with_theme(&RedisTheme)
+        .with_prompt(PROMPT)
+        .items(&DATABASE_ITEMS)
+        .default(0)
+        .interact_opt()
+        .map_err(prompt_failed)?;
+    match selection {
+        None => Err(cancelled(PROMPT)),
+        Some(0) => Ok(DatabaseChoice::Cloud),
+        Some(1) => ask_local(docker, local),
+        _ => ask_paste(),
+    }
+}
+
+/// The "Local Redis" sub-question, shaped by what the probe found: a ready server
+/// is offered for reuse, one that wants credentials routes to the paste prompt,
+/// and an absent one offers to create a Docker container.
+fn ask_local(docker: bool, local: engine::LocalRedis) -> Result<DatabaseChoice, RedisCtlError> {
+    if local == engine::LocalRedis::NeedsAuth {
+        eprintln!(
+            "  Found a local Redis at localhost:6379, but it needs credentials - paste its connection string."
+        );
+        return ask_paste();
+    }
     // An option that cannot work stays on the list carrying the reason - the same
     // information the error would deliver after the run, shown before it instead.
-    let docker_item = if docker {
-        "Local Docker container"
-    } else {
-        "Local Docker container  (Docker is not running)"
+    let docker_item = |label: &str| {
+        if docker {
+            label.to_string()
+        } else {
+            format!("{label}  (Docker is not running)")
+        }
     };
-    // No tier qualifier: the cloud flow connects to existing databases on any
-    // plan; only creating a new one defaults to the free Essentials plan.
-    let items = [docker_item, "Redis Cloud", "Paste a connection string"];
+    let found = local == engine::LocalRedis::Ready;
+    let (prompt, items) = if found {
+        (
+            LOCAL_FOUND_PROMPT,
+            [
+                "Use it".to_string(),
+                docker_item("Start a fresh Docker container instead"),
+            ],
+        )
+    } else {
+        (
+            LOCAL_NONE_PROMPT,
+            [
+                docker_item("Start one with Docker"),
+                "Paste a connection string".to_string(),
+            ],
+        )
+    };
+    let docker_index = if found { 1 } else { 0 };
+    let default = if found || docker { 0 } else { 1 };
     loop {
         let selection = Select::with_theme(&RedisTheme)
-            .with_prompt(PROMPT)
+            .with_prompt(prompt)
             .items(&items)
-            .default(if docker { 0 } else { 2 })
+            .default(default)
             .interact_opt()
             .map_err(prompt_failed)?;
         match selection {
-            None => return Err(cancelled(PROMPT)),
-            Some(0) if !docker => {
+            None => return Err(cancelled(prompt)),
+            Some(i) if i == docker_index && !docker => {
                 eprintln!("  Docker is not running - start it, or paste a connection string.");
             }
-            Some(0) => return Ok(DatabaseChoice::Docker),
-            Some(1) => return Ok(DatabaseChoice::Cloud),
-            _ => break,
+            Some(i) if i == docker_index => return Ok(DatabaseChoice::Docker),
+            Some(_) if found => return Ok(DatabaseChoice::Url(engine::LOCAL_REDIS_URL.into())),
+            Some(_) => return ask_paste(),
         }
     }
+}
+
+fn ask_paste() -> Result<DatabaseChoice, RedisCtlError> {
     let pasted: String = Input::with_theme(&RedisTheme)
         .with_prompt("Paste the connection string")
         .validate_with(|input: &String| {
@@ -362,6 +420,20 @@ mod tests {
     fn the_cloud_picker_cancel_gets_wizard_tips() {
         assert!(is_wizard_prompt(super::super::cloud::PICKER_PROMPT));
         assert!(!is_wizard_prompt("Delete user 5?"));
+    }
+
+    #[test]
+    fn redis_cloud_leads_the_database_options() {
+        assert_eq!(
+            DATABASE_ITEMS,
+            ["Redis Cloud", "Local Redis", "Paste a connection string"]
+        );
+    }
+
+    #[test]
+    fn the_local_subflow_prompts_get_wizard_cancel_tips() {
+        assert!(is_wizard_prompt(LOCAL_FOUND_PROMPT));
+        assert!(is_wizard_prompt(LOCAL_NONE_PROMPT));
     }
 
     #[test]


### PR DESCRIPTION
Reworks the wizard's database question and teaches init to reuse a Redis that is already running locally.

## What changed

- **Redis Cloud is the first option** (and the default) in "Where should the database come from?".
- **"Local Docker container" is now "Local Redis"**, and it probes `localhost:6379` before deciding:
  - a running open server is offered for reuse ("Found a local Redis at localhost:6379 - use it?") - no container gets created;
  - a server that wants credentials routes to the paste prompt with a note;
  - nothing listening offers to start a Docker container (or paste), with the Docker-not-running gating moved into this sub-question.
- `--defaults` and piped runs never probe or prompt - they keep the existing Docker behavior, so agent/CI runs are unchanged.

## How

- Engine: `probe_local_redis(url)` - PONG means ready, `NOAUTH`/`WRONGPASS` still counts as a running server, anything else (refused, timeout, non-Redis chatter) reads as absent. The URL is injected, so tests use fake servers on random ports, never the machine's real 6379.
- CLI: the probe runs only when the wizard will actually ask the database question; the two new sub-prompts joined `is_wizard_prompt`, so Esc keeps the `--defaults` cancel tip.

## Testing

- 3 engine tests against fake RESP servers (ready / NOAUTH / refused port).
- Wizard unit tests pin the option order and the cancel-tip coverage of the new prompts.
- Verified live end to end: with a real server on 6379 the full run reused it (`database: redis://localhost:6379 via provided URL`, validation green, no container created); with the port free, the create sub-question appears.
