### PR TITLE
feat(init): explicit database choices supersede .env, with keep and fill-later options

### DIFF
--- a/crates/redisctl-init/src/docker.rs
+++ b/crates/redisctl-init/src/docker.rs
@@ -30,6 +30,9 @@ pub(crate) enum DatabaseAction {
         port: u16,
         url: String,
     },
+    /// The user chose to connect later: a placeholder REDIS_URL gets written and
+    /// the run ends with instructions instead of validation.
+    Placeholder,
     /// No container yet: run the image on the chosen free port.
     RunNew {
         name: String,
@@ -43,7 +46,7 @@ pub(crate) enum DatabaseAction {
 impl DatabaseAction {
     pub(crate) fn container(&self) -> Option<&str> {
         match self {
-            DatabaseAction::Provided { .. } => None,
+            DatabaseAction::Provided { .. } | DatabaseAction::Placeholder => None,
             DatabaseAction::ExistingEnv { container, .. } => container.as_deref(),
             DatabaseAction::StartExisting { name, .. }
             | DatabaseAction::AlreadyRunning { name, .. }
@@ -53,6 +56,7 @@ impl DatabaseAction {
 
     pub(crate) fn url(&self) -> &str {
         match self {
+            DatabaseAction::Placeholder => PLACEHOLDER_URL,
             DatabaseAction::Provided { url }
             | DatabaseAction::ExistingEnv { url, .. }
             | DatabaseAction::StartExisting { url, .. }
@@ -64,6 +68,7 @@ impl DatabaseAction {
     pub(crate) fn source(&self, applied: bool) -> &'static str {
         match self {
             DatabaseAction::Provided { .. } => "provided URL",
+            DatabaseAction::Placeholder => "placeholder - fill .env",
             DatabaseAction::ExistingEnv { .. } => "existing .env",
             DatabaseAction::StartExisting { .. } | DatabaseAction::AlreadyRunning { .. } => {
                 "existing Docker container"
@@ -84,6 +89,7 @@ impl DatabaseAction {
                 Status::Planned,
                 "would start existing container",
             )),
+            DatabaseAction::Placeholder => Some(placeholder_change()),
             DatabaseAction::Provided { .. } | DatabaseAction::ExistingEnv { .. } => None,
             DatabaseAction::StartExisting { name, .. } => Some(Change::new(
                 format!("docker:{name}"),
@@ -104,6 +110,19 @@ impl DatabaseAction {
             )),
         }
     }
+}
+
+/// The value the "connect later" path writes to .env; a run that finds it treats
+/// the database as still pending instead of validating garbage.
+pub const PLACEHOLDER_URL: &str = "<paste-your-redis-url>";
+
+/// The same line in the plan preview and the apply report - dry-run parity.
+fn placeholder_change() -> Change {
+    Change::new(
+        "database",
+        Status::Skipped,
+        "no connection yet - fill REDIS_URL in .env, then run redisctl init --complete",
+    )
 }
 
 pub fn docker_ok() -> bool {
@@ -185,10 +204,18 @@ fn decide_existing_env(url: String, name: String, info: Option<ContainerInfo>) -
 }
 
 /// Probe (read-only) how this project gets its local database.
-pub(crate) fn plan_local_database(cwd: &Path) -> Result<DatabaseAction, InitError> {
+pub(crate) fn plan_local_database(
+    cwd: &Path,
+    ignore_env: bool,
+) -> Result<DatabaseAction, InitError> {
     let name = container_name(cwd);
 
-    if let Some(url) = read_env_key(cwd, ".env", "REDIS_URL") {
+    // `ignore_env` is the user's explicit choice of a fresh source superseding
+    // whatever .env carries.
+    if let Some(url) = read_env_key(cwd, ".env", "REDIS_URL").filter(|_| !ignore_env) {
+        if url == PLACEHOLDER_URL {
+            return Ok(DatabaseAction::Placeholder);
+        }
         // Second run typically lands here: revive our container if it is just stopped.
         let info = container_info(&name);
         return Ok(decide_existing_env(url, name, info));
@@ -229,6 +256,7 @@ pub(crate) async fn apply_database(
 ) -> Result<Option<Change>, InitError> {
     match action {
         DatabaseAction::Provided { .. } => Ok(None),
+        DatabaseAction::Placeholder => Ok(Some(placeholder_change())),
         DatabaseAction::ExistingEnv {
             url,
             container,
@@ -507,6 +535,20 @@ mod tests {
     }
 
     #[test]
+    fn a_placeholder_env_value_plans_a_pending_database() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            format!("REDIS_URL=\"{PLACEHOLDER_URL}\"\n"),
+        )
+        .unwrap();
+        // Returns before any docker probe, so this stays hermetic.
+        let action = plan_local_database(dir.path(), false).unwrap();
+        assert!(matches!(action, DatabaseAction::Placeholder));
+        assert_eq!(action.source(true), "placeholder - fill .env");
+    }
+
+    #[test]
     fn parse_container_info_reads_running_and_port() {
         let info = parse_container_info("true 6380\n").unwrap();
         assert!(info.running);
@@ -589,7 +631,7 @@ mod tests {
         .unwrap();
         // Whatever containers exist on this machine, a remote URL means none of
         // them belong to this database.
-        let action = plan_local_database(dir.path()).unwrap();
+        let action = plan_local_database(dir.path(), false).unwrap();
         assert_eq!(action.container(), None);
         assert!(matches!(
             action,
@@ -637,7 +679,7 @@ mod tests {
     fn existing_env_url_wins_without_docker() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join(".env"), "REDIS_URL=\"redis://h:1\"\n").unwrap();
-        let action = plan_local_database(dir.path()).unwrap();
+        let action = plan_local_database(dir.path(), false).unwrap();
         assert_eq!(action.url(), "redis://h:1");
         assert_eq!(action.source(true), "existing .env");
         // No local container matches, so nothing restarts.

--- a/crates/redisctl-init/src/env.rs
+++ b/crates/redisctl-init/src/env.rs
@@ -169,8 +169,9 @@ pub(crate) fn plan_env_replace(
                 regex::escape(key)
             ))
             .expect("escaped key regex");
+            let assignment = env_assignment(key, value)?;
             let replaced = re
-                .replace(&content, format!("{key}=\"{value}\""))
+                .replace(&content, regex::NoExpand(&assignment))
                 .into_owned();
             Ok(FileAction::Write {
                 rel: rel.to_string(),

--- a/crates/redisctl-init/src/env.rs
+++ b/crates/redisctl-init/src/env.rs
@@ -151,6 +151,38 @@ pub(crate) fn plan_env_set(
     }
 }
 
+/// Like [`plan_env_set`], but with explicit consent to supersede: a different
+/// existing value is replaced in place and the note names the old one (masked).
+/// Used only when the user explicitly chose a database source.
+pub(crate) fn plan_env_replace(
+    dir: &Path,
+    rel: &str,
+    key: &str,
+    value: &str,
+) -> Result<FileAction, InitError> {
+    let existing = read_env_key(dir, rel, key);
+    match existing {
+        Some(old) if old != value => {
+            let content = read_for_planning(dir, rel)?.unwrap_or_default();
+            let re = regex::Regex::new(&format!(
+                r"(?m)^\s*(?:export\s+)?{}\s*=.*$",
+                regex::escape(key)
+            ))
+            .expect("escaped key regex");
+            let replaced = re
+                .replace(&content, format!("{key}=\"{value}\""))
+                .into_owned();
+            Ok(FileAction::Write {
+                rel: rel.to_string(),
+                content: replaced,
+                status: Status::Updated,
+                note: format!("{key} replaced (was {})", mask_url(&old)),
+            })
+        }
+        _ => plan_env_set(dir, rel, key, value),
+    }
+}
+
 /// Set several keys as one provenance block. Never-clobber per key: absent keys are
 /// added, present-and-identical ignored, present-and-different kept (named, never
 /// echoed). `base` is the file content this block plans against - callers planning
@@ -310,6 +342,56 @@ mod tests {
         let action =
             plan_env_set(dir.path(), ".env", "REDIS_URL", "redis://localhost:6379").unwrap();
         assert_eq!(action.preview().status, Status::Unchanged);
+    }
+
+    #[test]
+    fn env_replace_swaps_the_value_and_masks_the_old_one_in_the_note() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(".env"),
+            "A=1\nREDIS_URL=\"redis://old:secret@h:1\"\nB=2\n",
+        )
+        .unwrap();
+        let action = plan_env_replace(dir.path(), ".env", "REDIS_URL", "redis://new:6379").unwrap();
+        let FileAction::Write {
+            content,
+            status,
+            note,
+            ..
+        } = action
+        else {
+            panic!("expected a write");
+        };
+        assert_eq!(status, Status::Updated);
+        assert!(
+            content.contains("REDIS_URL=\"redis://new:6379\""),
+            "{content}"
+        );
+        assert!(!content.contains("secret"), "{content}");
+        assert!(
+            content.contains("A=1") && content.contains("B=2"),
+            "{content}"
+        );
+        assert!(note.contains("redis://old:****@h:1"), "{note}");
+        assert!(!note.contains("secret"), "{note}");
+    }
+
+    #[test]
+    fn env_replace_reads_unchanged_on_same_value_and_appends_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".env"), "REDIS_URL=\"redis://h:1\"\n").unwrap();
+        assert!(matches!(
+            plan_env_replace(dir.path(), ".env", "REDIS_URL", "redis://h:1").unwrap(),
+            FileAction::Unchanged { .. }
+        ));
+        let fresh = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            plan_env_replace(fresh.path(), ".env", "REDIS_URL", "redis://h:1").unwrap(),
+            FileAction::Write {
+                status: Status::Created,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/redisctl-init/src/lib.rs
+++ b/crates/redisctl-init/src/lib.rs
@@ -22,7 +22,7 @@ pub use docker::docker_ok as docker_available;
 pub use project::{detect as detect_project, detect_agents};
 
 pub(crate) const SKILLS_DIR: &str = ".agents/skills";
-pub use docker::{LOCAL_REDIS_URL, LocalRedis, probe_local_redis, validate};
+pub use docker::{LOCAL_REDIS_URL, LocalRedis, PLACEHOLDER_URL, probe_local_redis, validate};
 pub use env::read_env_key;
 pub use products::{
     ProductKey, ProductRequest, SECRET_PLACEHOLDER, WiredProduct, validate_product,
@@ -115,6 +115,12 @@ pub struct Options {
     pub skills_repo: Option<PathBuf>,
     /// Install the official skills for the user instead of into this project.
     pub skills_global: bool,
+    /// The user explicitly chose a database source (wizard answer or flag), so an
+    /// existing REDIS_URL in .env is superseded instead of kept.
+    pub replace_env_url: bool,
+    /// The wizard's "connect later": write a placeholder REDIS_URL and end with
+    /// instructions instead of provisioning and validating.
+    pub env_placeholder: bool,
 }
 
 // Manual, because `{:?}` reaches logs: `url_input` can carry a password and
@@ -135,6 +141,8 @@ impl std::fmt::Debug for Options {
             .field("install_cli", &self.install_cli)
             .field("skills_repo", &self.skills_repo)
             .field("skills_global", &self.skills_global)
+            .field("replace_env_url", &self.replace_env_url)
+            .field("env_placeholder", &self.env_placeholder)
             .finish()
     }
 }
@@ -202,6 +210,12 @@ impl Plan {
     /// `None` means this run works without a database (products-only, `--iris`).
     pub fn database_url(&self) -> Option<&str> {
         self.database.as_ref().map(|db| db.url())
+    }
+
+    /// The "connect later" path: a placeholder REDIS_URL is written, nothing is
+    /// validated, and the run ends with instructions.
+    pub fn database_pending(&self) -> bool {
+        matches!(self.database, Some(docker::DatabaseAction::Placeholder))
     }
 
     /// The database's provenance for the summary line. `applied` picks the wording
@@ -293,7 +307,11 @@ pub fn plan(options: &Options) -> Result<Plan, InitError> {
         Some(input) => Some(docker::DatabaseAction::Provided {
             url: extract_url(input)?,
         }),
-        None if wants_database => Some(docker::plan_local_database(&options.cwd)?),
+        None if options.env_placeholder => Some(docker::DatabaseAction::Placeholder),
+        None if wants_database => Some(docker::plan_local_database(
+            &options.cwd,
+            options.replace_env_url,
+        )?),
         None => None,
     };
     let project = project::detect(&options.cwd);
@@ -308,7 +326,11 @@ pub fn plan(options: &Options) -> Result<Plan, InitError> {
     let mut env_base: Option<String> = None;
     let mut example_base: Option<String> = None;
     if let Some(database) = &database {
-        let action = env::plan_env_set(&options.cwd, ".env", "REDIS_URL", database.url())?;
+        let action = if options.replace_env_url {
+            env::plan_env_replace(&options.cwd, ".env", "REDIS_URL", database.url())?
+        } else {
+            env::plan_env_set(&options.cwd, ".env", "REDIS_URL", database.url())?
+        };
         if let env::FileAction::Write { content, .. } = &action {
             env_base = Some(content.clone());
         }
@@ -560,6 +582,8 @@ mod tests {
             install_cli: false,
             skills_repo: None,
             skills_global: false,
+            replace_env_url: false,
+            env_placeholder: false,
         })
         .unwrap();
         assert_eq!(plan.project.runtime, Runtime::Go);
@@ -585,6 +609,8 @@ mod tests {
             install_cli: false,
             skills_repo: None,
             skills_global: false,
+            replace_env_url: false,
+            env_placeholder: false,
         })
         .unwrap();
         let changes = plan.changes();
@@ -621,6 +647,8 @@ mod tests {
             install_cli: false,
             skills_repo: Some(repo.path().to_path_buf()),
             skills_global: false,
+            replace_env_url: false,
+            env_placeholder: false,
         };
         let plan = plan(&options(dir.path())).unwrap();
         let report = apply(&plan, &mut |_| {}).await.unwrap();

--- a/crates/redisctl/src/workflows/init/mod.rs
+++ b/crates/redisctl/src/workflows/init/mod.rs
@@ -178,6 +178,8 @@ async fn run_inner(
         install_cli: !args.no_install_cli,
         skills_repo: args.skills_repo.clone(),
         skills_global: args.skills_global,
+        replace_env_url: false,
+        env_placeholder: false,
     };
 
     output::banner();
@@ -215,6 +217,9 @@ async fn run_inner(
     let interactive = wizard::applies(args, &pending);
     telemetry.props.interactive = interactive;
     telemetry.props.wizard_questions_asked = if interactive { pending.len() } else { 0 };
+    // An explicit flag is consent to supersede whatever REDIS_URL .env carries;
+    // only the implicit no-flags default keeps it.
+    options.replace_env_url = options.url_input.is_some() || wants_cloud;
     if interactive {
         telemetry.step("wizard");
         // Probed only when the database question will actually be asked: the
@@ -224,16 +229,21 @@ async fn run_inner(
         } else {
             engine::LocalRedis::NotFound
         };
+        let env_url = engine::read_env_key(&cwd, ".env", "REDIS_URL")
+            .filter(|url| url != engine::PLACEHOLDER_URL);
         let answers = wizard::run(
             &pending,
             &engine::detect_agents(&cwd),
             engine::docker_available(),
             local,
+            env_url.as_deref(),
         )?;
         if let Some(url) = answers.url {
             options.url_input = Some(url);
         }
         wants_cloud = wants_cloud || answers.cloud;
+        options.replace_env_url = options.replace_env_url || answers.database_explicit;
+        options.env_placeholder = answers.placeholder;
         if let Some(agents) = answers.agents {
             options.agents = Some(agents);
             asked_agents = true;
@@ -243,18 +253,6 @@ async fn run_inner(
         }
     }
     telemetry.step("database");
-    // Never-clobber means a freshly provisioned database could never be recorded
-    // in .env; keep the existing value instead of creating one the project would
-    // not use (and burning the free-plan slot).
-    if wants_cloud && engine::read_env_key(&cwd, ".env", "REDIS_URL").is_some() {
-        println!(
-            "{}",
-            yellow(
-                "  note: .env already carries REDIS_URL - keeping it (init never overwrites credentials). Remove that line to take the database from Redis Cloud.\n"
-            )
-        );
-        wants_cloud = false;
-    }
     let mut cloud_changes = Vec::new();
     if wants_cloud {
         // A missing profile has one fix worth naming here; other client errors
@@ -318,25 +316,30 @@ async fn run_inner(
         .map(|a| a.as_str())
         .collect::<Vec<_>>()
         .join(", ");
+    // A rail entry, so the wizard's rail runs unbroken into the status steps.
     println!(
-        "{}    {}{}   {}\n",
-        bold("Agents"),
-        names,
-        if args.agents.is_empty() && !asked_agents {
-            dim(" (detected)")
-        } else {
-            String::new()
-        },
-        dim(&format!("existing: {agent_bits}"))
+        "{}",
+        output::rail_line(&format!(
+            "{}   {}{}   {}",
+            bold("Agents"),
+            names,
+            if args.agents.is_empty() && !asked_agents {
+                dim(" (detected)")
+            } else {
+                String::new()
+            },
+            dim(&format!("existing: {agent_bits}"))
+        ))
     );
     if proj.runtime == engine::Runtime::Unknown {
         println!(
             "{}",
-            yellow(
-                "  note: no package manifest detected - continuing; everything redisctl init writes is language-agnostic.\n"
-            )
+            output::rail_line(&yellow(
+                "note: no package manifest detected - continuing; everything redisctl init writes is language-agnostic."
+            ))
         );
     }
+    println!("{}", output::rail_gap());
 
     let subject = |applied: bool| match plan.database_url() {
         Some(url) => format!(
@@ -360,6 +363,7 @@ async fn run_inner(
     };
 
     if dry {
+        println!("{}\n", output::rail_end("plan ready"));
         println!(
             "{}  {}",
             bold("Plan"),
@@ -385,11 +389,17 @@ async fn run_inner(
                 p.done(&outcome);
             }
         }
-        engine::Event::Note(text) => println!("{}", dim(&text)),
-        engine::Event::Warning(text) => println!("{}", yellow(&text)),
+        engine::Event::Note(text) => {
+            println!("{}  {}", output::rail_gap(), dim(text.trim_start()))
+        }
+        engine::Event::Warning(text) => {
+            println!("{}  {}", output::rail_gap(), yellow(text.trim_start()))
+        }
     })
     .await?;
 
+    println!("{}", output::rail_gap());
+    println!("{}\n", output::rail_end("done"));
     println!(
         "{}  {}",
         bold("Changes"),
@@ -402,7 +412,14 @@ async fn run_inner(
 
     telemetry.props.skills_installed_count = report.skills_installed;
     telemetry.step("validate");
-    if let Some(url) = plan.database_url() {
+    if plan.database_pending() {
+        println!(
+            "\n{}  {} database  {}",
+            bold("Validate"),
+            yellow("○"),
+            dim("waiting for REDIS_URL")
+        );
+    } else if let Some(url) = plan.database_url() {
         print!("\n{}  ", bold("Validate"));
         let _ = std::io::Write::flush(&mut std::io::stdout());
         match engine::validate(url).await {
@@ -473,24 +490,33 @@ async fn run_inner(
         .iter()
         .filter_map(|product| product.pending_env())
         .collect();
-    if !pending.is_empty() {
+    if !pending.is_empty() || plan.database_pending() {
         println!("\n{}", bold("Action required"));
-        for (index, env_key) in pending.iter().enumerate() {
+        let mut step = 0;
+        if plan.database_pending() {
+            step += 1;
+            println!(
+                "  {step}. Open {} and replace {} with your database connection string.",
+                bold(".env"),
+                bold(&format!("REDIS_URL=\"{}\"", engine::PLACEHOLDER_URL)),
+            );
+        }
+        for env_key in &pending {
             let kind = if env_key.ends_with("_KEY") {
                 "key"
             } else {
                 "value"
             };
+            step += 1;
             println!(
-                "  {}. Open {} and replace {} with the {kind} from Redis Cloud.",
-                index + 1,
+                "  {step}. Open {} and replace {} with the {kind} from Redis Cloud.",
                 bold(".env"),
                 bold(&format!("{env_key}=\"{}\"", engine::SECRET_PLACEHOLDER)),
             );
         }
         println!(
             "  {}. Run {} to validate the full setup.",
-            pending.len() + 1,
+            step + 1,
             bold("redisctl init --complete")
         );
         println!(

--- a/crates/redisctl/src/workflows/init/output.rs
+++ b/crates/redisctl/src/workflows/init/output.rs
@@ -78,6 +78,23 @@ fn progress_open_line(label: &str) -> String {
     format!("{}  {}", brand_red("◇"), dim(&format!("{label}...")))
 }
 
+/// An info line on the same rail column, so header facts between the questions
+/// and the status steps keep the rail unbroken.
+pub fn rail_line(s: &str) -> String {
+    format!("{}  {}", brand_red("◇"), s)
+}
+
+/// A bare rail row: the connector that carries the line across gaps between
+/// entries, clack-style.
+pub fn rail_gap() -> String {
+    brand_red("│")
+}
+
+/// The rail's closing corner, ending the step column before the summary.
+pub fn rail_end(label: &str) -> String {
+    format!("{}  {}", brand_red("└"), dim(label))
+}
+
 pub fn progress(label: &str) -> Progress {
     use std::io::Write;
     print!("{}", progress_open_line(label));
@@ -197,6 +214,12 @@ mod tests {
                 (RunKind::Block, "██".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn rail_gap_and_end_close_the_line() {
+        assert_eq!(rail_gap(), "│");
+        assert_eq!(rail_end("done"), "└  done");
     }
 
     #[test]

--- a/crates/redisctl/src/workflows/init/wizard.rs
+++ b/crates/redisctl/src/workflows/init/wizard.rs
@@ -85,13 +85,16 @@ impl Theme for RedisTheme {
         prompt: &str,
         sel: &str,
     ) -> std::fmt::Result {
+        // The trailing bare rail row carries the line to the next entry, so the
+        // clack rail never breaks between answered questions.
         write!(
             f,
-            "{}  {}\n{}  {}",
+            "{}  {}\n{}  {}\n{}",
             brand().apply_to('◇'),
             Style::new().bold().apply_to(prompt),
             brand().apply_to('│'),
-            Style::new().dim().apply_to(sel)
+            Style::new().dim().apply_to(sel),
+            brand().apply_to('│')
         )
     }
 
@@ -140,7 +143,28 @@ impl Theme for RedisTheme {
 }
 
 const DATABASE_PROMPT: &str = "Where should the database come from?";
-const DATABASE_ITEMS: [&str; 3] = ["Redis Cloud", "Local Redis", "Paste a connection string"];
+
+/// The database options, shaped by what .env already carries: an existing
+/// REDIS_URL leads (masked) and replaces the fill-in-later option - placeholders
+/// make no sense when the value is already there.
+fn database_items(env_url: Option<&str>) -> Vec<String> {
+    let mut items = Vec::new();
+    if let Some(url) = env_url {
+        items.push(format!(
+            "Keep the REDIS_URL already in .env  ({})",
+            engine::mask_url(url)
+        ));
+    }
+    items.extend(
+        ["Redis Cloud", "Local Redis", "Paste a connection string"]
+            .into_iter()
+            .map(str::to_string),
+    );
+    if env_url.is_none() {
+        items.push("Skip for now - fill in .env later".to_string());
+    }
+    items
+}
 const LOCAL_FOUND_PROMPT: &str = "Found a local Redis at localhost:6379 - use it?";
 const LOCAL_NONE_PROMPT: &str = "No local Redis found - create one?";
 const AGENTS_PROMPT: &str = "Which agent(s) should be configured?";
@@ -199,6 +223,11 @@ pub fn applies(args: &InitArgs, pending: &[Question]) -> bool {
 pub struct Answers {
     pub url: Option<String>,
     pub cloud: bool,
+    /// The user picked a concrete source (not "keep .env"), superseding any
+    /// REDIS_URL already there.
+    pub database_explicit: bool,
+    /// "Skip for now": write a placeholder REDIS_URL to fill in later.
+    pub placeholder: bool,
     pub agents: Option<Vec<engine::Agent>>,
     pub skills_global: Option<bool>,
 }
@@ -225,14 +254,23 @@ pub fn run(
     detected: &[engine::Agent],
     docker: bool,
     local: engine::LocalRedis,
+    env_url: Option<&str>,
 ) -> Result<Answers, RedisCtlError> {
     let mut answers = Answers::default();
     for question in pending {
         match question {
-            Question::Database => match ask_database(docker, local)? {
-                DatabaseChoice::Docker => {}
-                DatabaseChoice::Cloud => answers.cloud = true,
-                DatabaseChoice::Url(url) => answers.url = Some(url),
+            Question::Database => match ask_database(docker, local, env_url)? {
+                DatabaseChoice::KeepEnv => {}
+                DatabaseChoice::Placeholder => answers.placeholder = true,
+                DatabaseChoice::Docker => answers.database_explicit = true,
+                DatabaseChoice::Cloud => {
+                    answers.cloud = true;
+                    answers.database_explicit = true;
+                }
+                DatabaseChoice::Url(url) => {
+                    answers.url = Some(url);
+                    answers.database_explicit = true;
+                }
             },
             Question::Agents => answers.agents = Some(ask_agents(detected)?),
             Question::Skills => answers.skills_global = Some(ask_skills_scope()?),
@@ -242,6 +280,8 @@ pub fn run(
 }
 
 enum DatabaseChoice {
+    KeepEnv,
+    Placeholder,
     Docker,
     Cloud,
     Url(String),
@@ -250,21 +290,35 @@ enum DatabaseChoice {
 /// Redis Cloud leads and is the default; "Local Redis" reuses a server that is
 /// already running (asking for credentials when it wants them) and only falls back
 /// to creating a Docker container; a paste comes back as the URL.
-fn ask_database(docker: bool, local: engine::LocalRedis) -> Result<DatabaseChoice, RedisCtlError> {
+fn ask_database(
+    docker: bool,
+    local: engine::LocalRedis,
+    env_url: Option<&str>,
+) -> Result<DatabaseChoice, RedisCtlError> {
     const PROMPT: &str = DATABASE_PROMPT;
     // No tier qualifier on Redis Cloud: the cloud flow connects to existing
     // databases on any plan; only creating a new one defaults to the free plan.
+    let items = database_items(env_url);
     let selection = Select::with_theme(&RedisTheme)
         .with_prompt(PROMPT)
-        .items(&DATABASE_ITEMS)
+        .items(&items)
         .default(0)
         .interact_opt()
         .map_err(prompt_failed)?;
-    match selection {
-        None => Err(cancelled(PROMPT)),
-        Some(0) => Ok(DatabaseChoice::Cloud),
-        Some(1) => ask_local(docker, local),
-        _ => ask_paste(),
+    let Some(selection) = selection else {
+        return Err(cancelled(PROMPT));
+    };
+    // With an existing .env the keep-option occupies slot 0 and there is no
+    // fill-in-later slot; without one the list ends with it.
+    let offset = usize::from(env_url.is_some());
+    if env_url.is_some() && selection == 0 {
+        return Ok(DatabaseChoice::KeepEnv);
+    }
+    match selection - offset {
+        0 => Ok(DatabaseChoice::Cloud),
+        1 => ask_local(docker, local),
+        2 => ask_paste(),
+        _ => Ok(DatabaseChoice::Placeholder),
     }
 }
 
@@ -423,11 +477,40 @@ mod tests {
     }
 
     #[test]
+    fn an_answered_question_carries_a_trailing_rail_row() {
+        // The bare rail row under each answer keeps the clack line unbroken
+        // between entries.
+        let mut out = String::new();
+        RedisTheme
+            .format_select_prompt_selection(&mut out, "Q?", "Answer")
+            .unwrap();
+        assert!(out.trim_end().ends_with('│'), "{out}");
+    }
+
+    #[test]
     fn redis_cloud_leads_the_database_options() {
         assert_eq!(
-            DATABASE_ITEMS,
-            ["Redis Cloud", "Local Redis", "Paste a connection string"]
+            database_items(None),
+            [
+                "Redis Cloud",
+                "Local Redis",
+                "Paste a connection string",
+                "Skip for now - fill in .env later"
+            ]
         );
+    }
+
+    #[test]
+    fn an_existing_env_url_becomes_the_first_option_masked() {
+        let items = database_items(Some("redis://default:s3cret@host:6379"));
+        assert_eq!(
+            items[0],
+            "Keep the REDIS_URL already in .env  (redis://default:****@host:6379)"
+        );
+        assert!(!items[0].contains("s3cret"));
+        assert_eq!(items[1], "Redis Cloud");
+        // Placeholders make no sense when .env is already filled in.
+        assert!(!items.iter().any(|i| i.contains("Skip for now")));
     }
 
     #[test]

--- a/crates/redisctl/tests/init_cli_tests.rs
+++ b/crates/redisctl/tests/init_cli_tests.rs
@@ -264,9 +264,16 @@ fn rerun_with_a_url_reports_env_unchanged() {
 }
 
 #[test]
-fn a_different_existing_redis_url_is_kept_not_clobbered() {
+fn an_explicit_url_replaces_a_different_existing_redis_url() {
+    // Explicit beats implicit: --url is consent to supersede what .env carries.
+    // The note names the old value masked; only the implicit no-flags default
+    // keeps an existing REDIS_URL.
     let dir = tempfile::tempdir().unwrap();
-    std::fs::write(dir.path().join(".env"), "REDIS_URL=\"redis://keep-me:1\"\n").unwrap();
+    std::fs::write(
+        dir.path().join(".env"),
+        "REDIS_URL=\"redis://default:0ldpw@keep-me:1\"\n",
+    )
+    .unwrap();
     redisctl()
         .current_dir(dir.path())
         .args([
@@ -277,15 +284,40 @@ fn a_different_existing_redis_url_is_kept_not_clobbered() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains("kept"))
-        .stdout(predicate::str::contains("left untouched"))
+        .stdout(predicate::str::contains(
+            "REDIS_URL replaced (was redis://default:****@keep-me:1)",
+        ))
         // A short token here once collided with a random tempdir name printed in the
         // Project line; whole-output negative assertions need collision-proof tokens.
-        .stdout(predicate::str::contains("s3cret").not());
+        .stdout(predicate::str::contains("s3cret").not())
+        .stdout(predicate::str::contains("0ldpw").not());
+    // Dry run: nothing written yet.
     assert_eq!(
         std::fs::read_to_string(dir.path().join(".env")).unwrap(),
-        "REDIS_URL=\"redis://keep-me:1\"\n"
+        "REDIS_URL=\"redis://default:0ldpw@keep-me:1\"\n"
     );
+}
+
+#[test]
+fn a_placeholder_env_completes_with_action_required() {
+    // The wizard's "skip for now" leaves this placeholder; --complete must treat
+    // it as still pending instead of validating garbage, and exit 0.
+    let dir = tempfile::tempdir().unwrap();
+    let repo = skills_fixture();
+    std::fs::write(
+        dir.path().join(".env"),
+        "REDIS_URL=\"<paste-your-redis-url>\"\n",
+    )
+    .unwrap();
+    redisctl()
+        .current_dir(dir.path())
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
+        .args(["init", "--complete", "--no-install-cli"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("waiting for REDIS_URL"))
+        .stdout(predicate::str::contains("Action required"))
+        .stdout(predicate::str::contains("redisctl init --complete"));
 }
 
 #[test]

--- a/crates/redisctl/tests/init_cloud_tests.rs
+++ b/crates/redisctl/tests/init_cloud_tests.rs
@@ -528,40 +528,37 @@ async fn empty_account_creates_a_free_subscription_and_database() {
     assert!(env.contains("REDIS_URL=\""), "{env}");
 }
 
-#[test]
-fn existing_env_url_wins_over_cloud_and_provisions_nothing() {
+#[tokio::test(flavor = "multi_thread")]
+async fn an_explicit_cloud_flag_replaces_an_existing_env_url() {
+    // Explicit beats implicit: --cloud is consent to supersede what .env carries.
+    // The old value is named masked and the file ends up on the cloud database.
+    let cfg = tempfile::tempdir().unwrap();
     let project = tempfile::tempdir().unwrap();
     let repo = skills_fixture();
+    let server = MockServer::start().await;
+    write_cloud_profile(&cfg, &server.uri());
     let endpoint = format!("127.0.0.1:{}", fake_redis());
+    mount_both_tiers(&server, &endpoint).await;
     std::fs::write(
         project.path().join(".env"),
-        format!("REDIS_URL=\"redis://{endpoint}\"\n"),
+        "REDIS_URL=\"redis://default:0ldpw@stale-host:1\"\n",
     )
     .unwrap();
-    let before = std::fs::read_to_string(project.path().join(".env")).unwrap();
 
-    // No cloud profile and no CAPI mock exist: reaching the cloud client at all
-    // would fail this run, so success proves the existing value short-circuits.
-    let mut cmd = Command::cargo_bin("redisctl").unwrap();
-    cmd.env("REDISCTL_INIT_AMPLITUDE_KEY", "")
-        .current_dir(project.path())
-        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
-        .args([
-            "init",
-            "--cloud",
-            "--name",
-            "brand-new",
-            "--defaults",
-            "--no-install-cli",
-            "--agent",
-            "claude",
-        ])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("already carries REDIS_URL"))
-        .stdout(predicate::str::contains("existing .env"));
-    assert_eq!(
-        std::fs::read_to_string(project.path().join(".env")).unwrap(),
-        before
-    );
+    run_init_cloud(
+        &cfg,
+        project.path(),
+        &repo,
+        &["--name", "essentials-db", "--defaults", "--agent", "claude"],
+    )
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(
+        "REDIS_URL replaced (was redis://default:****@stale-host:1)",
+    ))
+    .stdout(predicate::str::contains("0ldpw").not())
+    .stdout(predicate::str::contains("✓ PING"));
+    let env = std::fs::read_to_string(project.path().join(".env")).unwrap();
+    assert!(env.contains(&endpoint), "{env}");
+    assert!(!env.contains("stale-host"), "{env}");
 }

--- a/crates/redisctl/tests/init_env_replace_tests.rs
+++ b/crates/redisctl/tests/init_env_replace_tests.rs
@@ -1,0 +1,43 @@
+//! Explicit URL replacement preserves credentials in the generated dotenv file.
+#![cfg(unix)]
+
+mod init_common;
+
+#[test]
+fn replacing_a_url_preserves_dollar_characters() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_common::skills_fixture();
+    std::fs::write(
+        dir.path().join(".env"),
+        "REDIS_URL=\"redis://localhost:6379\"\n",
+    )
+    .unwrap();
+    let url = "redis://default:abc$REDISCTL_TEST_UNSET@127.0.0.1:9";
+    assert_cmd::Command::cargo_bin("redisctl")
+        .unwrap()
+        .current_dir(dir.path())
+        .env("REDISCTL_INIT_AMPLITUDE_KEY", "")
+        .env("REDISCTL_INIT_SKILLS_REPO", repo.path())
+        .args([
+            "init",
+            "--url",
+            url,
+            "--no-install-cli",
+            "--agent",
+            "claude",
+        ])
+        .assert()
+        .code(10);
+    assert_eq!(
+        redisctl_init::read_env_key(dir.path(), ".env", "REDIS_URL").as_deref(),
+        Some(url)
+    );
+    let output = std::process::Command::new("sh")
+        .args(["-c", ". ./.env; printf '%s' \"$REDIS_URL\""])
+        .env_remove("REDISCTL_TEST_UNSET")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), url);
+}

--- a/docs/docs/getting-started/init.md
+++ b/docs/docs/getting-started/init.md
@@ -18,8 +18,8 @@ redisctl init              # apply it
    container from an earlier run (restarted if stopped), or a fresh local Docker
    container - or point it at any database with `--url` (a pasted Redis Cloud
    connect command works verbatim).
-3. **Wires the project**: `REDIS_URL` appended to `.env` (never clobbering an
-   existing value), a committed `.env.example` placeholder, a `.gitignore` guard,
+3. **Wires the project**: `REDIS_URL` written to `.env` (an explicit database
+   choice replaces an existing value), a committed `.env.example` placeholder, a `.gitignore` guard,
    the official Redis client for the detected runtime, and redis-cli when missing.
 4. **Teaches the agents**: the official [redis/agent-skills](https://github.com/redis/agent-skills)
    via the standard skills CLI, a generated `redis-project-setup` skill carrying this
@@ -27,9 +27,9 @@ redisctl init              # apply it
    per agent config.
 5. **Proves it works**: a live PING and SET/GET round trip.
 
-Re-running is safe: every line reports `unchanged` the second time. Env values,
-`.gitignore` entries, and skill files are never overwritten - existing values are
-reported `kept`. The one deliberate exception: a `redis` entry in an agent's MCP
+Re-running with the same choices preserves the existing setup. An explicit database
+choice replaces `REDIS_URL`; other env values are kept, including placeholders
+that need filling. A `redis` entry in an agent's MCP
 config that differs from the generated launcher is replaced (reported `updated`);
 other MCP servers in the file survive
 untouched.


### PR DESCRIPTION
Makes the wizard's database question honest about `.env`, and finishes the clack rail.

## Explicit beats implicit

Choosing Redis Cloud / Local Redis / Paste in the wizard, or passing `--cloud` / `--url`, previously lost to an existing `REDIS_URL` - the run silently downgraded to "existing .env" with a note (a stale URL then failed validation). Now an explicit choice replaces the line, reported honestly:

```
~ updated .env  REDIS_URL replaced (was redis://default:****@old-host:6390)
```

Only the implicit no-flags default still keeps `.env` untouched. This deliberately narrows the never-clobber contract from slice 9's review: never-clobber now means "never *silently*"; explicit consent supersedes.

## Two new wizard options

- **Keep the REDIS_URL already in .env** - leads the list (masked URL in the label) whenever `.env` has one.
- **Skip for now - fill in .env later** - writes `REDIS_URL="<paste-your-redis-url>"`, wires everything else (client SDK, skills, MCP), skips validation, and ends with the same Action-required pattern the Iris products use. `redisctl init --complete` validates once filled, and recognizes the placeholder as still pending.

## Unbroken rail

Answered questions carry a trailing bare `│` row, the Agents line and apply notes join the rail, and it closes with `└ done` before the summary - one continuous line from the first question to the last status step.

## Testing

- Engine: replace-mode writer (masks the old value; unchanged on same value; appends when absent), placeholder plan branch (hermetic - returns before any docker probe).
- CLI: `--url` and `--cloud` against a stale `.env` assert the masked "replaced" note and that no credential leaks; `--complete` on a placeholder exits 0 with "waiting for REDIS_URL"; the wizard option order and cancel-tip coverage are unit-pinned.
- The two tests that pinned the old silent-keep behavior were rewritten to the new contract (both observed failing first).
