### PR TITLE
feat(core): report password accounts needing a social link distinctly

### DIFF
--- a/crates/redisctl-core/src/auth/oidc.rs
+++ b/crates/redisctl-core/src/auth/oidc.rs
@@ -61,6 +61,14 @@ pub enum AuthError {
     /// The identity provider returned something unexpected or unparseable.
     #[error("unexpected identity-provider response: {0}")]
     Protocol(String),
+
+    /// The Redis Cloud account still authenticates with a password and has not been linked to a
+    /// social/SSO identity, so the token exchange cannot complete. Linking is a one-time step the
+    /// user performs in the Redis Cloud console.
+    #[error(
+        "this Redis Cloud account must be linked to social sign-in once before the CLI can use it"
+    )]
+    MigrationRequired,
 }
 
 /// A `BasicClient` with the Okta authorize / token / device-authorization endpoints set. The

--- a/crates/redisctl-core/src/auth/sm_api.rs
+++ b/crates/redisctl-core/src/auth/sm_api.rs
@@ -18,6 +18,10 @@ use url::Url;
 
 use super::{AuthError, default_http_client, endpoint, truncate};
 
+/// SM error code returned when a password-only account must be linked to social sign-in before it
+/// can authenticate this way. The consent step is console-only.
+const SOCIAL_MIGRATION_REQUIRED_CODE: &str = "user-agreement-for-social-login-migration-missing";
+
 /// Attribution sent on `POST /login`, mirroring what RedisInsight sends. SM records these on the
 /// signup path (`registerOktaUser` → `buildRegistrationItem`), so without them a user whose first
 /// contact with Redis Cloud is `cloud auth login` is registered with no originating tool.
@@ -57,6 +61,37 @@ struct Session {
     /// Full cookie header value, e.g. `JSESSIONID=abc123`.
     cookie: String,
     csrf: String,
+}
+
+/// SM's error envelope: `{"errors": {"status": 422, "code": "…"}}`.
+#[derive(Debug, Default, Deserialize)]
+struct SmErrorEnvelope {
+    errors: Option<SmError>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SmError {
+    code: Option<String>,
+}
+
+/// Pull the error code out of an SM response body, if it has the usual envelope.
+fn sm_error_code(body: &str) -> Option<String> {
+    serde_json::from_str::<SmErrorEnvelope>(body)
+        .ok()?
+        .errors?
+        .code
+}
+
+/// Classify a failed `POST /login`. Codes we can act on get their own variant; everything else
+/// stays a protocol error carrying the body for diagnosis.
+fn classify_login_error(status: reqwest::StatusCode, body: &str) -> AuthError {
+    match sm_error_code(body).as_deref() {
+        // A password-only account that has never signed in socially: SM asks for consent to link
+        // it, which only the console can collect. Surface it distinctly so the CLI can name that
+        // one-time step instead of reporting a generic failure.
+        Some(SOCIAL_MIGRATION_REQUIRED_CODE) => AuthError::MigrationRequired,
+        _ => AuthError::Protocol(format!("SM /login failed ({status}): {}", truncate(body))),
+    }
 }
 
 /// The authenticated user (`GET /users/me`), trimmed to what the bootstrap needs.
@@ -177,10 +212,7 @@ impl SmApiClient {
         let cookie = extract_jsessionid(&resp);
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Err(AuthError::Protocol(format!(
-                "SM /login failed ({status}): {}",
-                truncate(&body)
-            )));
+            return Err(classify_login_error(status, &body));
         }
         let cookie = cookie
             .ok_or_else(|| AuthError::Protocol("SM /login did not set a JSESSIONID".into()))?;
@@ -563,6 +595,28 @@ mod tests {
     /// SM records `utm_*` on the signup path, so a first-ever login through redisctl must carry
     /// attribution or the tool is invisible in signup analytics. The mock matches only if all three
     /// fields are present, and `utm_campaign` distinguishes the two flows.
+    /// A password-only account that hasn't been linked to social sign-in gets its own error, so
+    /// the CLI can point the user at the one-time console step instead of a generic failure.
+    #[tokio::test]
+    async fn login_social_migration_required_is_classified() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "errors": {
+                    "status": 422,
+                    "code": "user-agreement-for-social-login-migration-missing"
+                }
+            })))
+            .mount(&server)
+            .await;
+        let mut c = client(&server);
+        assert!(matches!(
+            c.login("ACCESS", None).await,
+            Err(AuthError::MigrationRequired)
+        ));
+    }
+
     #[tokio::test]
     async fn login_sends_utm_attribution_per_flow() {
         for (flow, campaign) in [

--- a/crates/redisctl/src/structured_error.rs
+++ b/crates/redisctl/src/structured_error.rs
@@ -76,6 +76,15 @@ impl StructuredError {
     pub fn keyring_unavailable(message: impl Into<String>) -> Self {
         Self::new("keyring_unavailable", 2, false, message)
     }
+    pub fn migration_required() -> Self {
+        Self::new(
+            "migration_required",
+            2,
+            false,
+            "this Redis Cloud account signs in with a password and must be linked to Google or \
+             GitHub once, in the Redis Cloud console, before the CLI can use it",
+        )
+    }
     pub fn invalid_name(message: impl Into<String>) -> Self {
         Self::new("invalid_name", 2, false, message)
     }
@@ -140,6 +149,9 @@ impl From<AuthError> for StructuredError {
             AuthError::Protocol(msg) => {
                 Self::sm_exchange_failed(format!("login exchange failed: {msg}"))
             }
+            // A one-time console step, not a failure to retry — give it its own code so an agent
+            // can tell the user what to do rather than surfacing a generic exchange error.
+            AuthError::MigrationRequired => Self::migration_required(),
         }
     }
 }
@@ -195,6 +207,10 @@ mod tests {
             StructuredError::from(AuthError::Protocol("boom".into())).code,
             "sm_exchange_failed"
         );
+        let mig = StructuredError::from(AuthError::MigrationRequired);
+        assert_eq!(mig.code, "migration_required");
+        assert_eq!(mig.exit_code, 2);
+        assert!(!mig.retryable);
     }
 
     #[test]

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -95,6 +95,15 @@ sequenceDiagram
     CLI-->>A: authenticated and account_id
 ```
 
+### Password accounts need linking once
+
+Redis Cloud accounts that sign in with an email and password cannot be used by the CLI directly —
+the sign-in happens at the identity provider, which never held that password. Sign in to the
+[Redis Cloud console](https://app.redislabs.com) once with **Google or GitHub using the same email
+address** and accept the prompt to link the account; afterwards `cloud auth login` works normally.
+
+Until that's done, login exits `2` with `migration_required`.
+
 ## Status
 
 ```bash
@@ -178,7 +187,7 @@ of parsing prose:
 | Exit code | Meaning | Example codes |
 |-----------|---------|---------------|
 | `1` | unknown / backend failure | `sm_exchange_failed` |
-| `2` | usage / precondition to fix | `not_authenticated`, `auth_denied`, `keyring_unavailable` |
+| `2` | usage / precondition to fix | `not_authenticated`, `auth_denied`, `keyring_unavailable`, `migration_required` |
 | `3` | transient / retryable | `device_code_expired`, `transient_api_error`, `rate_limited` |
 
 Human (non-JSON) mode prints the usual diagnostic to stderr and keeps today's `0`/`1` exit behavior.

--- a/docs/docs/reference/agent-error-codes.md
+++ b/docs/docs/reference/agent-error-codes.md
@@ -38,6 +38,7 @@ keeps today's `0` / `1` exit behavior.
 | `not_authenticated` | 2 | no | No usable credentials for the profile. Run `redisctl cloud auth login`. |
 | `auth_denied` | 2 | no | The sign-in request was denied. |
 | `keyring_unavailable` | 2 | no | No OS keyring available to store the key. Re-run with `--allow-plaintext`. |
+| `migration_required` | 2 | no | The account signs in with a password and must be linked to Google/GitHub once in the Redis Cloud console. |
 | `invalid_name` | 2 | no | The database name doesn't match the naming rules (see below). |
 | `name_conflict` | 2 | no | The name maps to a conflicting existing resource. |
 | `device_code_expired` | 3 | yes | The device login code expired before approval. Start login again. |


### PR DESCRIPTION
## Summary

A Redis Cloud account that signs in with an email and password cannot authenticate through the
identity provider — which never held that password. What happens instead is that the user clicks
**Sign in with Google** (the supported path), authenticates successfully, and then the token exchange
returns:

```
422  {"errors": {"code": "user-agreement-for-social-login-migration-missing"}}
```

Redis Cloud is asking for consent to link the existing password account to that social identity —
consent only the console can collect. That was collapsing into `sm_exchange_failed`, so the user was
told the exchange failed rather than what to do about it:

```
error: login exchange failed: SM /login failed (422): {"errors":{"code":"user-agreement-...
```

It now maps to `migration_required` (exit 2), whose message names the one-time console step.

Worth noting the error appears on the **social** login path, not a password one — so it is reachable
by anyone doing exactly what the CLI supports, and it is the on-ramp from an unsupported account into
a supported one.

## Scope

- Affected areas: `crates/redisctl-core/src/auth/sm_api.rs`, `crates/redisctl-core/src/auth/oidc.rs`, `crates/redisctl/src/structured_error.rs`
- API surface changes: new `AuthError::MigrationRequired`; new `migration_required` error code (exit 2)
- Docs/tests updates: a section in the auth docs explaining the console step, plus the code inventory row

Also introduces the SM error-envelope parsing (`{"errors": {"code": …}}`) and a single place to
classify a failed `/login`, rather than matching on the raw response body. Codes we can act on get a
variant; everything else keeps the body for diagnosis.

## Testing

```bash
cargo test -p redisctl-core --lib auth::sm_api
```

`login_social_migration_required_is_classified` asserts the 422 becomes `MigrationRequired` rather
than a generic protocol error.

**Verified against a live QA environment**: a password account signing in with Google on the same
address produced exactly this message instead of the raw JSON.

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [x] Ready for review
- [x] Squash and merge when approved