### PR TITLE
feat(core): handle SM multi-factor challenges during cloud auth login

### DIFF
--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -104,16 +104,47 @@ impl CloudAuthenticator {
     }
 
     /// Given tokens from a flow, run the SM exchange and mint a CAPI key named `key_name`.
+    ///
+    /// Propagates [`AuthError::MfaRequired`] if the account is MFA-protected; use
+    /// [`CloudAuthenticator::complete_login_with_mfa`] to supply codes interactively.
     pub async fn complete_login(
         &self,
         tokens: &TokenSet,
         key_name: &str,
         flow: LoginFlow,
     ) -> Result<MintedCredentials, AuthError> {
+        self.complete_login_with_mfa(tokens, key_name, flow, |_, _| Ok(None))
+            .await
+    }
+
+    /// As [`CloudAuthenticator::complete_login`], but `mfa_prompt` is consulted when SM challenges
+    /// the login for multi-factor authentication.
+    ///
+    /// `mfa_prompt(factors, attempt)` is called with the factor types SM offered (possibly empty)
+    /// and a 1-based attempt number. Return `Some(code)` to submit a TOTP code, or `None` to give
+    /// up — which surfaces the original [`AuthError::MfaRequired`] to the caller, the right
+    /// behaviour when there is no terminal to prompt on.
+    pub async fn complete_login_with_mfa<F>(
+        &self,
+        tokens: &TokenSet,
+        key_name: &str,
+        flow: LoginFlow,
+        mut mfa_prompt: F,
+    ) -> Result<MintedCredentials, AuthError>
+    where
+        F: FnMut(&[String], u32) -> Result<Option<String>, AuthError>,
+    {
         let mut sm =
             SmApiClient::with_http_client(self.sm_api_url.clone(), self.http.clone(), flow);
         // Google/GitHub logins must not send Sm-Id-Token (SSO-only); see sm_api docs.
-        sm.login(&tokens.access_token, None).await?;
+        match sm.login(&tokens.access_token, None).await {
+            Ok(()) => {}
+            Err(AuthError::MfaRequired { factors }) => {
+                self.satisfy_mfa(&mut sm, tokens, &factors, &mut mfa_prompt)
+                    .await?
+            }
+            Err(e) => return Err(e),
+        }
         let user = sm.fetch_current_user().await?;
         sm.ensure_capi_enabled().await?;
         // Pick the account matching the logged-in user's current_account_id. /accounts list
@@ -146,7 +177,39 @@ impl CloudAuthenticator {
             redisctl_key_count,
         })
     }
+
+    /// Drive the MFA retry loop against an already-challenged client.
+    async fn satisfy_mfa<F>(
+        &self,
+        sm: &mut SmApiClient,
+        tokens: &TokenSet,
+        factors: &[String],
+        mfa_prompt: &mut F,
+    ) -> Result<(), AuthError>
+    where
+        F: FnMut(&[String], u32) -> Result<Option<String>, AuthError>,
+    {
+        for attempt in 1..=MFA_MAX_ATTEMPTS {
+            let Some(code) = mfa_prompt(factors, attempt)? else {
+                // Caller can't prompt (no TTY / agent): report the challenge, not a failure.
+                return Err(AuthError::MfaRequired {
+                    factors: factors.to_vec(),
+                });
+            };
+            match sm.complete_mfa(&tokens.access_token, None, &code).await {
+                Ok(()) => return Ok(()),
+                // Wrong code: loop and let the caller re-prompt, unless attempts are spent.
+                Err(AuthError::MfaInvalidCode) if attempt < MFA_MAX_ATTEMPTS => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        Err(AuthError::MfaInvalidCode)
+    }
 }
+
+/// How many TOTP codes a single login will accept before giving up. SM enforces its own quota
+/// (`mfa-quota-exceeded`); this only bounds our prompting.
+const MFA_MAX_ATTEMPTS: u32 = 3;
 
 /// Choose the account matching `current_account_id` (the logged-in user context); fall back to
 /// the first account only when the id is absent or not present in the list.

--- a/crates/redisctl-core/src/auth/oidc.rs
+++ b/crates/redisctl-core/src/auth/oidc.rs
@@ -69,6 +69,19 @@ pub enum AuthError {
         "this Redis Cloud account must be linked to social sign-in once before the CLI can use it"
     )]
     MigrationRequired,
+
+    /// SM challenged the login for multi-factor authentication (`user-mfa-required`). Carries the
+    /// factor types SM offered, when it reports them.
+    #[error("this account requires multi-factor authentication")]
+    MfaRequired { factors: Vec<String> },
+
+    /// The submitted MFA code was rejected (`mfa-invalid-code`).
+    #[error("the multi-factor code was not accepted")]
+    MfaInvalidCode,
+
+    /// Too many MFA attempts (`mfa-quota-exceeded`); retrying now will not help.
+    #[error("too many multi-factor attempts; wait before trying again")]
+    MfaQuotaExceeded,
 }
 
 /// A `BasicClient` with the Okta authorize / token / device-authorization endpoints set. The

--- a/crates/redisctl-core/src/auth/sm_api.rs
+++ b/crates/redisctl-core/src/auth/sm_api.rs
@@ -21,6 +21,20 @@ use super::{AuthError, default_http_client, endpoint, truncate};
 /// SM error code returned when a password-only account must be linked to social sign-in before it
 /// can authenticate this way. The consent step is console-only.
 const SOCIAL_MIGRATION_REQUIRED_CODE: &str = "user-agreement-for-social-login-migration-missing";
+/// SM error code for an MFA challenge on `/login`.
+const MFA_REQUIRED_CODE: &str = "user-mfa-required";
+/// SM error code for a rejected MFA code.
+const MFA_INVALID_CODE: &str = "mfa-invalid-code";
+/// SM error code for an `mfa_type` it does not recognise — a client bug, not a user error.
+const MFA_INVALID_TYPE_CODE: &str = "mfa-invalid-type";
+/// SM error code for too many MFA attempts.
+const MFA_QUOTA_EXCEEDED_CODE: &str = "mfa-quota-exceeded";
+/// The only MFA type we submit. SM also knows SMS and Email, but TOTP is what a CLI can prompt for.
+///
+/// Case matters: SM resolves this with `EnumMFAType.toEnum`, which compares against the enum
+/// constant name (`SMS`, `Totp`, `Email`) verbatim — there is no custom `toString`. Sending
+/// `"totp"` is rejected with `mfa-invalid-type`. RedisInsight sends the same `"Totp"`.
+const MFA_TYPE_TOTP: &str = "Totp";
 
 /// Attribution sent on `POST /login`, mirroring what RedisInsight sends. SM records these on the
 /// signup path (`registerOktaUser` → `buildRegistrationItem`), so without them a user whose first
@@ -55,6 +69,10 @@ pub struct SmApiClient {
     session: Option<Session>,
     /// Which flow produced the tokens, reported to SM as `utm_campaign`.
     flow: LoginFlow,
+    /// JSESSIONID from an MFA-challenged `/login`. SM keeps the challenge state in that session,
+    /// so [`SmApiClient::complete_mfa`] must reuse this exact cookie — a fresh session has no
+    /// challenge to verify against.
+    pending_mfa_cookie: Option<String>,
 }
 
 struct Session {
@@ -63,7 +81,7 @@ struct Session {
     csrf: String,
 }
 
-/// SM's error envelope: `{"errors": {"status": 422, "code": "…"}}`.
+/// SM's error envelope: `{"errors": {"status": 401, "code": "…", "params": …}}`.
 #[derive(Debug, Default, Deserialize)]
 struct SmErrorEnvelope {
     errors: Option<SmError>,
@@ -72,26 +90,50 @@ struct SmErrorEnvelope {
 #[derive(Debug, Default, Deserialize)]
 struct SmError {
     code: Option<String>,
+    /// Free-form; for MFA it carries the offered factors. Shape is not contractual, so it is
+    /// parsed best-effort and never allowed to fail the classification.
+    params: Option<serde_json::Value>,
 }
 
 /// Pull the error code out of an SM response body, if it has the usual envelope.
-fn sm_error_code(body: &str) -> Option<String> {
-    serde_json::from_str::<SmErrorEnvelope>(body)
-        .ok()?
-        .errors?
-        .code
+fn sm_error_code(body: &str) -> Option<(String, Option<serde_json::Value>)> {
+    let env: SmErrorEnvelope = serde_json::from_str(body).ok()?;
+    let err = env.errors?;
+    Some((err.code?, err.params))
 }
 
-/// Classify a failed `POST /login`. Codes we can act on get their own variant; everything else
-/// stays a protocol error carrying the body for diagnosis.
-fn classify_login_error(status: reqwest::StatusCode, body: &str) -> AuthError {
-    match sm_error_code(body).as_deref() {
-        // A password-only account that has never signed in socially: SM asks for consent to link
-        // it, which only the console can collect. Surface it distinctly so the CLI can name that
-        // one-time step instead of reporting a generic failure.
-        Some(SOCIAL_MIGRATION_REQUIRED_CODE) => AuthError::MigrationRequired,
-        _ => AuthError::Protocol(format!("SM /login failed ({status}): {}", truncate(body))),
+/// Best-effort extraction of MFA factor names from SM's `params`. Returns an empty list rather
+/// than failing: the factor list is cosmetic (it only enriches the prompt).
+fn mfa_factors(params: Option<&serde_json::Value>) -> Vec<String> {
+    fn strings(v: &serde_json::Value, out: &mut Vec<String>) {
+        match v {
+            serde_json::Value::String(s) => {
+                // `params` is sometimes a JSON-encoded string; try one level of nesting.
+                if let Ok(inner) = serde_json::from_str::<serde_json::Value>(s) {
+                    strings(&inner, out);
+                } else if !s.is_empty() {
+                    out.push(s.clone());
+                }
+            }
+            serde_json::Value::Array(items) => items.iter().for_each(|i| strings(i, out)),
+            serde_json::Value::Object(map) => {
+                for key in ["type", "factorType", "mfaType"] {
+                    if let Some(serde_json::Value::String(s)) = map.get(key) {
+                        out.push(s.clone());
+                        return;
+                    }
+                }
+                map.values().for_each(|v| strings(v, out));
+            }
+            _ => {}
+        }
     }
+    let mut out = Vec::new();
+    if let Some(p) = params {
+        strings(p, &mut out);
+    }
+    out.dedup();
+    out
 }
 
 /// The authenticated user (`GET /users/me`), trimmed to what the bootstrap needs.
@@ -168,6 +210,7 @@ impl SmApiClient {
             http: default_http_client(),
             session: None,
             flow,
+            pending_mfa_cookie: None,
         }
     }
 
@@ -178,16 +221,57 @@ impl SmApiClient {
             http,
             session: None,
             flow,
+            pending_mfa_cookie: None,
         }
     }
 
     /// Establish a session: `POST /login` with the Okta access token, then fetch the CSRF
     /// token. Pass `sm_id_token` only for SSO logins (omit for Google/GitHub).
+    ///
+    /// Returns [`AuthError::MfaRequired`] when SM challenges the login; call
+    /// [`SmApiClient::complete_mfa`] on this same client to finish it.
     pub async fn login(
         &mut self,
         access_token: &str,
         sm_id_token: Option<&str>,
     ) -> Result<(), AuthError> {
+        self.post_login(access_token, sm_id_token, None, None).await
+    }
+
+    /// Finish an MFA-challenged login with a TOTP code, reusing the challenged session.
+    ///
+    /// Errors with [`AuthError::Protocol`] if no challenge is outstanding — submitting a code on a
+    /// fresh session cannot work, because SM verifies it against challenge state held in the
+    /// session it issued.
+    pub async fn complete_mfa(
+        &mut self,
+        access_token: &str,
+        sm_id_token: Option<&str>,
+        code: &str,
+    ) -> Result<(), AuthError> {
+        let cookie = self.pending_mfa_cookie.clone().ok_or_else(|| {
+            AuthError::Protocol("no outstanding SM multi-factor challenge to complete".into())
+        })?;
+        self.post_login(access_token, sm_id_token, Some(code), Some(&cookie))
+            .await
+    }
+
+    async fn post_login(
+        &mut self,
+        access_token: &str,
+        sm_id_token: Option<&str>,
+        mfa_code: Option<&str>,
+        mfa_cookie: Option<&str>,
+    ) -> Result<(), AuthError> {
+        let mut body = serde_json::json!({
+            "utm_source": UTM_SOURCE,
+            "utm_medium": UTM_MEDIUM,
+            "utm_campaign": self.flow.as_str(),
+        });
+        if let Some(code) = mfa_code {
+            body["mfa_type"] = MFA_TYPE_TOTP.into();
+            body["mfa_code"] = code.into();
+        }
         let mut req = self
             .http
             .post(endpoint(&self.base_url, "login"))
@@ -196,32 +280,63 @@ impl SmApiClient {
                 format!("Bearer {access_token}"),
             )
             .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .body(
-                serde_json::json!({
-                    "utm_source": UTM_SOURCE,
-                    "utm_medium": UTM_MEDIUM,
-                    "utm_campaign": self.flow.as_str(),
-                })
-                .to_string(),
-            );
+            .body(body.to_string());
         if let Some(id) = sm_id_token {
             req = req.header("sm-id-token", id);
         }
+        if let Some(c) = mfa_cookie {
+            req = req.header(reqwest::header::COOKIE, format!("JSESSIONID={c}"));
+        }
         let resp = req.send().await?;
         let status = resp.status();
+        // Read the cookie before consuming the body: on an MFA challenge the session carrying the
+        // challenge arrives on the *error* response, and the retry must reuse it.
         let cookie = extract_jsessionid(&resp);
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Err(classify_login_error(status, &body));
+            return Err(self.classify_login_error(status, &body, cookie, mfa_cookie));
         }
         let cookie = cookie
+            .or_else(|| mfa_cookie.map(str::to_string))
             .ok_or_else(|| AuthError::Protocol("SM /login did not set a JSESSIONID".into()))?;
         let csrf = self.fetch_csrf(&cookie).await?;
         self.session = Some(Session {
             cookie: format!("JSESSIONID={cookie}"),
             csrf,
         });
+        self.pending_mfa_cookie = None;
         Ok(())
+    }
+
+    fn classify_login_error(
+        &mut self,
+        status: reqwest::StatusCode,
+        body: &str,
+        cookie: Option<String>,
+        previous_cookie: Option<&str>,
+    ) -> AuthError {
+        match sm_error_code(body) {
+            Some((code, params)) if code == MFA_REQUIRED_CODE => {
+                // Keep the challenged session for the retry; SM may or may not re-issue it.
+                self.pending_mfa_cookie = cookie.or_else(|| previous_cookie.map(str::to_string));
+                AuthError::MfaRequired {
+                    factors: mfa_factors(params.as_ref()),
+                }
+            }
+            Some((code, _)) if code == SOCIAL_MIGRATION_REQUIRED_CODE => {
+                AuthError::MigrationRequired
+            }
+            Some((code, _)) if code == MFA_INVALID_CODE => AuthError::MfaInvalidCode,
+            // We sent an mfa_type SM does not accept. Never the user's fault, and retrying the
+            // same request cannot help, so say so plainly rather than blaming their code.
+            Some((code, _)) if code == MFA_INVALID_TYPE_CODE => AuthError::Protocol(
+                "the multi-factor type this client sent was rejected by Redis Cloud \
+                 (mfa-invalid-type); this is a bug in redisctl, please report it"
+                    .to_string(),
+            ),
+            Some((code, _)) if code == MFA_QUOTA_EXCEEDED_CODE => AuthError::MfaQuotaExceeded,
+            _ => AuthError::Protocol(format!("SM /login failed ({status}): {}", truncate(body))),
+        }
     }
 
     async fn fetch_csrf(&self, jsessionid: &str) -> Result<String, AuthError> {
@@ -595,28 +710,6 @@ mod tests {
     /// SM records `utm_*` on the signup path, so a first-ever login through redisctl must carry
     /// attribution or the tool is invisible in signup analytics. The mock matches only if all three
     /// fields are present, and `utm_campaign` distinguishes the two flows.
-    /// A password-only account that hasn't been linked to social sign-in gets its own error, so
-    /// the CLI can point the user at the one-time console step instead of a generic failure.
-    #[tokio::test]
-    async fn login_social_migration_required_is_classified() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/login"))
-            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
-                "errors": {
-                    "status": 422,
-                    "code": "user-agreement-for-social-login-migration-missing"
-                }
-            })))
-            .mount(&server)
-            .await;
-        let mut c = client(&server);
-        assert!(matches!(
-            c.login("ACCESS", None).await,
-            Err(AuthError::MigrationRequired)
-        ));
-    }
-
     #[tokio::test]
     async fn login_sends_utm_attribution_per_flow() {
         for (flow, campaign) in [
@@ -646,6 +739,179 @@ mod tests {
             let mut c = SmApiClient::new(Url::parse(&server.uri()).unwrap(), flow);
             c.login("ACCESS", None).await.unwrap();
         }
+    }
+
+    /// The MFA retry must keep the attribution alongside the code.
+    #[tokio::test]
+    async fn mfa_retry_still_carries_utm() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .and(body_string_contains("\"mfa_code\":\"123456\""))
+            // Case-sensitive on SM's side; lowercase is rejected as mfa-invalid-type.
+            .and(body_string_contains("\"mfa_type\":\"Totp\""))
+            .and(body_string_contains("\"utm_source\":\"redisctl\""))
+            .respond_with(ResponseTemplate::new(200).append_header("Set-Cookie", "JSESSIONID=S"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/csrf"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "csrfToken": { "csrf_token": "CSRF", "csrf_enabled": true, "errors": [] }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .append_header("Set-Cookie", "JSESSIONID=CH; Path=/")
+                    .set_body_json(serde_json::json!({
+                        "errors": { "status": 401, "code": "user-mfa-required" }
+                    })),
+            )
+            .mount(&server)
+            .await;
+        let mut c = client(&server);
+        assert!(matches!(
+            c.login("ACCESS", None).await,
+            Err(AuthError::MfaRequired { .. })
+        ));
+        c.complete_mfa("ACCESS", None, "123456").await.unwrap();
+    }
+
+    /// A password-only account that hasn't been linked to social sign-in gets its own error, so
+    /// the CLI can point the user at the one-time console step instead of a generic failure.
+    #[tokio::test]
+    async fn login_social_migration_required_is_classified() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "errors": {
+                    "status": 422,
+                    "code": "user-agreement-for-social-login-migration-missing"
+                }
+            })))
+            .mount(&server)
+            .await;
+        let mut c = client(&server);
+        assert!(matches!(
+            c.login("ACCESS", None).await,
+            Err(AuthError::MigrationRequired)
+        ));
+    }
+
+    /// SM answers the first `/login` with `user-mfa-required`; the factors come back for the prompt.
+    #[tokio::test]
+    async fn login_reports_mfa_challenge_with_factors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .append_header("Set-Cookie", "JSESSIONID=CHALLENGED; Path=/")
+                    .set_body_json(serde_json::json!({
+                        "errors": { "status": 401, "code": "user-mfa-required",
+                                    "params": [{ "type": "totp" }] }
+                    })),
+            )
+            .mount(&server)
+            .await;
+        let mut c = client(&server);
+        match c.login("ACCESS", None).await {
+            Err(AuthError::MfaRequired { factors }) => assert_eq!(factors, vec!["totp"]),
+            other => panic!("expected MfaRequired, got {other:?}"),
+        }
+    }
+
+    /// The regression that matters: SM holds the challenge in the session it issued on the *401*,
+    /// so the retry must send that exact JSESSIONID back. The mock only matches if it does.
+    #[tokio::test]
+    async fn complete_mfa_reuses_the_challenged_session() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .and(header("cookie", "JSESSIONID=CHALLENGED"))
+            .and(body_string_contains("\"mfa_code\":\"123456\""))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/csrf"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "csrfToken": { "csrf_token": "CSRF", "csrf_enabled": true, "errors": [] }
+            })))
+            .mount(&server)
+            .await;
+        // Unmatched-request fallback: the challenge itself.
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .append_header("Set-Cookie", "JSESSIONID=CHALLENGED; Path=/")
+                    .set_body_json(serde_json::json!({
+                        "errors": { "status": 401, "code": "user-mfa-required" }
+                    })),
+            )
+            .mount(&server)
+            .await;
+
+        let mut c = client(&server);
+        assert!(matches!(
+            c.login("ACCESS", None).await,
+            Err(AuthError::MfaRequired { .. })
+        ));
+        // Succeeds only because the challenged cookie was carried over.
+        c.complete_mfa("ACCESS", None, "123456").await.unwrap();
+    }
+
+    /// A code with no outstanding challenge can never succeed against SM, so fail locally rather
+    /// than sending a request that would trip over missing session state.
+    #[tokio::test]
+    async fn complete_mfa_without_a_challenge_errors() {
+        let server = MockServer::start().await;
+        let mut c = client(&server);
+        assert!(matches!(
+            c.complete_mfa("ACCESS", None, "123456").await,
+            Err(AuthError::Protocol(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn mfa_error_codes_are_classified() {
+        for (code, want_invalid) in [("mfa-invalid-code", true), ("mfa-quota-exceeded", false)] {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/login"))
+                .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                    "errors": { "status": 400, "code": code }
+                })))
+                .mount(&server)
+                .await;
+            let mut c = client(&server);
+            let got = c.login("ACCESS", None).await;
+            if want_invalid {
+                assert!(matches!(got, Err(AuthError::MfaInvalidCode)), "{code}");
+            } else {
+                assert!(matches!(got, Err(AuthError::MfaQuotaExceeded)), "{code}");
+            }
+        }
+    }
+
+    #[test]
+    fn mfa_factors_tolerates_shapes_we_have_not_seen() {
+        assert!(mfa_factors(None).is_empty());
+        assert!(mfa_factors(Some(&serde_json::json!({}))).is_empty());
+        // A JSON-encoded string payload, which SM sometimes uses for `params`.
+        assert_eq!(
+            mfa_factors(Some(&serde_json::json!(
+                r#"[{"factorType":"token:software:totp"}]"#
+            ))),
+            vec!["token:software:totp"]
+        );
+        // Never panics on unexpected scalars.
+        assert!(mfa_factors(Some(&serde_json::json!(7))).is_empty());
     }
 
     #[tokio::test]

--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -18,6 +18,7 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use redisctl_core::AuthError;
 use redisctl_core::auth::{CloudAuthenticator, LoginFlow, MintedCredentials};
 use redisctl_core::{CloudAuthConfig, Config, CredentialStore, DeviceAuthorization, TokenSet};
 use serde::{Deserialize, Serialize};
@@ -206,7 +207,7 @@ async fn initiate_device_login(
 async fn run_device_flow_blocking(auth: &CloudAuthenticator) -> CliResult<TokenSet> {
     let client = auth.device();
     let authz = client.start(&SCOPES).await.map_err(auth_err)?;
-    eprintln!("{}(waiting for approval…)", device_instructions(&authz));
+    eprintln!("{}(waiting for approval…)", device_instructions(&authz),);
 
     // oauth2 owns the poll loop (honoring the server's interval / slow_down); `None` polls until
     // the device code's own lifetime expires, which surfaces as `device_code_expired` via auth_err.
@@ -225,6 +226,44 @@ async fn run_loopback_flow(auth: &CloudAuthenticator) -> CliResult<TokenSet> {
     Ok(tokens)
 }
 
+/// Ask the user for a TOTP code when SM challenges the login for MFA.
+///
+/// Returns `Ok(None)` when there is no terminal to prompt on — an agent can't produce a
+/// time-based code, so the caller reports `mfa_required` and the human re-runs interactively.
+/// The `^\d{6}$` check is local on purpose: a malformed value would otherwise consume one of the
+/// user's server-side attempts.
+fn prompt_mfa_code(factors: &[String], attempt: u32) -> Result<Option<String>, AuthError> {
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return Ok(None);
+    }
+    if attempt == 1 {
+        let detail = if factors.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", factors.join(", "))
+        };
+        eprintln!("\nThis account requires multi-factor authentication{detail}.");
+    } else {
+        eprintln!(
+            "That code wasn't accepted. {} attempt(s) left.",
+            4 - attempt
+        );
+    }
+    loop {
+        eprint!("Enter the 6-digit code from your authenticator app: ");
+        let _ = std::io::Write::flush(&mut std::io::stderr());
+        let mut line = String::new();
+        if std::io::stdin().read_line(&mut line).unwrap_or(0) == 0 {
+            return Ok(None); // EOF / Ctrl-D
+        }
+        let code = line.trim();
+        if code.len() == 6 && code.chars().all(|c| c.is_ascii_digit()) {
+            return Ok(Some(code.to_string()));
+        }
+        eprintln!("Codes are exactly 6 digits.");
+    }
+}
+
 /// Run the SM exchange, persist the profile + secrets, and return the minted credentials.
 async fn complete_and_persist(
     conn_mgr: &ConnectionManager,
@@ -236,7 +275,7 @@ async fn complete_and_persist(
     flow: LoginFlow,
 ) -> CliResult<MintedCredentials> {
     let creds = authenticator
-        .complete_login(tokens, &default_key_name(), flow)
+        .complete_login_with_mfa(tokens, &default_key_name(), flow, prompt_mfa_code)
         .await
         .map_err(auth_err)?;
 

--- a/crates/redisctl/src/structured_error.rs
+++ b/crates/redisctl/src/structured_error.rs
@@ -85,6 +85,31 @@ impl StructuredError {
              GitHub once, in the Redis Cloud console, before the CLI can use it",
         )
     }
+    pub fn mfa_required() -> Self {
+        Self::new(
+            "mfa_required",
+            2,
+            false,
+            "this account requires multi-factor authentication; run `redisctl cloud auth login` \
+             in an interactive terminal to enter the code",
+        )
+    }
+    pub fn mfa_invalid_code() -> Self {
+        Self::new(
+            "mfa_invalid_code",
+            2,
+            false,
+            "the multi-factor code was not accepted; start login again",
+        )
+    }
+    pub fn mfa_quota_exceeded() -> Self {
+        Self::new(
+            "mfa_quota_exceeded",
+            4,
+            false,
+            "too many multi-factor attempts; wait before trying again",
+        )
+    }
     pub fn invalid_name(message: impl Into<String>) -> Self {
         Self::new("invalid_name", 2, false, message)
     }
@@ -152,6 +177,11 @@ impl From<AuthError> for StructuredError {
             // A one-time console step, not a failure to retry — give it its own code so an agent
             // can tell the user what to do rather than surfacing a generic exchange error.
             AuthError::MigrationRequired => Self::migration_required(),
+            // Reached only when there was no terminal to prompt on: the caller must re-run
+            // interactively, so this is a precondition to fix rather than a retryable failure.
+            AuthError::MfaRequired { .. } => Self::mfa_required(),
+            AuthError::MfaInvalidCode => Self::mfa_invalid_code(),
+            AuthError::MfaQuotaExceeded => Self::mfa_quota_exceeded(),
         }
     }
 }
@@ -211,6 +241,19 @@ mod tests {
         assert_eq!(mig.code, "migration_required");
         assert_eq!(mig.exit_code, 2);
         assert!(!mig.retryable);
+        // MFA reaches the structured path only when we couldn't prompt, so it's a precondition
+        // (exit 2) the caller fixes by re-running interactively — never "retryable".
+        let mfa = StructuredError::from(AuthError::MfaRequired { factors: vec![] });
+        assert_eq!(mfa.code, "mfa_required");
+        assert_eq!(mfa.exit_code, 2);
+        assert!(!mfa.retryable);
+        assert_eq!(
+            StructuredError::from(AuthError::MfaInvalidCode).code,
+            "mfa_invalid_code"
+        );
+        let quota = StructuredError::from(AuthError::MfaQuotaExceeded);
+        assert_eq!(quota.code, "mfa_quota_exceeded");
+        assert_eq!(quota.exit_code, 4);
     }
 
     #[test]

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -61,6 +61,7 @@ sequenceDiagram
     CLI->>OK: exchange code and PKCE verifier for tokens
     OK-->>CLI: access and refresh tokens
     CLI->>SM: sign in, enable programmatic access, mint an API key
+    Note over CLI,SM: if the account has MFA: prompt for a 6-digit code, retry on the same session
     SM-->>CLI: account API key and user secret
     CLI->>CFG: write cloud profile (secrets to keyring)
     CLI-->>U: signed in - profile ready
@@ -90,10 +91,30 @@ sequenceDiagram
     CLI->>OK: poll for tokens until approved
     OK-->>CLI: access and refresh tokens
     CLI->>SM: sign in, enable access, mint an API key
+    Note over CLI,SM: if the account has MFA: needs a terminal, else exits mfa_required
     SM-->>CLI: account API key and user secret
     CLI->>CFG: write cloud profile (secrets to keyring)
     CLI-->>A: authenticated and account_id
 ```
+
+### Multi-factor authentication
+
+If your Redis Cloud account has MFA enabled, `login` prompts for the 6-digit code from your
+authenticator app after you sign in, then completes normally:
+
+```
+✓ Authenticated as user@example.com
+This account requires multi-factor authentication.
+Enter the 6-digit code from your authenticator app:
+```
+
+You get three attempts per login.
+
+!!! note "MFA needs an interactive terminal"
+    A time-based code can't be supplied ahead of time, so MFA can't be completed
+    non-interactively. Piped or agent-driven runs exit `2` with `mfa_required`; re-run
+    `redisctl cloud auth login` in a terminal. For unattended automation, use a
+    pre-created API key instead of `auth login`.
 
 ### Password accounts need linking once
 
@@ -187,7 +208,7 @@ of parsing prose:
 | Exit code | Meaning | Example codes |
 |-----------|---------|---------------|
 | `1` | unknown / backend failure | `sm_exchange_failed` |
-| `2` | usage / precondition to fix | `not_authenticated`, `auth_denied`, `keyring_unavailable`, `migration_required` |
+| `2` | usage / precondition to fix | `not_authenticated`, `auth_denied`, `keyring_unavailable`, `migration_required`, `mfa_required` |
 | `3` | transient / retryable | `device_code_expired`, `transient_api_error`, `rate_limited` |
 
 Human (non-JSON) mode prints the usual diagnostic to stderr and keeps today's `0`/`1` exit behavior.

--- a/docs/docs/reference/agent-error-codes.md
+++ b/docs/docs/reference/agent-error-codes.md
@@ -39,6 +39,8 @@ keeps today's `0` / `1` exit behavior.
 | `auth_denied` | 2 | no | The sign-in request was denied. |
 | `keyring_unavailable` | 2 | no | No OS keyring available to store the key. Re-run with `--allow-plaintext`. |
 | `migration_required` | 2 | no | The account signs in with a password and must be linked to Google/GitHub once in the Redis Cloud console. |
+| `mfa_required` | 2 | no | The account requires multi-factor authentication and there was no terminal to prompt on. Re-run `cloud auth login` interactively. |
+| `mfa_invalid_code` | 2 | no | The multi-factor code was rejected. Start login again. |
 | `invalid_name` | 2 | no | The database name doesn't match the naming rules (see below). |
 | `name_conflict` | 2 | no | The name maps to a conflicting existing resource. |
 | `device_code_expired` | 3 | yes | The device login code expired before approval. Start login again. |
@@ -47,6 +49,7 @@ keeps today's `0` / `1` exit behavior.
 | `rate_limited` | 3 | yes | Too many requests. Back off and retry. |
 | `free_db_exists` | 4 | no | The account already has a free database. |
 | `quota_exceeded` | 4 | no | An account quota or limit was reached. |
+| `mfa_quota_exceeded` | 4 | no | Too many multi-factor attempts. Wait before trying again. |
 | `sm_exchange_failed` | 1 | no | The sign-in / key-mint exchange failed unexpectedly. |
 | `unknown` | 1 | no | Unclassified failure; inspect `message`. |
 


### PR DESCRIPTION
## Summary

Redis Cloud challenges the token exchange for multi-factor authentication whenever the account
carries the MFA user flag and the auth mode is not SSO — so **Google and GitHub logins are affected
too**, not only password accounts. The challenge was unhandled, so login simply failed for those
users.

Now the challenge is classified, the user is prompted for a TOTP code, and the exchange is retried —
up to three attempts.

## Two details are load-bearing

**Session reuse.** The challenge state lives in the session issued on the **401**, so the retry has
to send that exact `JSESSIONID` back. A code submitted on a fresh session can never verify, so
`complete_mfa` refuses outright when no challenge is outstanding. A test fails if the challenged
cookie is not carried over.

**`mfa_type` casing.** Redis Cloud resolves it against enum constant names — `SMS`, `Totp`, `Email` —
compared verbatim. Lowercase `totp` is rejected with `mfa-invalid-type`, so a correct 6-digit code
still failed the login. RedisInsight sends the same `Totp`.

That second one is worth calling out as a test-design lesson: the original retry test asserted the
field was *present*, which passes for any spelling. It took a live run to catch it, and the test now
pins the exact wire value.

## Behaviour

- The 6-digit shape is validated **locally** before the request, so a typo does not consume one of
  the user's server-side attempts.
- `mfa-invalid-type` is classified separately — it means this client sent something the server does
  not accept, which is never the user's fault and cannot be fixed by retrying, so it must not be
  reported as a rejected code.
- Non-interactive callers cannot produce a time-based code, so they get `mfa_required` (exit 2)
  pointing at an interactive terminal rather than a prompt they cannot answer.

Persisting the tokens to resume later was considered and rejected: it would put access/refresh tokens
at rest for little gain, since the human has to be present either way.

## Scope

- Affected areas: `crates/redisctl-core/src/auth/sm_api.rs`, `.../auth/authenticator.rs`, `.../auth/oidc.rs`, `crates/redisctl/src/commands/cloud/auth.rs`, `crates/redisctl/src/structured_error.rs`
- API surface changes: `AuthError::{MfaRequired, MfaInvalidCode, MfaQuotaExceeded}`; `CloudAuthenticator::complete_login_with_mfa`; three new error codes
- Docs/tests updates: MFA section in the auth docs, notes on both sequence diagrams, three inventory rows

## Testing

```bash
cargo test -p redisctl-core --lib auth::sm_api
cargo test --workspace
```

Covers: the challenge is classified with its factor list; the challenged session is reused on retry;
a code with no outstanding challenge fails locally; `mfa-invalid-code` and `mfa-quota-exceeded` are
distinguished; the retry still carries attribution and the correct `mfa_type`; and the factor parser
tolerates shapes we have not seen rather than failing the login.

**Verified end to end against an MFA-enabled Redis Cloud account** — challenge detected, prompt
shown, code accepted, key minted, profile written.

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [x] Ready for review
- [x] Squash and merge when approved