### PR TITLE
feat(core): report owner-only programmatic access distinctly

### DIFF
--- a/crates/redisctl-core/src/auth/oidc.rs
+++ b/crates/redisctl-core/src/auth/oidc.rs
@@ -70,6 +70,14 @@ pub enum AuthError {
     )]
     MigrationRequired,
 
+    /// Programmatic (CAPI) access is off for the account and only its owner may enable it, so the
+    /// login cannot mint a key. A one-time console step for the owner, not a retryable failure.
+    #[error(
+        "enabling programmatic access requires the Redis Cloud account owner; ask them to enable \
+         it once in the console, then run login again"
+    )]
+    NotAccountOwner,
+
     /// SM challenged the login for multi-factor authentication (`user-mfa-required`). Carries the
     /// factor types SM offered, when it reports them.
     #[error("this account requires multi-factor authentication")]

--- a/crates/redisctl-core/src/auth/sm_api.rs
+++ b/crates/redisctl-core/src/auth/sm_api.rs
@@ -18,6 +18,10 @@ use url::Url;
 
 use super::{AuthError, default_http_client, endpoint, truncate};
 
+/// SM error code on the CAPI-enable call when the signed-in user is not the account owner. Note
+/// this endpoint nests its errors as a JSON-encoded string, so it is matched on the body rather
+/// than through the `/login` error envelope.
+const INSUFFICIENT_PERMISSION_CODE: &str = "insufficient-permission";
 /// SM error code returned when a password-only account must be linked to social sign-in before it
 /// can authenticate this way. The consent step is console-only.
 const SOCIAL_MIGRATION_REQUIRED_CODE: &str = "user-agreement-for-social-login-migration-missing";
@@ -385,6 +389,11 @@ impl SmApiClient {
         if body.contains("account_api_key_already_exists") {
             return Ok(());
         }
+        // Only an account owner can turn on programmatic access. Nothing the CLI can do, but the
+        // user can ask the owner to enable it once — after which the call above is a no-op.
+        if body.contains(INSUFFICIENT_PERMISSION_CODE) {
+            return Err(AuthError::NotAccountOwner);
+        }
         Err(AuthError::Protocol(format!(
             "enabling CAPI failed ({status}): {}",
             truncate(&body)
@@ -603,6 +612,25 @@ mod tests {
             .await;
         let c = logged_in(&server).await;
         assert!(c.ensure_capi_enabled().await.is_ok());
+    }
+
+    /// Only an owner may enable programmatic access. SM says so precisely, but nests the code in a
+    /// JSON-encoded string, so it is matched on the body — this pins that it is still classified.
+    #[tokio::test]
+    async fn ensure_capi_enabled_reports_owner_only_distinctly() {
+        let server = MockServer::start().await;
+        let c = logged_in(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/cloud-api/cloudApiAccessKey"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "errors": "[{\"field_name\":null,\"error_code\":\"insufficient-permission\",\"params\":[{\"key\":\"allowed-roles\",\"value\":[\"owner\"]}]}]"
+            })))
+            .mount(&server)
+            .await;
+        assert!(matches!(
+            c.ensure_capi_enabled().await,
+            Err(AuthError::NotAccountOwner)
+        ));
     }
 
     #[tokio::test]

--- a/crates/redisctl/src/structured_error.rs
+++ b/crates/redisctl/src/structured_error.rs
@@ -76,6 +76,15 @@ impl StructuredError {
     pub fn keyring_unavailable(message: impl Into<String>) -> Self {
         Self::new("keyring_unavailable", 2, false, message)
     }
+    pub fn insufficient_permission() -> Self {
+        Self::new(
+            "insufficient_permission",
+            2,
+            false,
+            "enabling programmatic access requires the Redis Cloud account owner; ask them to \
+             enable it once in the console, then run login again",
+        )
+    }
     pub fn migration_required() -> Self {
         Self::new(
             "migration_required",
@@ -176,6 +185,7 @@ impl From<AuthError> for StructuredError {
             }
             // A one-time console step, not a failure to retry — give it its own code so an agent
             // can tell the user what to do rather than surfacing a generic exchange error.
+            AuthError::NotAccountOwner => Self::insufficient_permission(),
             AuthError::MigrationRequired => Self::migration_required(),
             // Reached only when there was no terminal to prompt on: the caller must re-run
             // interactively, so this is a precondition to fix rather than a retryable failure.
@@ -237,6 +247,9 @@ mod tests {
             StructuredError::from(AuthError::Protocol("boom".into())).code,
             "sm_exchange_failed"
         );
+        let owner = StructuredError::from(AuthError::NotAccountOwner);
+        assert_eq!(owner.code, "insufficient_permission");
+        assert_eq!(owner.exit_code, 2);
         let mig = StructuredError::from(AuthError::MigrationRequired);
         assert_eq!(mig.code, "migration_required");
         assert_eq!(mig.exit_code, 2);

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -208,7 +208,7 @@ of parsing prose:
 | Exit code | Meaning | Example codes |
 |-----------|---------|---------------|
 | `1` | unknown / backend failure | `sm_exchange_failed` |
-| `2` | usage / precondition to fix | `not_authenticated`, `auth_denied`, `keyring_unavailable`, `migration_required`, `mfa_required` |
+| `2` | usage / precondition to fix | `not_authenticated`, `auth_denied`, `keyring_unavailable`, `migration_required`, `insufficient_permission`, `mfa_required` |
 | `3` | transient / retryable | `device_code_expired`, `transient_api_error`, `rate_limited` |
 
 Human (non-JSON) mode prints the usual diagnostic to stderr and keeps today's `0`/`1` exit behavior.

--- a/docs/docs/reference/agent-error-codes.md
+++ b/docs/docs/reference/agent-error-codes.md
@@ -39,6 +39,7 @@ keeps today's `0` / `1` exit behavior.
 | `auth_denied` | 2 | no | The sign-in request was denied. |
 | `keyring_unavailable` | 2 | no | No OS keyring available to store the key. Re-run with `--allow-plaintext`. |
 | `migration_required` | 2 | no | The account signs in with a password and must be linked to Google/GitHub once in the Redis Cloud console. |
+| `insufficient_permission` | 2 | no | Enabling programmatic access requires the Redis Cloud account owner. Ask them to enable it once in the console. |
 | `mfa_required` | 2 | no | The account requires multi-factor authentication and there was no terminal to prompt on. Re-run `cloud auth login` interactively. |
 | `mfa_invalid_code` | 2 | no | The multi-factor code was rejected. Start login again. |
 | `invalid_name` | 2 | no | The database name doesn't match the naming rules (see below). |


### PR DESCRIPTION
## Summary

Enabling programmatic (API) access on a Redis Cloud account is restricted to its **owner**. A
non-owner running `cloud auth login` authenticates fine, then hits the enable step and gets the raw
response relayed back through `sm_exchange_failed`:

```
error: login exchange failed: enabling CAPI failed (403 Forbidden): {"errors":"[{\"field_name\":
null,\"error_code\":\"insufficient-permission\",\"params\":[{\"key\":\"allowed-roles\",\"value\":
[\"owner\"]}]}]"}
```

Redis Cloud is saying something precise and actionable — *you need the owner role* — and we were
handing back escaped JSON. It now maps to `insufficient_permission` (exit 2):

```
error: enabling programmatic access requires the Redis Cloud account owner; ask them to enable it
       once in the console, then run login again
```

Once the owner has enabled it, the call is a no-op for everyone else: an already-enabled account
reports `account_api_key_already_exists`, which is already treated as success.

## Implementation note

Matched on the response body rather than through the `/login` error envelope. This endpoint nests its
errors as a **JSON-encoded string** (`"errors": "[{...}]"`) rather than the object shape `/login`
uses, so the envelope parser does not apply — consistent with the existing
`account_api_key_already_exists` check immediately above it. The test pins that shape, since it is
exactly the kind of thing that silently stops matching.

## Scope

- Affected areas: `crates/redisctl-core/src/auth/sm_api.rs`, `.../auth/oidc.rs`, `crates/redisctl/src/structured_error.rs`
- API surface changes: new `AuthError::NotAccountOwner`; new `insufficient_permission` error code (exit 2)
- Docs/tests updates: one row in the code inventory, and the exit-2 example list

## Testing

```bash
cargo test -p redisctl-core --lib auth::sm_api
```

`ensure_capi_enabled_reports_owner_only_distinctly` replays the exact 403 body observed in the wild
and asserts it becomes `NotAccountOwner` rather than a generic protocol error.

**Encountered live** on two Redis Cloud accounts during testing — this is the message that replaced
the JSON blob above.

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [x] Ready for review
- [x] Squash and merge when approved