### PR TITLE
fix(cli): surface a pending device login in cloud auth status

### DIFF
--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -342,10 +342,20 @@ async fn status(
     let authenticated = conn_mgr
         .resolve_cloud_connection(Some(&profile_name))
         .is_ok();
-    print_formatted_output(
-        serde_json::json!({ "authenticated": authenticated, "profile": profile_name }),
-        output,
-    )
+    // A pending device login is invisible in a bare `authenticated: false`, which reads as "login
+    // failed" when in fact it is half-finished. Say so, and name the command that completes it.
+    let pending = !authenticated && load_pending(conn_mgr, &profile_name).is_some();
+    if pending {
+        eprintln!(
+            "A device login for profile '{profile_name}' is waiting for approval.\nComplete it \
+             with: redisctl cloud auth status --wait"
+        );
+    }
+    let mut report = serde_json::json!({ "authenticated": authenticated, "profile": profile_name });
+    if pending {
+        report["status"] = "authorization_pending".into();
+    }
+    print_formatted_output(report, output)
 }
 
 /// Poll a pending device authorization to completion. `Ok(Some)` = approved (tokens),


### PR DESCRIPTION
## Summary

`cloud auth login --device` is non-blocking: it writes a pending record, prints the verification URL
and code, and tells the user to finish with `auth status --wait`.

Run plain `auth status` instead and it reported only:

```
 authenticated   false
 profile         prod
```

Which reads as *"the login failed"*, when in fact it is half-finished and waiting for browser
approval. Nothing pointed at the command that completes it.

It now says so:

```
A device login for profile 'prod' is waiting for approval.
Complete it with: redisctl cloud auth status --wait
```

and adds `"status": "authorization_pending"` to the structured output, matching what
`login --device` already reports — so an agent polling `status` can tell "waiting for the human"
apart from "not signed in".

Only fires when a pending record exists **and** the profile has no credentials, so an ordinary
"not signed in" answer is unchanged.

## Scope

- Affected areas: `crates/redisctl/src/commands/cloud/auth.rs` (the non-`--wait` branch of `status`)
- API surface changes: none — `authorization_pending` is an existing status value, now also reported here
- Docs/tests updates: none needed; the documented `--wait` behaviour is unchanged

## Testing

```bash
cargo test --workspace
```

Manual: `cloud auth login --device`, then `cloud auth status` without `--wait` — the pending state and
the completing command are now named. Then `cloud auth status --wait` completes as before.

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated (n/a)
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [x] Ready for review
- [x] Squash and merge when approved