### PR TITLE
feat(cli): choose which Redis Cloud account the minted key belongs to

### DIFF
--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -199,6 +199,10 @@ impl CloudAuthenticator {
         let account = select_account(accounts, user.current_account_id.as_deref())
             .ok_or_else(|| AuthError::Protocol("no accounts associated with this login".into()))?;
         let account_name = account.name.clone();
+        // Report the account the key belongs to, taken from the same entry the key came from.
+        // `user.current_account_id` can disagree with it (absent or unknown → `select_account`
+        // falls back), and printing that id would name an account the key is not for.
+        let account_id = Some(account.id.to_string());
         let api_key = account.api_access_key.ok_or_else(|| {
             AuthError::Protocol("account has no CAPI access key after enabling CAPI".into())
         })?;
@@ -211,7 +215,7 @@ impl CloudAuthenticator {
             .map(|keys| keys.iter().filter(|n| n.starts_with("redisctl-")).count())
             .unwrap_or(0);
         Ok(MintedCredentials {
-            account_id: user.current_account_id,
+            account_id,
             email: user.email,
             api_key,
             api_secret: minted.secret_key,
@@ -237,8 +241,18 @@ impl CloudAuthenticator {
         if user.current_account_id.as_deref() == Some(want.to_string().as_str()) {
             return Ok(user);
         }
+        // Fetched here rather than reusing the later call: membership has to be checked *before*
+        // `setcurrent`, while the later fetch has to come *after* `ensure_capi_enabled` to see the
+        // account access key it creates. Only runs when `--account` was given.
         let accounts = sm.fetch_accounts().await?;
         if !accounts.iter().any(|a| a.id == want) {
+            if accounts.is_empty() {
+                return Err(AuthError::Protocol(
+                    "this login is not associated with any Redis Cloud account, so there is \
+                     nothing to switch to"
+                        .into(),
+                ));
+            }
             return Err(AuthError::UnknownAccount {
                 requested: want,
                 available: accounts
@@ -483,6 +497,220 @@ mod tests {
         // secrets must not leak via Debug
         let dbg = format!("{creds:?}");
         assert!(!dbg.contains("SECRET") && !dbg.contains("ACCT-KEY") && !dbg.contains("RT"));
+    }
+
+    fn tokens() -> TokenSet {
+        TokenSet {
+            access_token: "AT".to_string(),
+            refresh_token: None,
+            expires_in: 3600,
+        }
+    }
+
+    fn authenticator(server: &MockServer) -> CloudAuthenticator {
+        CloudAuthenticator::new(
+            Url::parse("https://issuer.example/oauth2/default").unwrap(),
+            "client",
+            Url::parse(&server.uri()).unwrap(),
+            "https://capi.example/v1",
+        )
+    }
+
+    /// Everything the exchange needs apart from the account-shaped endpoints each test varies.
+    async fn common_login_mocks(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({}))
+                    .append_header("Set-Cookie", "JSESSIONID=SID; Path=/"),
+            )
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/csrf"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"csrfToken": {"csrf_token": "C"}})),
+            )
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/cloud-api/cloudApiAccessKey"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"cloudApiAccessKey": {"accessKey": "ACCT"}})),
+            )
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/cloud-api/cloudApiKeys"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"name": "redisctl-test", "secret_key": "SECRET"}),
+            ))
+            .mount(server)
+            .await;
+    }
+
+    /// `--account` has to switch the session *before* anything account-scoped runs: both
+    /// `ensure_capi_enabled` and the mint resolve the account from the session, so a switch that
+    /// happened afterwards would put the key on the previous account. The mocks answer
+    /// `/users/me` differently before and after `setcurrent`, so the minted account is only right
+    /// if the ordering held.
+    #[tokio::test]
+    async fn complete_login_switches_before_minting() {
+        let server = MockServer::start().await;
+        let switched = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        common_login_mocks(&server).await;
+
+        // /users/me reports 111 until setcurrent runs, then 222.
+        let flag = switched.clone();
+        Mock::given(method("GET"))
+            .and(path("/users/me"))
+            .respond_with(move |_: &wiremock::Request| {
+                let id = if flag.load(std::sync::atomic::Ordering::SeqCst) {
+                    "222"
+                } else {
+                    "111"
+                };
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "1", "current_account_id": id, "email": "u@e.com"
+                }))
+            })
+            .mount(&server)
+            .await;
+        let flag = switched.clone();
+        Mock::given(method("POST"))
+            .and(path("/accounts/setcurrent/222"))
+            .respond_with(move |_: &wiremock::Request| {
+                flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({}))
+            })
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/accounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "accounts": [
+                    {"id": 111, "name": "One", "api_access_key": "KEY-111"},
+                    {"id": 222, "name": "Two", "api_access_key": "KEY-222"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let creds = authenticator(&server)
+            .complete_login(&tokens(), "redisctl-test", LoginFlow::Loopback, Some(222))
+            .await
+            .unwrap();
+        // The key, the reported id and the reported name all describe the requested account.
+        assert_eq!(creds.account_id.as_deref(), Some("222"));
+        assert_eq!(creds.account_name.as_deref(), Some("Two"));
+        assert_eq!(creds.api_key, "KEY-222");
+        assert_eq!(creds.account_count(), 2);
+    }
+
+    /// An account the user does not belong to is refused before any switch is attempted, and the
+    /// message names the accounts they do have.
+    #[tokio::test]
+    async fn complete_login_refuses_an_account_the_user_is_not_in() {
+        let server = MockServer::start().await;
+        common_login_mocks(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/users/me"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"id": "1", "current_account_id": "111", "email": "u@e.com"}),
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/accounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "accounts": [{"id": 111, "name": "One", "api_access_key": "KEY-111"}]
+            })))
+            .mount(&server)
+            .await;
+        // No /accounts/setcurrent/* mock is mounted: reaching one would 404 and surface as a
+        // different error, which is itself the assertion that no switch was attempted.
+        match authenticator(&server)
+            .complete_login(&tokens(), "k", LoginFlow::Loopback, Some(999))
+            .await
+        {
+            Err(AuthError::UnknownAccount {
+                requested,
+                available,
+            }) => {
+                assert_eq!(requested, 999);
+                assert_eq!(available, "One (#111)");
+            }
+            other => panic!("expected UnknownAccount, got {other:?}"),
+        }
+    }
+
+    /// A `setcurrent` that reports success but leaves the session on the old account must fail
+    /// loudly: continuing would mint the key on the wrong account and report success.
+    #[tokio::test]
+    async fn complete_login_fails_when_the_switch_does_not_take() {
+        let server = MockServer::start().await;
+        common_login_mocks(&server).await;
+        // Never changes, however many times it is asked.
+        Mock::given(method("GET"))
+            .and(path("/users/me"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"id": "1", "current_account_id": "111", "email": "u@e.com"}),
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/setcurrent/222"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/accounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "accounts": [
+                    {"id": 111, "name": "One", "api_access_key": "KEY-111"},
+                    {"id": 222, "name": "Two", "api_access_key": "KEY-222"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+        let err = authenticator(&server)
+            .complete_login(&tokens(), "k", LoginFlow::Loopback, Some(222))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, AuthError::Protocol(ref m) if m.contains("still reports")),
+            "expected a switch-verification failure, got {err:?}"
+        );
+    }
+
+    /// Asking for the account the session is already on must not issue a switch at all.
+    #[tokio::test]
+    async fn complete_login_skips_the_switch_when_already_current() {
+        let server = MockServer::start().await;
+        common_login_mocks(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/users/me"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"id": "1", "current_account_id": "111", "email": "u@e.com"}),
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/accounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "accounts": [{"id": 111, "name": "One", "api_access_key": "KEY-111"}]
+            })))
+            .mount(&server)
+            .await;
+        // Again, no setcurrent mount: if one were issued it would 404 and fail the login.
+        let creds = authenticator(&server)
+            .complete_login(&tokens(), "k", LoginFlow::Loopback, Some(111))
+            .await
+            .unwrap();
+        assert_eq!(creds.account_id.as_deref(), Some("111"));
     }
 
     #[tokio::test]

--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -9,7 +9,7 @@
 
 use url::Url;
 
-use super::sm_api::{LoginFlow, SmAccount, SmApiClient};
+use super::sm_api::{LoginFlow, SmAccount, SmApiClient, SmUser};
 use super::{AuthError, DeviceFlowClient, LoopbackFlowClient, TokenSet, default_http_client};
 
 /// Result of a completed login: a Redis Cloud CAPI key pair plus context, ready to persist.
@@ -34,10 +34,35 @@ pub struct MintedCredentials {
     pub redisctl_key_count: usize,
     /// Name of the account the key was minted for, when the API reports one.
     pub account_name: Option<String>,
-    /// How many accounts the signed-in user belongs to. The key is scoped to one of them — the
-    /// user's *current* account, chosen server-side from the session — so the CLI can say which
-    /// one it used when there was more than one it could have been.
-    pub account_count: usize,
+    /// Every account the signed-in user belongs to. The key is scoped to exactly one of them —
+    /// the session's *current* account — so the CLI can both name the one it used and list the
+    /// alternatives, which are otherwise only discoverable in the console.
+    pub accounts: Vec<LoginAccount>,
+}
+
+/// One account the signed-in user belongs to, as reported during login.
+#[derive(Debug, Clone)]
+pub struct LoginAccount {
+    pub id: u64,
+    pub name: Option<String>,
+}
+
+impl LoginAccount {
+    /// `Acme (#316941)`, or `#316941` when the API reports no name. Used both in the CLI listing
+    /// and in the `UnknownAccount` message, so the two always read the same.
+    pub fn label(&self) -> String {
+        match &self.name {
+            Some(n) => format!("{} (#{})", n, self.id),
+            None => format!("#{}", self.id),
+        }
+    }
+}
+
+impl MintedCredentials {
+    /// How many accounts the signed-in user belongs to.
+    pub fn account_count(&self) -> usize {
+        self.accounts.len()
+    }
 }
 
 impl std::fmt::Debug for MintedCredentials {
@@ -55,7 +80,7 @@ impl std::fmt::Debug for MintedCredentials {
             .field("capi_key_name", &self.capi_key_name)
             .field("redisctl_key_count", &self.redisctl_key_count)
             .field("account_name", &self.account_name)
-            .field("account_count", &self.account_count)
+            .field("accounts", &self.accounts)
             .finish()
     }
 }
@@ -120,8 +145,9 @@ impl CloudAuthenticator {
         tokens: &TokenSet,
         key_name: &str,
         flow: LoginFlow,
+        account: Option<u64>,
     ) -> Result<MintedCredentials, AuthError> {
-        self.complete_login_with_mfa(tokens, key_name, flow, |_, _| Ok(None))
+        self.complete_login_with_mfa(tokens, key_name, flow, account, |_, _| Ok(None))
             .await
     }
 
@@ -137,6 +163,7 @@ impl CloudAuthenticator {
         tokens: &TokenSet,
         key_name: &str,
         flow: LoginFlow,
+        account: Option<u64>,
         mut mfa_prompt: F,
     ) -> Result<MintedCredentials, AuthError>
     where
@@ -153,13 +180,22 @@ impl CloudAuthenticator {
             }
             Err(e) => return Err(e),
         }
-        let user = sm.fetch_current_user().await?;
+        let mut user = sm.fetch_current_user().await?;
+        if let Some(want) = account {
+            user = self.switch_account(&sm, user, want).await?;
+        }
         sm.ensure_capi_enabled().await?;
         // Pick the account matching the logged-in user's current_account_id. /accounts list
         // order isn't guaranteed, so taking the first entry could mint a key for the wrong
         // account in a multi-account org. Fall back to the first only when it's absent/unknown.
         let accounts = sm.fetch_accounts().await?;
-        let account_count = accounts.len();
+        let all_accounts: Vec<LoginAccount> = accounts
+            .iter()
+            .map(|a| LoginAccount {
+                id: a.id,
+                name: a.name.clone(),
+            })
+            .collect();
         let account = select_account(accounts, user.current_account_id.as_deref())
             .ok_or_else(|| AuthError::Protocol("no accounts associated with this login".into()))?;
         let account_name = account.name.clone();
@@ -184,8 +220,50 @@ impl CloudAuthenticator {
             capi_key_name: minted.name,
             redisctl_key_count,
             account_name,
-            account_count,
+            accounts: all_accounts,
         })
+    }
+
+    /// Point the session at `want` before anything account-scoped happens.
+    ///
+    /// Verifies the switch actually took rather than assuming it: every later call resolves the
+    /// account from the session, so a silent no-op here would mint the key on the wrong account.
+    async fn switch_account(
+        &self,
+        sm: &SmApiClient,
+        user: SmUser,
+        want: u64,
+    ) -> Result<SmUser, AuthError> {
+        if user.current_account_id.as_deref() == Some(want.to_string().as_str()) {
+            return Ok(user);
+        }
+        let accounts = sm.fetch_accounts().await?;
+        if !accounts.iter().any(|a| a.id == want) {
+            return Err(AuthError::UnknownAccount {
+                requested: want,
+                available: accounts
+                    .iter()
+                    .map(|a| {
+                        LoginAccount {
+                            id: a.id,
+                            name: a.name.clone(),
+                        }
+                        .label()
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            });
+        }
+        sm.set_current_account(want).await?;
+        let user = sm.fetch_current_user().await?;
+        // Trust the server's answer, not the request's success.
+        if user.current_account_id.as_deref() != Some(want.to_string().as_str()) {
+            return Err(AuthError::Protocol(format!(
+                "asked Redis Cloud to switch to account {want} but the session still reports {}",
+                user.current_account_id.as_deref().unwrap_or("none")
+            )));
+        }
+        Ok(user)
     }
 
     /// Drive the MFA retry loop against an already-challenged client.
@@ -244,6 +322,28 @@ mod tests {
         .unwrap()
     }
 
+    /// The label is shared by the CLI's account listing and the `UnknownAccount` message, so
+    /// both read identically — including when the API reports no name.
+    #[test]
+    fn login_account_labels_named_and_unnamed_accounts() {
+        assert_eq!(
+            LoginAccount {
+                id: 316941,
+                name: Some("Acme".to_string()),
+            }
+            .label(),
+            "Acme (#316941)"
+        );
+        assert_eq!(
+            LoginAccount {
+                id: 316941,
+                name: None,
+            }
+            .label(),
+            "#316941"
+        );
+    }
+
     #[test]
     fn select_account_prefers_current_account_id() {
         let accts = vec![account(111), account(222), account(333)];
@@ -282,7 +382,16 @@ mod tests {
             capi_key_name: "redisctl-cli-1".to_string(),
             redisctl_key_count: 3,
             account_name: Some("Acme".to_string()),
-            account_count: 2,
+            accounts: vec![
+                LoginAccount {
+                    id: 316941,
+                    name: Some("Acme".to_string()),
+                },
+                LoginAccount {
+                    id: 481022,
+                    name: Some("Contoso".to_string()),
+                },
+            ],
         };
         let dbg = format!("{creds:?}");
         assert!(dbg.contains("<redacted>"));
@@ -361,7 +470,7 @@ mod tests {
         };
 
         let creds = auth
-            .complete_login(&tokens, "redisctl-test", LoginFlow::Loopback)
+            .complete_login(&tokens, "redisctl-test", LoginFlow::Loopback, None)
             .await
             .unwrap();
         assert_eq!(creds.api_key, "ACCT-KEY");
@@ -396,7 +505,8 @@ mod tests {
             expires_in: 3600,
         };
         assert!(matches!(
-            auth.complete_login(&tokens, "k", LoginFlow::Loopback).await,
+            auth.complete_login(&tokens, "k", LoginFlow::Loopback, None)
+                .await,
             Err(AuthError::Protocol(_))
         ));
     }

--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -32,6 +32,12 @@ pub struct MintedCredentials {
     /// How many `redisctl-*` CAPI keys the account has after this mint (best-effort; 0 if the
     /// listing failed). The CLI warns when this grows, since each login mints a new key (D5).
     pub redisctl_key_count: usize,
+    /// Name of the account the key was minted for, when the API reports one.
+    pub account_name: Option<String>,
+    /// How many accounts the signed-in user belongs to. The key is scoped to one of them — the
+    /// user's *current* account, chosen server-side from the session — so the CLI can say which
+    /// one it used when there was more than one it could have been.
+    pub account_count: usize,
 }
 
 impl std::fmt::Debug for MintedCredentials {
@@ -48,6 +54,8 @@ impl std::fmt::Debug for MintedCredentials {
             )
             .field("capi_key_name", &self.capi_key_name)
             .field("redisctl_key_count", &self.redisctl_key_count)
+            .field("account_name", &self.account_name)
+            .field("account_count", &self.account_count)
             .finish()
     }
 }
@@ -150,11 +158,11 @@ impl CloudAuthenticator {
         // Pick the account matching the logged-in user's current_account_id. /accounts list
         // order isn't guaranteed, so taking the first entry could mint a key for the wrong
         // account in a multi-account org. Fall back to the first only when it's absent/unknown.
-        let account = select_account(
-            sm.fetch_accounts().await?,
-            user.current_account_id.as_deref(),
-        )
-        .ok_or_else(|| AuthError::Protocol("no accounts associated with this login".into()))?;
+        let accounts = sm.fetch_accounts().await?;
+        let account_count = accounts.len();
+        let account = select_account(accounts, user.current_account_id.as_deref())
+            .ok_or_else(|| AuthError::Protocol("no accounts associated with this login".into()))?;
+        let account_name = account.name.clone();
         let api_key = account.api_access_key.ok_or_else(|| {
             AuthError::Protocol("account has no CAPI access key after enabling CAPI".into())
         })?;
@@ -175,6 +183,8 @@ impl CloudAuthenticator {
             refresh_token: tokens.refresh_token.clone(),
             capi_key_name: minted.name,
             redisctl_key_count,
+            account_name,
+            account_count,
         })
     }
 
@@ -271,6 +281,8 @@ mod tests {
             refresh_token: Some("RT-should-not-appear".to_string()),
             capi_key_name: "redisctl-cli-1".to_string(),
             redisctl_key_count: 3,
+            account_name: Some("Acme".to_string()),
+            account_count: 2,
         };
         let dbg = format!("{creds:?}");
         assert!(dbg.contains("<redacted>"));

--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -17,7 +17,9 @@ use super::{AuthError, DeviceFlowClient, LoopbackFlowClient, TokenSet, default_h
 /// Secret fields are redacted from `Debug`.
 #[derive(Clone)]
 pub struct MintedCredentials {
-    pub account_id: Option<String>,
+    /// Numeric account id, matching the `id` of the matching entry in `accounts`, so the two can
+    /// be compared directly by a caller reading the JSON output.
+    pub account_id: Option<u64>,
     pub email: Option<String>,
     /// Account-level CAPI key (`x-api-key`).
     pub api_key: String,
@@ -202,7 +204,7 @@ impl CloudAuthenticator {
         // Report the account the key belongs to, taken from the same entry the key came from.
         // `user.current_account_id` can disagree with it (absent or unknown → `select_account`
         // falls back), and printing that id would name an account the key is not for.
-        let account_id = Some(account.id.to_string());
+        let account_id = Some(account.id);
         let api_key = account.api_access_key.ok_or_else(|| {
             AuthError::Protocol("account has no CAPI access key after enabling CAPI".into())
         })?;
@@ -387,7 +389,7 @@ mod tests {
     #[test]
     fn debug_redacts_secrets() {
         let creds = MintedCredentials {
-            account_id: Some("42".to_string()),
+            account_id: Some(42),
             email: Some("u@example.com".to_string()),
             api_key: "AKEY-visible-should-not-appear".to_string(),
             api_secret: "SECRET-should-not-appear".to_string(),
@@ -490,7 +492,7 @@ mod tests {
         assert_eq!(creds.api_key, "ACCT-KEY");
         assert_eq!(creds.api_secret, "SECRET");
         assert_eq!(creds.api_url, "https://capi.example/v1");
-        assert_eq!(creds.account_id.as_deref(), Some("112117"));
+        assert_eq!(creds.account_id, Some(112117));
         assert_eq!(creds.email.as_deref(), Some("u@e.com"));
         assert_eq!(creds.refresh_token.as_deref(), Some("RT"));
         assert_eq!(creds.capi_key_name, "redisctl-test");
@@ -604,7 +606,7 @@ mod tests {
             .await
             .unwrap();
         // The key, the reported id and the reported name all describe the requested account.
-        assert_eq!(creds.account_id.as_deref(), Some("222"));
+        assert_eq!(creds.account_id, Some(222));
         assert_eq!(creds.account_name.as_deref(), Some("Two"));
         assert_eq!(creds.api_key, "KEY-222");
         assert_eq!(creds.account_count(), 2);
@@ -710,7 +712,7 @@ mod tests {
             .complete_login(&tokens(), "k", LoginFlow::Loopback, Some(111))
             .await
             .unwrap();
-        assert_eq!(creds.account_id.as_deref(), Some("111"));
+        assert_eq!(creds.account_id, Some(111));
     }
 
     #[tokio::test]

--- a/crates/redisctl-core/src/auth/mod.rs
+++ b/crates/redisctl-core/src/auth/mod.rs
@@ -20,7 +20,7 @@ pub mod sm_api;
 mod oidc;
 
 pub use auth_code_loopback::LoopbackFlowClient;
-pub use authenticator::{CloudAuthenticator, MintedCredentials};
+pub use authenticator::{CloudAuthenticator, LoginAccount, MintedCredentials};
 pub use device_flow::{DeviceAuthorization, DeviceFlowClient};
 pub use oidc::{AuthError, TokenSet};
 pub use sm_api::{CapiKey, LoginFlow, SmAccount, SmApiClient, SmUser};

--- a/crates/redisctl-core/src/auth/oidc.rs
+++ b/crates/redisctl-core/src/auth/oidc.rs
@@ -70,13 +70,22 @@ pub enum AuthError {
     )]
     MigrationRequired,
 
-    /// Programmatic (CAPI) access is off for the account and only its owner may enable it, so the
-    /// login cannot mint a key. A one-time console step for the owner, not a retryable failure.
+    /// The signed-in user's role on the account does not permit programmatic (CAPI) access, so
+    /// the login cannot mint a key. A one-time step for someone who does hold the role, not a
+    /// retryable failure. `allowed_roles` is what SM reported as sufficient, already formatted.
     #[error(
-        "enabling programmatic access requires the Redis Cloud account owner; ask them to enable \
-         it once in the console, then run login again"
+        "enabling programmatic access requires the {allowed_roles} role on this Redis Cloud \
+         account; ask someone with it to enable it once in the console, then run login again"
     )]
-    NotAccountOwner,
+    NotAccountOwner { allowed_roles: String },
+
+    /// The account itself has API access switched off, so no role can mint a key. Only Redis can
+    /// turn it back on — it is not exposed to account owners.
+    #[error(
+        "programmatic access is not enabled for this Redis Cloud account; ask Redis support to \
+         enable API access for the account, then run login again"
+    )]
+    CapiDisabled,
 
     /// `--account` named an account the signed-in user does not belong to. Carries what they do
     /// have, so the caller can list the options instead of just refusing.

--- a/crates/redisctl-core/src/auth/oidc.rs
+++ b/crates/redisctl-core/src/auth/oidc.rs
@@ -74,8 +74,9 @@ pub enum AuthError {
     /// the login cannot mint a key. A one-time step for someone who does hold the role, not a
     /// retryable failure. `allowed_roles` is what SM reported as sufficient, already formatted.
     #[error(
-        "enabling programmatic access requires the {allowed_roles} role on this Redis Cloud \
-         account; ask someone with it to enable it once in the console, then run login again"
+        "your role on this Redis Cloud account cannot enable programmatic access; that needs \
+         {allowed_roles}. Ask someone who has it to enable it once in the console, then run \
+         login again"
     )]
     NotAccountOwner { allowed_roles: String },
 

--- a/crates/redisctl-core/src/auth/oidc.rs
+++ b/crates/redisctl-core/src/auth/oidc.rs
@@ -78,6 +78,11 @@ pub enum AuthError {
     )]
     NotAccountOwner,
 
+    /// `--account` named an account the signed-in user does not belong to. Carries what they do
+    /// have, so the caller can list the options instead of just refusing.
+    #[error("account {requested} is not one of yours; you belong to: {available}")]
+    UnknownAccount { requested: u64, available: String },
+
     /// SM challenged the login for multi-factor authentication (`user-mfa-required`). Carries the
     /// factor types SM offered, when it reports them.
     #[error("this account requires multi-factor authentication")]

--- a/crates/redisctl-core/src/auth/sm_api.rs
+++ b/crates/redisctl-core/src/auth/sm_api.rs
@@ -22,6 +22,10 @@ use super::{AuthError, default_http_client, endpoint, truncate};
 /// this endpoint nests its errors as a JSON-encoded string, so it is matched on the body rather
 /// than through the `/login` error envelope.
 const INSUFFICIENT_PERMISSION_CODE: &str = "insufficient-permission";
+/// SM error code when the *account* cannot have programmatic access at all. On this flow the
+/// caller has already passed the role gate and mints for themselves, so the remaining cause is
+/// the account's `IsApiEnabled` flag being off — which only Redis can change.
+const FORBIDDEN_REQUEST_CODE: &str = "forbidden-request";
 /// SM error code returned when a password-only account must be linked to social sign-in before it
 /// can authenticate this way. The consent step is console-only.
 const SOCIAL_MIGRATION_REQUIRED_CODE: &str = "user-agreement-for-social-login-migration-missing";
@@ -204,6 +208,34 @@ struct CsrfToken {
 struct AccountsEnvelope {
     #[serde(default)]
     accounts: Vec<SmAccount>,
+}
+
+/// Roles SM named as sufficient in an `insufficient-permission` body, formatted for a message.
+///
+/// The response nests its error list as a JSON-encoded string, so the params arrive escaped and a
+/// plain `serde_json` walk does not reach them; scanning the raw body handles both shapes. Role
+/// names are bare words (`owner`, `viewer`), so anything else is discarded. Falls back to
+/// `"owner"` — the only role that has ever held this permission — when nothing is parseable, so
+/// the message stays accurate rather than empty.
+fn allowed_roles(body: &str) -> String {
+    let roles: Vec<&str> = body
+        .split_once("allowed-roles")
+        .map(|(_, rest)| rest)
+        .and_then(|rest| {
+            let start = rest.find('[')?;
+            let end = rest[start..].find(']')?;
+            Some(&rest[start..start + end])
+        })
+        .map(|list| {
+            list.split(['"', '\\', '[', ',', ' '])
+                .filter(|t| !t.is_empty() && t.chars().all(|c| c.is_ascii_lowercase() || c == '_'))
+                .collect()
+        })
+        .unwrap_or_default();
+    if roles.is_empty() {
+        return "owner".to_string();
+    }
+    roles.join(" or ")
 }
 
 impl SmApiClient {
@@ -389,10 +421,15 @@ impl SmApiClient {
         if body.contains("account_api_key_already_exists") {
             return Ok(());
         }
-        // Only an account owner can turn on programmatic access. Nothing the CLI can do, but the
-        // user can ask the owner to enable it once — after which the call above is a no-op.
+        // The caller's role does not carry the CAPI permission. Nothing the CLI can do, but
+        // someone who holds the role can enable it once — after which the call above is a no-op.
         if body.contains(INSUFFICIENT_PERMISSION_CODE) {
-            return Err(AuthError::NotAccountOwner);
+            return Err(AuthError::NotAccountOwner {
+                allowed_roles: allowed_roles(&body),
+            });
+        }
+        if body.contains(FORBIDDEN_REQUEST_CODE) {
+            return Err(AuthError::CapiDisabled);
         }
         Err(AuthError::Protocol(format!(
             "enabling CAPI failed ({status}): {}",
@@ -651,9 +688,53 @@ mod tests {
             })))
             .mount(&server)
             .await;
+        // The role SM named is carried through, not a hardcoded string.
+        match c.ensure_capi_enabled().await {
+            Err(AuthError::NotAccountOwner { allowed_roles }) => {
+                assert_eq!(allowed_roles, "owner")
+            }
+            other => panic!("expected NotAccountOwner, got {other:?}"),
+        }
+    }
+
+    /// `allowed-roles` reaches us escaped inside a JSON-encoded string, and SM can name more than
+    /// one role. Anything unparseable still has to produce an accurate message.
+    #[test]
+    fn allowed_roles_parses_both_body_shapes_and_falls_back() {
+        assert_eq!(
+            allowed_roles(
+                r#"{"errors":"[{\"params\":[{\"key\":\"allowed-roles\",\"value\":[\"owner\"]}]}]"}"#
+            ),
+            "owner"
+        );
+        assert_eq!(
+            allowed_roles(r#"{"params":[{"key":"allowed-roles","value":["owner","viewer"]}]}"#),
+            "owner or viewer"
+        );
+        // No params at all, or a shape we cannot read: name the only role that has ever held it.
+        assert_eq!(
+            allowed_roles(r#"{"errors":"insufficient-permission"}"#),
+            "owner"
+        );
+        assert_eq!(allowed_roles("allowed-roles but no list"), "owner");
+    }
+
+    /// The account's own API access being off is a different failure from a role problem: no role
+    /// can fix it, so it must not be reported as "ask someone with the owner role".
+    #[tokio::test]
+    async fn ensure_capi_enabled_reports_a_disabled_account_distinctly() {
+        let server = MockServer::start().await;
+        let c = logged_in(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/cloud-api/cloudApiAccessKey"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "errors": "[{\"field_name\":null,\"error_code\":\"forbidden-request\"}]"
+            })))
+            .mount(&server)
+            .await;
         assert!(matches!(
             c.ensure_capi_enabled().await,
-            Err(AuthError::NotAccountOwner)
+            Err(AuthError::CapiDisabled)
         ));
     }
 

--- a/crates/redisctl-core/src/auth/sm_api.rs
+++ b/crates/redisctl-core/src/auth/sm_api.rs
@@ -464,6 +464,30 @@ impl SmApiClient {
             .ok_or_else(|| AuthError::Protocol("not logged in to the SM API".into()))
     }
 
+    /// Rebind the session to `account_id` (`POST /accounts/setcurrent/{id}`).
+    ///
+    /// Every CAPI call resolves the account from the session — `createApiSecretKey` uses the
+    /// session's `userAccountId` — so this must happen *before* enabling access or minting, or the
+    /// key lands on the previous account. Annotated `LEGACY_ONLY` server-side, which the JSESSIONID
+    /// established by [`SmApiClient::login`] satisfies.
+    pub async fn set_current_account(&self, account_id: u64) -> Result<(), AuthError> {
+        let resp = self
+            .authed_post_json(
+                &format!("accounts/setcurrent/{account_id}"),
+                serde_json::json!({}),
+            )
+            .await?;
+        if resp.status().is_success() {
+            return Ok(());
+        }
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        Err(AuthError::Protocol(format!(
+            "could not switch to account {account_id} ({status}): {}",
+            truncate(&body)
+        )))
+    }
+
     async fn authed_get(&self, path: &str) -> Result<reqwest::Response, AuthError> {
         let s = self.session()?;
         Ok(self
@@ -738,6 +762,36 @@ mod tests {
     /// SM records `utm_*` on the signup path, so a first-ever login through redisctl must carry
     /// attribution or the tool is invisible in signup analytics. The mock matches only if all three
     /// fields are present, and `utm_campaign` distinguishes the two flows.
+    /// Every account-scoped call resolves the account from the session, so a switch has to be a
+    /// real request to the documented path — the mock only matches that exact URL.
+    #[tokio::test]
+    async fn set_current_account_posts_to_setcurrent() {
+        let server = MockServer::start().await;
+        let c = logged_in(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/setcurrent/424242"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        c.set_current_account(424242).await.unwrap();
+    }
+
+    /// A refused switch must fail loudly; silently continuing would mint on the previous account.
+    #[tokio::test]
+    async fn set_current_account_surfaces_a_refusal() {
+        let server = MockServer::start().await;
+        let c = logged_in(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/setcurrent/1"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("nope"))
+            .mount(&server)
+            .await;
+        assert!(matches!(
+            c.set_current_account(1).await,
+            Err(AuthError::Protocol(_))
+        ));
+    }
+
     #[tokio::test]
     async fn login_sends_utm_attribution_per_flow() {
         for (flow, campaign) in [

--- a/crates/redisctl-core/src/auth/sm_api.rs
+++ b/crates/redisctl-core/src/auth/sm_api.rs
@@ -210,32 +210,93 @@ struct AccountsEnvelope {
     accounts: Vec<SmAccount>,
 }
 
+/// Every `error_code` in an SM error body, in order.
+///
+/// Same nesting as [`allowed_roles`]: `errors` is a JSON-encoded string holding the list. Used to
+/// classify on the *set* of codes present rather than on a substring, so a generic code cannot be
+/// matched out of an unrelated envelope.
+fn sm_error_codes(body: &str) -> Vec<String> {
+    fn codes(errors: &serde_json::Value) -> Vec<String> {
+        errors
+            .as_array()
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|e| {
+                        e.get("error_code")
+                            .or_else(|| e.get("code"))?
+                            .as_str()
+                            .map(str::to_string)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| {
+            let errors = v.get("errors")?.clone();
+            Some(match errors {
+                serde_json::Value::String(inner) => {
+                    codes(&serde_json::from_str::<serde_json::Value>(&inner).ok()?)
+                }
+                other => codes(&other),
+            })
+        })
+        .unwrap_or_default()
+}
+
 /// Roles SM named as sufficient in an `insufficient-permission` body, formatted for a message.
 ///
-/// The response nests its error list as a JSON-encoded string, so the params arrive escaped and a
-/// plain `serde_json` walk does not reach them; scanning the raw body handles both shapes. Role
-/// names are bare words (`owner`, `viewer`), so anything else is discarded. Falls back to
-/// `"owner"` — the only role that has ever held this permission — when nothing is parseable, so
-/// the message stays accurate rather than empty.
+/// SM nests its error list as a JSON-encoded *string*, so reaching the params means parsing the
+/// body and then parsing `errors` again. Walking the decoded structure — rather than scanning the
+/// raw text — keeps this independent of key order inside each param object and of how role names
+/// are spelled. Falls back to `owner`, the only role that has ever held this permission, when
+/// nothing is parseable, so the message is never empty.
 fn allowed_roles(body: &str) -> String {
-    let roles: Vec<&str> = body
-        .split_once("allowed-roles")
-        .map(|(_, rest)| rest)
-        .and_then(|rest| {
-            let start = rest.find('[')?;
-            let end = rest[start..].find(']')?;
-            Some(&rest[start..start + end])
-        })
-        .map(|list| {
-            list.split(['"', '\\', '[', ',', ' '])
-                .filter(|t| !t.is_empty() && t.chars().all(|c| c.is_ascii_lowercase() || c == '_'))
-                .collect()
+    fn from_params(errors: &serde_json::Value) -> Option<Vec<String>> {
+        for err in errors.as_array()? {
+            for param in err.get("params")?.as_array()? {
+                if param.get("key")?.as_str()? != "allowed-roles" {
+                    continue;
+                }
+                let roles: Vec<String> = match param.get("value")? {
+                    serde_json::Value::Array(items) => items
+                        .iter()
+                        .filter_map(|v| v.as_str())
+                        .map(str::to_string)
+                        .collect(),
+                    serde_json::Value::String(one) => vec![one.clone()],
+                    _ => continue,
+                };
+                if !roles.is_empty() {
+                    return Some(roles);
+                }
+            }
+        }
+        None
+    }
+
+    let roles = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| {
+            let errors = v.get("errors")?.clone();
+            // `errors` is normally a JSON-encoded string; tolerate it arriving already decoded.
+            match errors {
+                serde_json::Value::String(inner) => {
+                    from_params(&serde_json::from_str::<serde_json::Value>(&inner).ok()?)
+                }
+                other => from_params(&other),
+            }
         })
         .unwrap_or_default();
-    if roles.is_empty() {
-        return "owner".to_string();
+    match roles.len() {
+        // Only ever `owner` in practice; phrase both cases so the message reads correctly if the
+        // set widens (SM has feature flags for exactly that).
+        0 => "the owner role".to_string(),
+        1 => format!("the {} role", roles[0]),
+        _ => format!("one of these roles: {}", roles.join(", ")),
     }
-    roles.join(" or ")
 }
 
 impl SmApiClient {
@@ -428,7 +489,9 @@ impl SmApiClient {
                 allowed_roles: allowed_roles(&body),
             });
         }
-        if body.contains(FORBIDDEN_REQUEST_CODE) {
+        if status == reqwest::StatusCode::FORBIDDEN
+            && sm_error_codes(&body) == [FORBIDDEN_REQUEST_CODE]
+        {
             return Err(AuthError::CapiDisabled);
         }
         Err(AuthError::Protocol(format!(
@@ -691,32 +754,63 @@ mod tests {
         // The role SM named is carried through, not a hardcoded string.
         match c.ensure_capi_enabled().await {
             Err(AuthError::NotAccountOwner { allowed_roles }) => {
-                assert_eq!(allowed_roles, "owner")
+                assert_eq!(allowed_roles, "the owner role")
             }
             other => panic!("expected NotAccountOwner, got {other:?}"),
         }
     }
 
-    /// `allowed-roles` reaches us escaped inside a JSON-encoded string, and SM can name more than
-    /// one role. Anything unparseable still has to produce an accurate message.
+    /// `allowed-roles` reaches us escaped inside a JSON-encoded string. Parsing the structure
+    /// (rather than scanning the text) has to be independent of key order within a param and of
+    /// how role names are spelled, and anything unreadable must still say something accurate.
     #[test]
-    fn allowed_roles_parses_both_body_shapes_and_falls_back() {
+    fn allowed_roles_reads_the_param_regardless_of_shape() {
+        // The real wire shape: `errors` is a JSON-encoded string.
         assert_eq!(
             allowed_roles(
-                r#"{"errors":"[{\"params\":[{\"key\":\"allowed-roles\",\"value\":[\"owner\"]}]}]"}"#
+                r#"{"errors":"[{\"error_code\":\"insufficient-permission\",\"params\":[{\"key\":\"allowed-roles\",\"value\":[\"owner\"]}]}]"}"#
             ),
-            "owner"
+            "the owner role"
         );
+        // `value` before `key`, plus a second param that also has a value list: must not pick the
+        // wrong one. JSON object order carries no meaning, so this cannot be assumed away.
         assert_eq!(
-            allowed_roles(r#"{"params":[{"key":"allowed-roles","value":["owner","viewer"]}]}"#),
-            "owner or viewer"
+            allowed_roles(
+                r#"{"errors":[{"params":[{"value":["owner"],"key":"allowed-roles"},{"value":["viewer"],"key":"current-role"}]}]}"#
+            ),
+            "the owner role"
         );
-        // No params at all, or a shape we cannot read: name the only role that has ever held it.
+        // Several roles, including a name that is neither lowercase nor underscore-only.
+        assert_eq!(
+            allowed_roles(
+                r#"{"errors":[{"params":[{"key":"allowed-roles","value":["owner","billing_admin","Manager"]}]}]}"#
+            ),
+            "one of these roles: owner, billing_admin, Manager"
+        );
+        // No params, not JSON, or the param missing: name the only role that has ever held it.
         assert_eq!(
             allowed_roles(r#"{"errors":"insufficient-permission"}"#),
-            "owner"
+            "the owner role"
         );
-        assert_eq!(allowed_roles("allowed-roles but no list"), "owner");
+        assert_eq!(allowed_roles("not json at all"), "the owner role");
+        assert_eq!(
+            allowed_roles(r#"{"errors":[{"params":[{"key":"other","value":["x"]}]}]}"#),
+            "the owner role"
+        );
+    }
+
+    /// A generic code must not be matched out of an unrelated envelope.
+    #[test]
+    fn sm_error_codes_reads_every_nested_code() {
+        assert_eq!(
+            sm_error_codes(r#"{"errors":"[{\"error_code\":\"forbidden-request\"}]"}"#),
+            vec!["forbidden-request"]
+        );
+        assert_eq!(
+            sm_error_codes(r#"{"errors":[{"error_code":"a"},{"error_code":"b"}]}"#),
+            vec!["a", "b"]
+        );
+        assert!(sm_error_codes("not json").is_empty());
     }
 
     /// The account's own API access being off is a different failure from a role problem: no role
@@ -840,9 +934,6 @@ mod tests {
         ));
     }
 
-    /// SM records `utm_*` on the signup path, so a first-ever login through redisctl must carry
-    /// attribution or the tool is invisible in signup analytics. The mock matches only if all three
-    /// fields are present, and `utm_campaign` distinguishes the two flows.
     /// Every account-scoped call resolves the account from the session, so a switch has to be a
     /// real request to the documented path — the mock only matches that exact URL.
     #[tokio::test]
@@ -873,6 +964,9 @@ mod tests {
         ));
     }
 
+    /// SM records `utm_*` on the signup path, so a first-ever login through redisctl must carry
+    /// attribution or the tool is invisible in signup analytics. The mock matches only if all three
+    /// fields are present, and `utm_campaign` distinguishes the two flows.
     #[tokio::test]
     async fn login_sends_utm_attribution_per_flow() {
         for (flow, campaign) in [

--- a/crates/redisctl-core/tests/cloud_auth_config.rs
+++ b/crates/redisctl-core/tests/cloud_auth_config.rs
@@ -105,6 +105,8 @@ fn apply_cloud_login_writes_profile_default_and_endpoints() {
         refresh_token: Some("RT".to_string()),
         capi_key_name: "redisctl-demo".to_string(),
         redisctl_key_count: 1,
+        account_name: None,
+        account_count: 1,
     };
 
     config

--- a/crates/redisctl-core/tests/cloud_auth_config.rs
+++ b/crates/redisctl-core/tests/cloud_auth_config.rs
@@ -97,7 +97,7 @@ fn apply_cloud_login_writes_profile_default_and_endpoints() {
     let mut config = Config::default();
     let store = CredentialStore::plaintext(); // never touches the keyring
     let creds = MintedCredentials {
-        account_id: Some("112117".to_string()),
+        account_id: Some(112117),
         email: Some("u@e.com".to_string()),
         api_key: "ACCT-KEY".to_string(),
         api_secret: "USER-SECRET".to_string(),

--- a/crates/redisctl-core/tests/cloud_auth_config.rs
+++ b/crates/redisctl-core/tests/cloud_auth_config.rs
@@ -106,7 +106,10 @@ fn apply_cloud_login_writes_profile_default_and_endpoints() {
         capi_key_name: "redisctl-demo".to_string(),
         redisctl_key_count: 1,
         account_name: None,
-        account_count: 1,
+        accounts: vec![redisctl_core::auth::LoginAccount {
+            id: 112117,
+            name: None,
+        }],
     };
 
     config

--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -1680,6 +1680,10 @@ pub enum CloudAuthCommands {
         /// agent-friendly split. The browser (loopback) flow always blocks.
         #[arg(long)]
         wait: bool,
+        /// Mint the key for this Redis Cloud account id. Defaults to your current account; only
+        /// matters if you belong to more than one.
+        #[arg(long, value_name = "ID")]
+        account: Option<u64>,
     },
     /// Report whether the profile is authenticated to Redis Cloud.
     Status {

--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use redisctl_core::AuthError;
-use redisctl_core::auth::{CloudAuthenticator, LoginFlow, MintedCredentials};
+use redisctl_core::auth::{CloudAuthenticator, LoginAccount, LoginFlow, MintedCredentials};
 use redisctl_core::{CloudAuthConfig, Config, CredentialStore, DeviceAuthorization, TokenSet};
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -52,7 +52,19 @@ pub async fn handle_auth_command(
             device,
             allow_plaintext,
             wait,
-        } => login(conn_mgr, profile, *device, *allow_plaintext, *wait, output).await,
+            account,
+        } => {
+            login(
+                conn_mgr,
+                profile,
+                *device,
+                *allow_plaintext,
+                *wait,
+                *account,
+                output,
+            )
+            .await
+        }
         CloudAuthCommands::Status { wait, timeout } => {
             status(conn_mgr, profile, *wait, *timeout, output).await
         }
@@ -103,6 +115,7 @@ async fn login(
     device: bool,
     allow_plaintext: bool,
     wait: bool,
+    account: Option<u64>,
     output: OutputFormat,
 ) -> CliResult<()> {
     let (profile_name, authenticator, auth_cfg) = prepare(conn_mgr, profile)?;
@@ -119,6 +132,7 @@ async fn login(
             &profile_name,
             &authenticator,
             allow_plaintext,
+            account,
             output,
         )
         .await;
@@ -134,12 +148,15 @@ async fn login(
         &profile_name,
         &authenticator,
         &tokens,
-        allow_plaintext,
         auth_cfg,
-        if use_device {
-            LoginFlow::Device
-        } else {
-            LoginFlow::Loopback
+        LoginRun {
+            flow: if use_device {
+                LoginFlow::Device
+            } else {
+                LoginFlow::Loopback
+            },
+            account,
+            allow_plaintext,
         },
     )
     .await?;
@@ -170,6 +187,7 @@ async fn initiate_device_login(
     profile_name: &str,
     authenticator: &CloudAuthenticator,
     allow_plaintext: bool,
+    account: Option<u64>,
     output: OutputFormat,
 ) -> CliResult<()> {
     let authz = authenticator
@@ -183,6 +201,7 @@ async fn initiate_device_login(
             profile: profile_name.to_string(),
             device_authorization: authz.clone(),
             allow_plaintext,
+            account,
         },
     )?;
 
@@ -264,22 +283,36 @@ fn prompt_mfa_code(factors: &[String], attempt: u32) -> Result<Option<String>, A
     }
 }
 
+/// What one login run decided, threaded to the persist step together rather than as loose
+/// positional arguments.
+struct LoginRun {
+    flow: LoginFlow,
+    /// `--account`: mint for this account rather than the session's current one.
+    account: Option<u64>,
+    allow_plaintext: bool,
+}
+
 /// Run the SM exchange, persist the profile + secrets, and return the minted credentials.
 async fn complete_and_persist(
     conn_mgr: &ConnectionManager,
     profile_name: &str,
     authenticator: &CloudAuthenticator,
     tokens: &TokenSet,
-    allow_plaintext: bool,
     auth_cfg: CloudAuthConfig,
-    flow: LoginFlow,
+    run: LoginRun,
 ) -> CliResult<MintedCredentials> {
     let creds = authenticator
-        .complete_login_with_mfa(tokens, &default_key_name(), flow, prompt_mfa_code)
+        .complete_login_with_mfa(
+            tokens,
+            &default_key_name(),
+            run.flow,
+            run.account,
+            prompt_mfa_code,
+        )
         .await
         .map_err(auth_err)?;
 
-    let store = if allow_plaintext {
+    let store = if run.allow_plaintext {
         CredentialStore::plaintext()
     } else {
         CredentialStore::new()
@@ -290,7 +323,7 @@ async fn complete_and_persist(
     config
         .apply_cloud_login(&store, profile_name, &creds, Some(auth_cfg))
         .map_err(|e| {
-            if allow_plaintext {
+            if run.allow_plaintext {
                 RedisCtlError::from(e)
             } else {
                 RedisCtlError::Structured(Box::new(StructuredError::keyring_unavailable(format!(
@@ -316,7 +349,7 @@ fn emit_signed_in(
     );
     // The key is scoped to one account — whichever is *current* for this user, decided server-side
     // from the session. Say which was used when there was more than one it could have been.
-    if creds.account_count > 1 {
+    if creds.account_count() > 1 {
         let which = match (&creds.account_name, &creds.account_id) {
             (Some(name), Some(id)) => format!("{name} (#{id})"),
             (None, Some(id)) => format!("account #{id}"),
@@ -324,9 +357,22 @@ fn emit_signed_in(
             (None, None) => "your current account".to_string(),
         };
         eprintln!(
-            "  note: the key is for {which} — 1 of {} accounts you belong to. To use another, \
-             switch accounts in the Redis Cloud console and run login again.",
-            creds.account_count
+            "  note: the key is for {which} — 1 of {} accounts you belong to:",
+            creds.account_count()
+        );
+        eprintln!(
+            "    {}",
+            creds
+                .accounts
+                .iter()
+                .map(LoginAccount::label)
+                .collect::<Vec<_>>()
+                .join(" · ")
+        );
+        // Name the profile actually in use: a `<name>` placeholder invites inventing a new one,
+        // and an unconfigured profile silently resolves to the *production* endpoints.
+        eprintln!(
+            "  To use another: redisctl --profile {profile_name} cloud auth login --account <id>"
         );
     }
     // D5: each login mints a new redisctl-* CAPI key. Warn (don't delete) when they pile up.
@@ -344,7 +390,11 @@ fn emit_signed_in(
             "profile": profile_name,
             "account_id": creds.account_id,
             "account_name": creds.account_name,
-            "account_count": creds.account_count,
+            "account_count": creds.account_count(),
+            "accounts": creds.accounts.iter().map(|a| serde_json::json!({
+                "id": a.id,
+                "name": a.name,
+            })).collect::<Vec<_>>(),
             "email": creds.email,
             "redisctl_key_count": key_count,
         }),
@@ -372,9 +422,14 @@ async fn status(
                     &profile_name,
                     &authenticator,
                     &tokens,
-                    pending.allow_plaintext,
                     auth_cfg,
-                    LoginFlow::Device,
+                    LoginRun {
+                        flow: LoginFlow::Device,
+                        // Whatever the initiating `login --device --account` asked for; `None`
+                        // (no flag) keeps the session's current account.
+                        account: pending.account,
+                        allow_plaintext: pending.allow_plaintext,
+                    },
                 )
                 .await?;
                 clear_pending(conn_mgr, &profile_name);
@@ -473,6 +528,10 @@ fn logout(
 #[derive(Serialize, Deserialize)]
 struct PendingAuth {
     profile: String,
+    /// `--account` from the initiating `login`, so the account it asked for survives into the
+    /// `status --wait` that actually mints. Defaulted for pending files written before this field.
+    #[serde(default)]
+    account: Option<u64>,
     /// The full device authorization (serde-serializable), so a later `status --wait` — possibly
     /// a different process — can resume polling via `DeviceFlowClient::poll`.
     device_authorization: DeviceAuthorization,

--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -314,6 +314,21 @@ fn emit_signed_in(
         creds.email.as_deref().unwrap_or("your account"),
         profile_name
     );
+    // The key is scoped to one account — whichever is *current* for this user, decided server-side
+    // from the session. Say which was used when there was more than one it could have been.
+    if creds.account_count > 1 {
+        let which = match (&creds.account_name, &creds.account_id) {
+            (Some(name), Some(id)) => format!("{name} (#{id})"),
+            (None, Some(id)) => format!("account #{id}"),
+            (Some(name), None) => name.clone(),
+            (None, None) => "your current account".to_string(),
+        };
+        eprintln!(
+            "  note: the key is for {which} — 1 of {} accounts you belong to. To use another, \
+             switch accounts in the Redis Cloud console and run login again.",
+            creds.account_count
+        );
+    }
     // D5: each login mints a new redisctl-* CAPI key. Warn (don't delete) when they pile up.
     let key_count = creds.redisctl_key_count;
     if key_count > STALE_KEY_WARN_THRESHOLD {
@@ -328,6 +343,8 @@ fn emit_signed_in(
             "authenticated": true,
             "profile": profile_name,
             "account_id": creds.account_id,
+            "account_name": creds.account_name,
+            "account_count": creds.account_count,
             "email": creds.email,
             "redisctl_key_count": key_count,
         }),

--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -350,12 +350,20 @@ fn emit_signed_in(
     // The key is scoped to one account — whichever is *current* for this user, decided server-side
     // from the session. Say which was used when there was more than one it could have been.
     if creds.account_count() > 1 {
-        let which = match (&creds.account_name, &creds.account_id) {
-            (Some(name), Some(id)) => format!("{name} (#{id})"),
-            (None, Some(id)) => format!("account #{id}"),
-            (Some(name), None) => name.clone(),
-            (None, None) => "your current account".to_string(),
-        };
+        // Render through `label()` like the list below, so one account is never spelled two
+        // different ways two lines apart.
+        let which = creds
+            .account_id
+            .as_deref()
+            .and_then(|id| id.parse::<u64>().ok())
+            .and_then(|id| creds.accounts.iter().find(|a| a.id == id))
+            .map(LoginAccount::label)
+            .unwrap_or_else(|| match (&creds.account_name, &creds.account_id) {
+                (Some(name), Some(id)) => format!("{name} (#{id})"),
+                (None, Some(id)) => format!("#{id}"),
+                (Some(name), None) => name.clone(),
+                (None, None) => "your current account".to_string(),
+            });
         eprintln!(
             "  note: the key is for {which} — 1 of {} accounts you belong to:",
             creds.account_count()

--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -351,19 +351,13 @@ fn emit_signed_in(
     // from the session. Say which was used when there was more than one it could have been.
     if creds.account_count() > 1 {
         // Render through `label()` like the list below, so one account is never spelled two
-        // different ways two lines apart.
+        // different ways two lines apart. `account_id` is always one of `accounts` — both come
+        // from the same `/accounts` response — so the lookup only misses for a hand-built value.
         let which = creds
             .account_id
-            .as_deref()
-            .and_then(|id| id.parse::<u64>().ok())
             .and_then(|id| creds.accounts.iter().find(|a| a.id == id))
             .map(LoginAccount::label)
-            .unwrap_or_else(|| match (&creds.account_name, &creds.account_id) {
-                (Some(name), Some(id)) => format!("{name} (#{id})"),
-                (None, Some(id)) => format!("#{id}"),
-                (Some(name), None) => name.clone(),
-                (None, None) => "your current account".to_string(),
-            });
+            .unwrap_or_else(|| "your current account".to_string());
         eprintln!(
             "  note: the key is for {which} — 1 of {} accounts you belong to:",
             creds.account_count()

--- a/crates/redisctl/src/structured_error.rs
+++ b/crates/redisctl/src/structured_error.rs
@@ -85,6 +85,9 @@ impl StructuredError {
              enable it once in the console, then run login again",
         )
     }
+    pub fn unknown_account(message: impl Into<String>) -> Self {
+        Self::new("unknown_account", 2, false, message)
+    }
     pub fn migration_required() -> Self {
         Self::new(
             "migration_required",
@@ -186,6 +189,13 @@ impl From<AuthError> for StructuredError {
             // A one-time console step, not a failure to retry — give it its own code so an agent
             // can tell the user what to do rather than surfacing a generic exchange error.
             AuthError::NotAccountOwner => Self::insufficient_permission(),
+            // --account named an account the user is not in; the message lists the real ones.
+            AuthError::UnknownAccount {
+                requested,
+                ref available,
+            } => Self::unknown_account(format!(
+                "account {requested} is not one of yours; you belong to: {available}"
+            )),
             AuthError::MigrationRequired => Self::migration_required(),
             // Reached only when there was no terminal to prompt on: the caller must re-run
             // interactively, so this is a precondition to fix rather than a retryable failure.

--- a/crates/redisctl/src/structured_error.rs
+++ b/crates/redisctl/src/structured_error.rs
@@ -76,13 +76,16 @@ impl StructuredError {
     pub fn keyring_unavailable(message: impl Into<String>) -> Self {
         Self::new("keyring_unavailable", 2, false, message)
     }
-    pub fn insufficient_permission() -> Self {
+    pub fn insufficient_permission(message: impl Into<String>) -> Self {
+        Self::new("insufficient_permission", 2, false, message)
+    }
+    pub fn capi_disabled() -> Self {
         Self::new(
-            "insufficient_permission",
+            "capi_disabled",
             2,
             false,
-            "enabling programmatic access requires the Redis Cloud account owner; ask them to \
-             enable it once in the console, then run login again",
+            "programmatic access is not enabled for this Redis Cloud account; ask Redis support \
+             to enable API access for the account, then run login again",
         )
     }
     pub fn unknown_account(message: impl Into<String>) -> Self {
@@ -188,7 +191,15 @@ impl From<AuthError> for StructuredError {
             }
             // A one-time console step, not a failure to retry — give it its own code so an agent
             // can tell the user what to do rather than surfacing a generic exchange error.
-            AuthError::NotAccountOwner => Self::insufficient_permission(),
+            // Relay the role SM itself named, so the message stays right if that set widens.
+            AuthError::NotAccountOwner { ref allowed_roles } => {
+                Self::insufficient_permission(format!(
+                    "enabling programmatic access requires the {allowed_roles} role on this Redis \
+                     Cloud account; ask someone with it to enable it once in the console, then \
+                     run login again"
+                ))
+            }
+            AuthError::CapiDisabled => Self::capi_disabled(),
             // --account named an account the user is not in; the message lists the real ones.
             AuthError::UnknownAccount {
                 requested,
@@ -257,9 +268,17 @@ mod tests {
             StructuredError::from(AuthError::Protocol("boom".into())).code,
             "sm_exchange_failed"
         );
-        let owner = StructuredError::from(AuthError::NotAccountOwner);
+        let owner = StructuredError::from(AuthError::NotAccountOwner {
+            allowed_roles: "owner".to_string(),
+        });
         assert_eq!(owner.code, "insufficient_permission");
         assert_eq!(owner.exit_code, 2);
+        // The role SM reported reaches the user rather than a hardcoded one.
+        assert!(owner.message.contains("owner role"));
+        let disabled = StructuredError::from(AuthError::CapiDisabled);
+        assert_eq!(disabled.code, "capi_disabled");
+        assert_eq!(disabled.exit_code, 2);
+        assert!(!disabled.retryable);
         let mig = StructuredError::from(AuthError::MigrationRequired);
         assert_eq!(mig.code, "migration_required");
         assert_eq!(mig.exit_code, 2);

--- a/crates/redisctl/src/structured_error.rs
+++ b/crates/redisctl/src/structured_error.rs
@@ -79,14 +79,8 @@ impl StructuredError {
     pub fn insufficient_permission(message: impl Into<String>) -> Self {
         Self::new("insufficient_permission", 2, false, message)
     }
-    pub fn capi_disabled() -> Self {
-        Self::new(
-            "capi_disabled",
-            2,
-            false,
-            "programmatic access is not enabled for this Redis Cloud account; ask Redis support \
-             to enable API access for the account, then run login again",
-        )
+    pub fn capi_disabled(message: impl Into<String>) -> Self {
+        Self::new("capi_disabled", 2, false, message)
     }
     pub fn unknown_account(message: impl Into<String>) -> Self {
         Self::new("unknown_account", 2, false, message)
@@ -191,22 +185,12 @@ impl From<AuthError> for StructuredError {
             }
             // A one-time console step, not a failure to retry — give it its own code so an agent
             // can tell the user what to do rather than surfacing a generic exchange error.
-            // Relay the role SM itself named, so the message stays right if that set widens.
-            AuthError::NotAccountOwner { ref allowed_roles } => {
-                Self::insufficient_permission(format!(
-                    "enabling programmatic access requires the {allowed_roles} role on this Redis \
-                     Cloud account; ask someone with it to enable it once in the console, then \
-                     run login again"
-                ))
-            }
-            AuthError::CapiDisabled => Self::capi_disabled(),
+            // Reuse the `AuthError` Display text rather than restating it: a second copy here
+            // would leave the agent-facing message stale whenever the attribute is edited.
+            AuthError::NotAccountOwner { .. } => Self::insufficient_permission(err.to_string()),
+            AuthError::CapiDisabled => Self::capi_disabled(err.to_string()),
             // --account named an account the user is not in; the message lists the real ones.
-            AuthError::UnknownAccount {
-                requested,
-                ref available,
-            } => Self::unknown_account(format!(
-                "account {requested} is not one of yours; you belong to: {available}"
-            )),
+            AuthError::UnknownAccount { .. } => Self::unknown_account(err.to_string()),
             AuthError::MigrationRequired => Self::migration_required(),
             // Reached only when there was no terminal to prompt on: the caller must re-run
             // interactively, so this is a precondition to fix rather than a retryable failure.
@@ -232,6 +216,13 @@ mod tests {
             StructuredError::not_authenticated("x"),
             StructuredError::sm_exchange_failed("x"),
             StructuredError::keyring_unavailable("x"),
+            StructuredError::insufficient_permission("x"),
+            StructuredError::capi_disabled("x"),
+            StructuredError::unknown_account("x"),
+            StructuredError::migration_required(),
+            StructuredError::mfa_required(),
+            StructuredError::mfa_invalid_code(),
+            StructuredError::mfa_quota_exceeded(),
             StructuredError::invalid_name("x"),
             StructuredError::name_conflict("x"),
             StructuredError::free_db_exists("x"),
@@ -268,13 +259,22 @@ mod tests {
             StructuredError::from(AuthError::Protocol("boom".into())).code,
             "sm_exchange_failed"
         );
+        // `allowed_roles` arrives already phrased (see sm_api::allowed_roles).
         let owner = StructuredError::from(AuthError::NotAccountOwner {
-            allowed_roles: "owner".to_string(),
+            allowed_roles: "the owner role".to_string(),
         });
         assert_eq!(owner.code, "insufficient_permission");
         assert_eq!(owner.exit_code, 2);
         // The role SM reported reaches the user rather than a hardcoded one.
-        assert!(owner.message.contains("owner role"));
+        assert!(owner.message.contains("the owner role"));
+        // The relayed text is the AuthError's own, so the two paths cannot drift.
+        assert_eq!(
+            owner.message,
+            AuthError::NotAccountOwner {
+                allowed_roles: "the owner role".to_string()
+            }
+            .to_string()
+        );
         let disabled = StructuredError::from(AuthError::CapiDisabled);
         assert_eq!(disabled.code, "capi_disabled");
         assert_eq!(disabled.exit_code, 2);

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -158,7 +158,11 @@ recent account stays usable.
 
 `-o json` reports `account_id`, `account_name` and `account_count`, plus an `accounts` array of
 every `{id, name}` — so a script can confirm it got the account it expected, or pick one without a
-trip to the console.
+trip to the console. `account_id` and `accounts[].id` are both numbers, so they compare directly:
+
+```bash
+redisctl cloud auth login -o json | jq -e '.account_id == 316941'
+```
 
 ### Password accounts need linking once
 

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -40,6 +40,7 @@ redisctl cloud auth login --allow-plaintext
 | `--device` | Use the device-authorization flow (print a URL + code) instead of opening a browser. |
 | `--wait` | With `--device`: block until approved (one-shot). Without it, `login --device` returns immediately and `auth status --wait` completes the login. |
 | `--allow-plaintext` | Store credentials in the config file when no OS keyring is available. |
+| `--account <ID>` | Mint the key for this Redis Cloud account id. Defaults to your current account. Carried through the device flow, so `login --device --account <id>` still applies when `auth status --wait` completes it. |
 
 ### Browser (loopback) flow
 
@@ -120,24 +121,42 @@ You get three attempts per login.
 
 A Redis Cloud API key is scoped to **one account**. If you belong to several, `cloud auth login`
 mints the key for your **current** account — the one selected in the
-[Redis Cloud console](https://app.redislabs.com) — and says which it used:
+[Redis Cloud console](https://app.redislabs.com) — then names it and lists the alternatives, so you
+never have to look an account id up:
 
 ```
 ✓ Signed in as user@example.com. Credentials saved to profile 'cloud'.
-  note: the key is for Acme (#316941) — 1 of 3 accounts you belong to. To use another, switch
-  accounts in the Redis Cloud console and run login again.
+  note: the key is for Acme (#316941) — 1 of 3 accounts you belong to:
+    Acme (#316941) · Contoso (#481022) · Initech (#502113)
+  To use another: redisctl cloud auth login --profile <name> --account <id>
 ```
 
-To target a different one, switch to it in the console (top-right user menu) and run
-`cloud auth login` again. Keeping one profile per account works well:
+Use `--account` to pick one explicitly, without touching the console:
 
 ```bash
-redisctl cloud auth login --profile acme      # with Acme selected in the console
-redisctl cloud auth login --profile contoso   # after switching to Contoso
+redisctl cloud auth login --account 316941
 ```
 
-`-o json` reports `account_id`, `account_name` and `account_count`, so a script can confirm it got
-the account it expected before doing anything.
+Naming an account you don't belong to exits `2` with `unknown_account`, and the message lists the
+ones you do have. Keeping one profile per account works well:
+
+```bash
+redisctl --profile acme    cloud auth login --account 316941
+redisctl --profile contoso cloud auth login --account 481022
+```
+
+Re-using one profile is fine too, but each login replaces that profile's key, so only the most
+recent account stays usable.
+
+!!! note "A new profile name defaults to production"
+    A profile with no `[cloud_auth.<name>]` section falls back to the built-in **production**
+    endpoints. That is what you want for production, but when logging in to a non-production
+    environment, add the section first — otherwise the new profile silently signs you in to
+    production instead.
+
+`-o json` reports `account_id`, `account_name` and `account_count`, plus an `accounts` array of
+every `{id, name}` — so a script can confirm it got the account it expected, or pick one without a
+trip to the console.
 
 ### Password accounts need linking once
 

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -138,7 +138,9 @@ redisctl cloud auth login --account 316941
 ```
 
 Naming an account you don't belong to exits `2` with `unknown_account`, and the message lists the
-ones you do have. Keeping one profile per account works well:
+ones you do have. You need the **Owner** role on whichever account you pick — being an owner of one
+account says nothing about your role on another, so `--account` can exit `2` with
+`insufficient_permission` even when a plain `login` succeeds. Keeping one profile per account works well:
 
 ```bash
 redisctl --profile acme    cloud auth login --account 316941
@@ -214,6 +216,13 @@ sign-in the identity provider can perform:
 | SSO / SAML | ❌ | the CLI cannot select an organization's own identity provider — use an API key |
 | Email + password | after linking | link the account to Google or GitHub once, in the console |
 | Marketplace (Heroku, GCP, Azure) | ❌ | sign-in is initiated by the marketplace; there is no Redis-side credential |
+
+!!! note "Account owners only"
+    Whatever the sign-in method, `cloud auth login` also needs the **Owner** role on the account:
+    a Redis Cloud API key can only be created and held by an account owner. Every other role —
+    Member, Manager, Viewer, Billing Admin, Logs Viewer — exits `2` with
+    `insufficient_permission`, naming the role that is required. Ask an owner to create a key and
+    use it directly, as below.
 
 For anything unsupported — and for **unattended automation** of any kind — create an API key in the
 [Redis Cloud console](https://app.redislabs.com) and configure it directly:

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -128,7 +128,7 @@ never have to look an account id up:
 ✓ Signed in as user@example.com. Credentials saved to profile 'cloud'.
   note: the key is for Acme (#316941) — 1 of 3 accounts you belong to:
     Acme (#316941) · Contoso (#481022) · Initech (#502113)
-  To use another: redisctl cloud auth login --profile <name> --account <id>
+  To use another: redisctl --profile cloud cloud auth login --account <id>
 ```
 
 Use `--account` to pick one explicitly, without touching the console:
@@ -138,9 +138,9 @@ redisctl cloud auth login --account 316941
 ```
 
 Naming an account you don't belong to exits `2` with `unknown_account`, and the message lists the
-ones you do have. You need the **Owner** role on whichever account you pick — being an owner of one
-account says nothing about your role on another, so `--account` can exit `2` with
-`insufficient_permission` even when a plain `login` succeeds. Keeping one profile per account works well:
+ones you do have. You also need a role that can create API keys on whichever account you
+pick — your role on one account says nothing about your role on another, so `--account` can exit
+`2` with `insufficient_permission` even when a plain `login` succeeds. Keeping one profile per account works well:
 
 ```bash
 redisctl --profile acme    cloud auth login --account 316941
@@ -217,12 +217,12 @@ sign-in the identity provider can perform:
 | Email + password | after linking | link the account to Google or GitHub once, in the console |
 | Marketplace (Heroku, GCP, Azure) | ❌ | sign-in is initiated by the marketplace; there is no Redis-side credential |
 
-!!! note "Account owners only"
-    Whatever the sign-in method, `cloud auth login` also needs the **Owner** role on the account:
-    a Redis Cloud API key can only be created and held by an account owner. Every other role —
-    Member, Manager, Viewer, Billing Admin, Logs Viewer — exits `2` with
-    `insufficient_permission`, naming the role that is required. Ask an owner to create a key and
-    use it directly, as below.
+!!! note "You need a role that can create API keys"
+    Whatever the sign-in method, `cloud auth login` also needs a role on the account that permits
+    programmatic access — in practice the **Owner** role today. Other roles (Member, Manager,
+    Viewer, Billing Admin, Logs Viewer) exit `2` with `insufficient_permission`, and the message
+    names the role that is required, so it stays accurate if Redis widens that set. Ask someone
+    with it to create a key and use it directly, as below.
 
 For anything unsupported — and for **unattended automation** of any kind — create an API key in the
 [Redis Cloud console](https://app.redislabs.com) and configure it directly:

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -116,6 +116,29 @@ You get three attempts per login.
     `redisctl cloud auth login` in a terminal. For unattended automation, use a
     pre-created API key instead of `auth login`.
 
+### Which account the key belongs to
+
+A Redis Cloud API key is scoped to **one account**. If you belong to several, `cloud auth login`
+mints the key for your **current** account — the one selected in the
+[Redis Cloud console](https://app.redislabs.com) — and says which it used:
+
+```
+✓ Signed in as user@example.com. Credentials saved to profile 'cloud'.
+  note: the key is for Acme (#316941) — 1 of 3 accounts you belong to. To use another, switch
+  accounts in the Redis Cloud console and run login again.
+```
+
+To target a different one, switch to it in the console (top-right user menu) and run
+`cloud auth login` again. Keeping one profile per account works well:
+
+```bash
+redisctl cloud auth login --profile acme      # with Acme selected in the console
+redisctl cloud auth login --profile contoso   # after switching to Contoso
+```
+
+`-o json` reports `account_id`, `account_name` and `account_count`, so a script can confirm it got
+the account it expected before doing anything.
+
 ### Password accounts need linking once
 
 Redis Cloud accounts that sign in with an email and password cannot be used by the CLI directly —

--- a/docs/docs/reference/agent-error-codes.md
+++ b/docs/docs/reference/agent-error-codes.md
@@ -40,6 +40,7 @@ keeps today's `0` / `1` exit behavior.
 | `keyring_unavailable` | 2 | no | No OS keyring available to store the key. Re-run with `--allow-plaintext`. |
 | `migration_required` | 2 | no | The account signs in with a password and must be linked to Google/GitHub once in the Redis Cloud console. |
 | `insufficient_permission` | 2 | no | Enabling programmatic access requires the Redis Cloud account owner. Ask them to enable it once in the console. |
+| `unknown_account` | 2 | no | `--account` named an account you don't belong to. The message lists the accounts you do have. |
 | `mfa_required` | 2 | no | The account requires multi-factor authentication and there was no terminal to prompt on. Re-run `cloud auth login` interactively. |
 | `mfa_invalid_code` | 2 | no | The multi-factor code was rejected. Start login again. |
 | `invalid_name` | 2 | no | The database name doesn't match the naming rules (see below). |

--- a/docs/docs/reference/agent-error-codes.md
+++ b/docs/docs/reference/agent-error-codes.md
@@ -39,7 +39,8 @@ keeps today's `0` / `1` exit behavior.
 | `auth_denied` | 2 | no | The sign-in request was denied. |
 | `keyring_unavailable` | 2 | no | No OS keyring available to store the key. Re-run with `--allow-plaintext`. |
 | `migration_required` | 2 | no | The account signs in with a password and must be linked to Google/GitHub once in the Redis Cloud console. |
-| `insufficient_permission` | 2 | no | Enabling programmatic access requires the Redis Cloud account owner. Ask them to enable it once in the console. |
+| `insufficient_permission` | 2 | no | Your role on the account does not permit programmatic access. The message names the role that does — in practice the account owner. |
+| `capi_disabled` | 2 | no | API access is switched off for the whole account, so no role can mint a key. Only Redis can re-enable it. |
 | `unknown_account` | 2 | no | `--account` named an account you don't belong to. The message lists the accounts you do have. |
 | `mfa_required` | 2 | no | The account requires multi-factor authentication and there was no terminal to prompt on. Re-run `cloud auth login` interactively. |
 | `mfa_invalid_code` | 2 | no | The multi-factor code was rejected. Start login again. |


### PR DESCRIPTION
A Redis Cloud API key is scoped to **one account**. `cloud auth login` minted for
whichever account the session happened to be on, said nothing about it, and gave no
way to target another — so a user who belongs to several got a key for an account
they may not have meant, with nothing in the output to tell them.

## Saying which account

Login now names the account the key is for and lists the alternatives, but only when
there is more than one it could have been:

```
✓ Signed in as user@example.com. Credentials saved to profile 'cloud'.
  note: the key is for Acme (#316941) — 1 of 3 accounts you belong to:
    Acme (#316941) · Contoso (#481022) · Initech (#502113)
  To use another: redisctl --profile cloud cloud auth login --account <id>
```

This costs nothing: login already fetched the account list to count it and then
discarded it. `-o json` carries the same data as an `accounts` array.

## Choosing the account

```bash
redisctl cloud auth login --account 316941
```

`POST /accounts/setcurrent/{id}` rebinds the session, and it is reachable from here:
the endpoint accepts session authentication, which is exactly the `JSESSIONID` that
`/login` returns and that every authenticated call already carries.

The switch happens **before** enabling programmatic access and minting, since both
resolve the account from the session — doing it afterwards would put the key on the
previous account. A test pins that ordering by answering `/users/me` differently
before and after the switch, so the minted account is only correct if the sequence
held.

Two things it refuses to do quietly:

- An account the user does not belong to fails with `unknown_account` (exit 2)
  before any switch is attempted, and the message lists the accounts they do have.
- After switching, the session's account is re-read and compared with what was asked
  for. A switch that reports success but does not take would otherwise mint on the
  wrong account and report success — silently wrong rather than merely broken.

`--account` survives the device flow's two-process split: `login --device --account`
records it, and `auth status --wait` mints against it.

## Roles, and a refusal that was being misreported

Enabling programmatic access needs a role that carries the Cloud API permission —
in practice the account owner. That was undocumented: the \"who can use login\"
table covered sign-in methods only, so other roles had no way to know. It matters
more with \`--account\`, since your role on one account says nothing about your role
on another.

The refusal also relays the role the API names, rather than a hardcoded one, so the
message stays accurate if that set ever widens.

Separately, an account with API access switched off returns a *different* error, and
it was landing in `sm_exchange_failed` — exit 1, \"treat this as a bug\". It is a
precondition with its own remedy (no role can fix it), so it is now `capi_disabled`
(exit 2).

## Testing

Verified end to end against a QA user belonging to two accounts: the note lists
both, `--account` switches and mints on the requested one, and subsequent
account-scoped commands read the switched-to account. Both the browser and device
flows, including the non-blocking `login --device` → `status --wait` handoff. The
role refusal was exercised with a non-owner role.

Not exercised against a live backend: `capi_disabled` (the account flag is not
customer-settable) and the multiple-role message (the API reports a single role
today). Both are covered by tests.

Docs updated: the flag, the account section, the role requirement, and the new
error code in the agent error inventory.