### PR TITLE
feat(cli): add cloud auth switch to change account without signing in again

### DIFF
--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -218,7 +218,7 @@ impl CloudAuthenticator {
             // The picker needs the list, so fetch it here; `switch_account` re-reads it to
             // validate, which also covers ids that did not come from a picker.
             AccountChoice::Prompt(choose) => {
-                let accounts: Vec<LoginAccount> = sm
+                let mut accounts: Vec<LoginAccount> = sm
                     .fetch_accounts()
                     .await?
                     .into_iter()
@@ -227,6 +227,9 @@ impl CloudAuthenticator {
                         name: a.name,
                     })
                     .collect();
+                // `/accounts` order is not guaranteed. Sort so a positional picker means the same
+                // thing between runs — otherwise "2" could select a different account each time.
+                accounts.sort_by_key(|a| a.id);
                 let current = user
                     .current_account_id
                     .as_deref()

--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -42,6 +42,35 @@ pub struct MintedCredentials {
     pub accounts: Vec<LoginAccount>,
 }
 
+/// How the account to mint for is decided.
+///
+/// [`AccountChoice::Prompt`] exists because a picker cannot run before the exchange: listing the
+/// accounts needs a session, and re-logging-in to act on the answer would mean a second sign-in
+/// (and a second MFA challenge). The callback is invoked mid-exchange instead, on the one session.
+pub enum AccountChoice {
+    /// Whatever account the session is already on.
+    Current,
+    /// A specific account id.
+    Id(u64),
+    /// Decide once the accounts are known. Called with every account the user belongs to and the
+    /// id of the current one, when the API reports it.
+    Prompt(AccountPrompt),
+}
+
+/// Callback for [`AccountChoice::Prompt`]: pick an account id, or fail with the reason.
+pub type AccountPrompt =
+    Box<dyn Fn(&[LoginAccount], Option<u64>) -> Result<u64, AuthError> + Send + Sync>;
+
+impl std::fmt::Debug for AccountChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Current => f.write_str("Current"),
+            Self::Id(id) => write!(f, "Id({id})"),
+            Self::Prompt(_) => f.write_str("Prompt(..)"),
+        }
+    }
+}
+
 /// One account the signed-in user belongs to, as reported during login.
 #[derive(Debug, Clone)]
 pub struct LoginAccount {
@@ -147,7 +176,7 @@ impl CloudAuthenticator {
         tokens: &TokenSet,
         key_name: &str,
         flow: LoginFlow,
-        account: Option<u64>,
+        account: AccountChoice,
     ) -> Result<MintedCredentials, AuthError> {
         self.complete_login_with_mfa(tokens, key_name, flow, account, |_, _| Ok(None))
             .await
@@ -165,7 +194,7 @@ impl CloudAuthenticator {
         tokens: &TokenSet,
         key_name: &str,
         flow: LoginFlow,
-        account: Option<u64>,
+        account: AccountChoice,
         mut mfa_prompt: F,
     ) -> Result<MintedCredentials, AuthError>
     where
@@ -183,7 +212,29 @@ impl CloudAuthenticator {
             Err(e) => return Err(e),
         }
         let mut user = sm.fetch_current_user().await?;
-        if let Some(want) = account {
+        let want = match account {
+            AccountChoice::Current => None,
+            AccountChoice::Id(id) => Some(id),
+            // The picker needs the list, so fetch it here; `switch_account` re-reads it to
+            // validate, which also covers ids that did not come from a picker.
+            AccountChoice::Prompt(choose) => {
+                let accounts: Vec<LoginAccount> = sm
+                    .fetch_accounts()
+                    .await?
+                    .into_iter()
+                    .map(|a| LoginAccount {
+                        id: a.id,
+                        name: a.name,
+                    })
+                    .collect();
+                let current = user
+                    .current_account_id
+                    .as_deref()
+                    .and_then(|s| s.parse::<u64>().ok());
+                Some(choose(&accounts, current)?)
+            }
+        };
+        if let Some(want) = want {
             user = self.switch_account(&sm, user, want).await?;
         }
         sm.ensure_capi_enabled().await?;
@@ -486,7 +537,12 @@ mod tests {
         };
 
         let creds = auth
-            .complete_login(&tokens, "redisctl-test", LoginFlow::Loopback, None)
+            .complete_login(
+                &tokens,
+                "redisctl-test",
+                LoginFlow::Loopback,
+                AccountChoice::Current,
+            )
             .await
             .unwrap();
         assert_eq!(creds.api_key, "ACCT-KEY");
@@ -602,7 +658,12 @@ mod tests {
             .await;
 
         let creds = authenticator(&server)
-            .complete_login(&tokens(), "redisctl-test", LoginFlow::Loopback, Some(222))
+            .complete_login(
+                &tokens(),
+                "redisctl-test",
+                LoginFlow::Loopback,
+                AccountChoice::Id(222),
+            )
             .await
             .unwrap();
         // The key, the reported id and the reported name all describe the requested account.
@@ -635,7 +696,7 @@ mod tests {
         // No /accounts/setcurrent/* mock is mounted: reaching one would 404 and surface as a
         // different error, which is itself the assertion that no switch was attempted.
         match authenticator(&server)
-            .complete_login(&tokens(), "k", LoginFlow::Loopback, Some(999))
+            .complete_login(&tokens(), "k", LoginFlow::Loopback, AccountChoice::Id(999))
             .await
         {
             Err(AuthError::UnknownAccount {
@@ -679,7 +740,7 @@ mod tests {
             .mount(&server)
             .await;
         let err = authenticator(&server)
-            .complete_login(&tokens(), "k", LoginFlow::Loopback, Some(222))
+            .complete_login(&tokens(), "k", LoginFlow::Loopback, AccountChoice::Id(222))
             .await
             .unwrap_err();
         assert!(
@@ -709,7 +770,7 @@ mod tests {
             .await;
         // Again, no setcurrent mount: if one were issued it would 404 and fail the login.
         let creds = authenticator(&server)
-            .complete_login(&tokens(), "k", LoginFlow::Loopback, Some(111))
+            .complete_login(&tokens(), "k", LoginFlow::Loopback, AccountChoice::Id(111))
             .await
             .unwrap();
         assert_eq!(creds.account_id, Some(111));
@@ -735,7 +796,7 @@ mod tests {
             expires_in: 3600,
         };
         assert!(matches!(
-            auth.complete_login(&tokens, "k", LoginFlow::Loopback, None)
+            auth.complete_login(&tokens, "k", LoginFlow::Loopback, AccountChoice::Current)
                 .await,
             Err(AuthError::Protocol(_))
         ));

--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -94,6 +94,18 @@ impl MintedCredentials {
     pub fn account_count(&self) -> usize {
         self.accounts.len()
     }
+
+    /// The account the key is for, rendered like the listing (`Acme (#316941)`).
+    ///
+    /// Shared so every place that names the account spells it the same way. `account_id` is always
+    /// one of `accounts` — both come from the same `/accounts` response — so the lookup only
+    /// misses for a hand-built value.
+    pub fn account_label(&self) -> String {
+        self.account_id
+            .and_then(|id| self.accounts.iter().find(|a| a.id == id))
+            .map(LoginAccount::label)
+            .unwrap_or_else(|| "your current account".to_string())
+    }
 }
 
 impl std::fmt::Debug for MintedCredentials {
@@ -218,18 +230,7 @@ impl CloudAuthenticator {
             // The picker needs the list, so fetch it here; `switch_account` re-reads it to
             // validate, which also covers ids that did not come from a picker.
             AccountChoice::Prompt(choose) => {
-                let mut accounts: Vec<LoginAccount> = sm
-                    .fetch_accounts()
-                    .await?
-                    .into_iter()
-                    .map(|a| LoginAccount {
-                        id: a.id,
-                        name: a.name,
-                    })
-                    .collect();
-                // `/accounts` order is not guaranteed. Sort so a positional picker means the same
-                // thing between runs — otherwise "2" could select a different account each time.
-                accounts.sort_by_key(|a| a.id);
+                let accounts = login_accounts(&sm.fetch_accounts().await?);
                 let current = user
                     .current_account_id
                     .as_deref()
@@ -245,13 +246,7 @@ impl CloudAuthenticator {
         // order isn't guaranteed, so taking the first entry could mint a key for the wrong
         // account in a multi-account org. Fall back to the first only when it's absent/unknown.
         let accounts = sm.fetch_accounts().await?;
-        let all_accounts: Vec<LoginAccount> = accounts
-            .iter()
-            .map(|a| LoginAccount {
-                id: a.id,
-                name: a.name.clone(),
-            })
-            .collect();
+        let all_accounts = login_accounts(&accounts);
         let account = select_account(accounts, user.current_account_id.as_deref())
             .ok_or_else(|| AuthError::Protocol("no accounts associated with this login".into()))?;
         let account_name = account.name.clone();
@@ -371,6 +366,23 @@ const MFA_MAX_ATTEMPTS: u32 = 3;
 
 /// Choose the account matching `current_account_id` (the logged-in user context); fall back to
 /// the first account only when the id is absent or not present in the list.
+/// Project the API's accounts into [`LoginAccount`]s, in a stable order.
+///
+/// `/accounts` order is not guaranteed. Sorting here rather than at each use means the picker's
+/// numbering, the printed listing and the JSON `accounts` array all agree between runs — the last
+/// of which callers are told to read for ids.
+fn login_accounts(accounts: &[SmAccount]) -> Vec<LoginAccount> {
+    let mut out: Vec<LoginAccount> = accounts
+        .iter()
+        .map(|a| LoginAccount {
+            id: a.id,
+            name: a.name.clone(),
+        })
+        .collect();
+    out.sort_by_key(|a| a.id);
+    out
+}
+
 fn select_account(accounts: Vec<SmAccount>, current_account_id: Option<&str>) -> Option<SmAccount> {
     let target = current_account_id.and_then(|s| s.parse::<u64>().ok());
     let idx = target
@@ -674,6 +686,111 @@ mod tests {
         assert_eq!(creds.account_name.as_deref(), Some("Two"));
         assert_eq!(creds.api_key, "KEY-222");
         assert_eq!(creds.account_count(), 2);
+    }
+
+    /// The picker runs mid-exchange, on the one session. It must see every account in a stable
+    /// order (the API does not promise one) along with the session's current account, and its
+    /// answer must be what gets minted.
+    #[tokio::test]
+    async fn complete_login_mints_what_the_picker_chose() {
+        let server = MockServer::start().await;
+        let switched = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        common_login_mocks(&server).await;
+
+        let flag = switched.clone();
+        Mock::given(method("GET"))
+            .and(path("/users/me"))
+            .respond_with(move |_: &wiremock::Request| {
+                let id = if flag.load(std::sync::atomic::Ordering::SeqCst) {
+                    "111"
+                } else {
+                    "222"
+                };
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "1", "current_account_id": id, "email": "u@e.com"
+                }))
+            })
+            .mount(&server)
+            .await;
+        let flag = switched.clone();
+        Mock::given(method("POST"))
+            .and(path("/accounts/setcurrent/111"))
+            .respond_with(move |_: &wiremock::Request| {
+                flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({}))
+            })
+            .mount(&server)
+            .await;
+        // Deliberately returned highest-id-first, so a stable order cannot come from the API.
+        Mock::given(method("GET"))
+            .and(path("/accounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "accounts": [
+                    {"id": 222, "name": "Two", "api_access_key": "KEY-222"},
+                    {"id": 111, "name": "One", "api_access_key": "KEY-111"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen_current = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let (s2, c2) = (seen.clone(), seen_current.clone());
+        let creds = authenticator(&server)
+            .complete_login(
+                &tokens(),
+                "k",
+                LoginFlow::Switch,
+                AccountChoice::Prompt(Box::new(move |accounts, current| {
+                    *s2.lock().unwrap() = accounts.iter().map(|a| a.id).collect::<Vec<_>>();
+                    *c2.lock().unwrap() = current;
+                    Ok(111)
+                })),
+            )
+            .await
+            .unwrap();
+
+        // Sorted by id despite the API's order, so a positional choice is stable between runs.
+        assert_eq!(*seen.lock().unwrap(), vec![111, 222]);
+        // The session's account is passed through for context.
+        assert_eq!(*seen_current.lock().unwrap(), Some(222));
+        // And the picker's answer is what got minted.
+        assert_eq!(creds.account_id, Some(111));
+        assert_eq!(creds.api_key, "KEY-111");
+        assert_eq!(creds.account_label(), "One (#111)");
+    }
+
+    /// Refusing at the picker abandons the switch instead of minting something unasked for.
+    #[tokio::test]
+    async fn complete_login_propagates_a_declined_picker() {
+        let server = MockServer::start().await;
+        common_login_mocks(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/users/me"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"id": "1", "current_account_id": "111", "email": "u@e.com"}),
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/accounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "accounts": [{"id": 111, "name": "One", "api_access_key": "KEY-111"}]
+            })))
+            .mount(&server)
+            .await;
+        let err = authenticator(&server)
+            .complete_login(
+                &tokens(),
+                "k",
+                LoginFlow::Switch,
+                AccountChoice::Prompt(Box::new(|_, _| {
+                    Err(AuthError::AccountRequired("declined".into()))
+                })),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AuthError::AccountRequired(_)), "got {err:?}");
     }
 
     /// An account the user does not belong to is refused before any switch is attempted, and the

--- a/crates/redisctl-core/src/auth/mod.rs
+++ b/crates/redisctl-core/src/auth/mod.rs
@@ -20,7 +20,9 @@ pub mod sm_api;
 mod oidc;
 
 pub use auth_code_loopback::LoopbackFlowClient;
-pub use authenticator::{CloudAuthenticator, LoginAccount, MintedCredentials};
+pub use authenticator::{
+    AccountChoice, AccountPrompt, CloudAuthenticator, LoginAccount, MintedCredentials,
+};
 pub use device_flow::{DeviceAuthorization, DeviceFlowClient};
 pub use oidc::{AuthError, TokenSet};
 pub use sm_api::{CapiKey, LoginFlow, SmAccount, SmApiClient, SmUser};

--- a/crates/redisctl-core/src/auth/oidc.rs
+++ b/crates/redisctl-core/src/auth/oidc.rs
@@ -93,6 +93,11 @@ pub enum AuthError {
     #[error("account {requested} is not one of yours; you belong to: {available}")]
     UnknownAccount { requested: u64, available: String },
 
+    /// No usable account choice: none was given where one is required, or the caller gave up.
+    /// A precondition for the caller to fix, not a backend failure.
+    #[error("{0}")]
+    AccountRequired(String),
+
     /// SM challenged the login for multi-factor authentication (`user-mfa-required`). Carries the
     /// factor types SM offered, when it reports them.
     #[error("this account requires multi-factor authentication")]

--- a/crates/redisctl-core/src/auth/sm_api.rs
+++ b/crates/redisctl-core/src/auth/sm_api.rs
@@ -59,6 +59,8 @@ pub enum LoginFlow {
     Loopback,
     /// Device-authorization grant — headless machines and agents.
     Device,
+    /// `cloud auth switch`: no browser at all, a stored refresh token stands in for the sign-in.
+    Switch,
 }
 
 impl LoginFlow {
@@ -66,6 +68,7 @@ impl LoginFlow {
         match self {
             Self::Loopback => "loopback",
             Self::Device => "device",
+            Self::Switch => "switch",
         }
     }
 }

--- a/crates/redisctl-core/src/config/config.rs
+++ b/crates/redisctl-core/src/config/config.rs
@@ -662,6 +662,7 @@ impl Config {
         profile_name: &str,
         creds: &crate::auth::MintedCredentials,
         cloud_auth: Option<CloudAuthConfig>,
+        make_default: bool,
     ) -> Result<()> {
         let api_key =
             store.store_credential(&format!("{profile_name}-cloud-api-key"), &creds.api_key)?;
@@ -687,10 +688,14 @@ impl Config {
         if let Some(mut auth) = cloud_auth {
             // Remember the account this key is for, so a later switch can say which one the
             // profile is on without asking the server (which would report the user's default).
-            auth.account_id = creds.account_id.as_deref().and_then(|id| id.parse().ok());
+            auth.account_id = creds.account_id;
             self.cloud_auth.insert(profile_name.to_string(), auth);
         }
-        self.default_cloud = Some(profile_name.to_string());
+        // Only a login bootstraps a profile; re-pointing the default is not something a caller
+        // asked for when it merely changed which account an existing profile targets.
+        if make_default {
+            self.default_cloud = Some(profile_name.to_string());
+        }
         Ok(())
     }
 

--- a/crates/redisctl-core/src/config/config.rs
+++ b/crates/redisctl-core/src/config/config.rs
@@ -70,6 +70,14 @@ pub struct CloudAuthConfig {
     /// Public CAPI base recorded in the resulting cloud profile (`api_url`).
     #[serde(default = "default_prod_capi_url")]
     pub capi_url: String,
+    /// Which account the profile's key was last minted for.
+    ///
+    /// Recorded because it cannot be derived locally: an API key does not name its account, and
+    /// `setcurrent` is session-scoped server-side, so a fresh sign-in reports the user's default
+    /// account rather than the one this profile is on. Absent for profiles written before this
+    /// existed, or set up by hand.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<u64>,
 }
 
 fn default_prod_capi_url() -> String {
@@ -86,6 +94,7 @@ impl CloudAuthConfig {
             okta_client_id: "0oaw90hjzrLoATW0q5d7".to_string(),
             sm_api_url: "https://cloud.redis.io/api/v1".to_string(),
             capi_url: default_prod_capi_url(),
+            account_id: None,
         }
     }
 
@@ -675,7 +684,10 @@ impl Config {
             tags: Vec::new(),
         };
         self.profiles.insert(profile_name.to_string(), profile);
-        if let Some(auth) = cloud_auth {
+        if let Some(mut auth) = cloud_auth {
+            // Remember the account this key is for, so a later switch can say which one the
+            // profile is on without asking the server (which would report the user's default).
+            auth.account_id = creds.account_id.as_deref().and_then(|id| id.parse().ok());
             self.cloud_auth.insert(profile_name.to_string(), auth);
         }
         self.default_cloud = Some(profile_name.to_string());

--- a/crates/redisctl-core/tests/cloud_auth_config.rs
+++ b/crates/redisctl-core/tests/cloud_auth_config.rs
@@ -114,7 +114,7 @@ fn apply_cloud_login_writes_profile_default_and_endpoints() {
     };
 
     config
-        .apply_cloud_login(&store, "qa", &creds, Some(qa_cloud_auth()))
+        .apply_cloud_login(&store, "qa", &creds, Some(qa_cloud_auth()), true)
         .unwrap();
 
     // Default cloud profile is set.

--- a/crates/redisctl-core/tests/cloud_auth_config.rs
+++ b/crates/redisctl-core/tests/cloud_auth_config.rs
@@ -26,6 +26,7 @@ fn qa_cloud_auth() -> CloudAuthConfig {
         okta_client_id: "test-client-id".to_string(),
         sm_api_url: "https://sm.example.com/api/v1".to_string(),
         capi_url: "https://api.example.com/v1".to_string(),
+        account_id: None,
     }
 }
 
@@ -123,13 +124,18 @@ fn apply_cloud_login_writes_profile_default_and_endpoints() {
     assert_eq!(key, "ACCT-KEY");
     assert_eq!(secret, "USER-SECRET");
     assert_eq!(url, "https://api.example.com/v1");
-    // Login endpoints were recorded for re-login.
-    assert_eq!(config.resolve_cloud_auth("qa"), qa_cloud_auth());
+    // Login endpoints were recorded for re-login, along with the account the key is for — which
+    // cannot be derived later, since a key does not name its account.
+    let expected = CloudAuthConfig {
+        account_id: Some(112117),
+        ..qa_cloud_auth()
+    };
+    assert_eq!(config.resolve_cloud_auth("qa"), expected);
 
     // And it survives a save/load round-trip.
     let (_, loaded) = roundtrip(&config);
     assert_eq!(loaded.default_cloud.as_deref(), Some("qa"));
-    assert_eq!(loaded.resolve_cloud_auth("qa"), qa_cloud_auth());
+    assert_eq!(loaded.resolve_cloud_auth("qa"), expected);
 }
 
 /// Mirrors what `cloud auth logout` does at the config layer: it removes the profile (and its

--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -1685,6 +1685,15 @@ pub enum CloudAuthCommands {
         #[arg(long, value_name = "ID")]
         account: Option<u64>,
     },
+    /// Switch which Redis Cloud account this profile's key belongs to.
+    ///
+    /// Reuses the sign-in stored at login, so no browser is opened. With no ID, lists the
+    /// accounts you belong to and asks which one.
+    Switch {
+        /// Account id to switch to. Omit to choose from a list.
+        #[arg(value_name = "ID")]
+        account: Option<u64>,
+    },
     /// Report whether the profile is authenticated to Redis Cloud.
     Status {
         /// Block until a pending device-authorization login completes (or times out / is

--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -195,6 +195,9 @@ async fn switch(
         )));
     }
 
+    // Which account this profile is on today, as recorded at the last login/switch.
+    let on_account = auth_cfg.account_id;
+
     let store = CredentialStore::new();
     let refresh_token = store
         .get_credential(&format!("keyring:{profile_name}-okta-refresh"), None)
@@ -224,7 +227,12 @@ async fn switch(
             flow: LoginFlow::Loopback,
             account: match account {
                 Some(id) => AccountChoice::Id(id),
-                None => AccountChoice::Prompt(Box::new(prompt_account)),
+                // `on_account` comes from the profile, not the session: `setcurrent` is
+                // session-scoped server-side, so a fresh sign-in reports the user's default
+                // account and would mark the wrong row as current.
+                None => AccountChoice::Prompt(Box::new(move |accounts, _session_account| {
+                    prompt_account(accounts, on_account)
+                })),
             },
             // A refresh token only exists on the keyring path, so this is never plaintext.
             allow_plaintext: false,
@@ -271,6 +279,9 @@ fn prompt_account(accounts: &[LoginAccount], current: Option<u64>) -> Result<u64
             ""
         };
         eprintln!("  {}) {}{}", i + 1, a.label(), marker);
+    }
+    if current.is_none() {
+        eprintln!("  (which one this profile is on is unknown — sign in again to record it)");
     }
     eprint!("Switch to which? [1-{}]: ", accounts.len());
     use std::io::Write;

--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -19,7 +19,9 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use redisctl_core::AuthError;
-use redisctl_core::auth::{CloudAuthenticator, LoginAccount, LoginFlow, MintedCredentials};
+use redisctl_core::auth::{
+    AccountChoice, CloudAuthenticator, LoginAccount, LoginFlow, MintedCredentials,
+};
 use redisctl_core::{CloudAuthConfig, Config, CredentialStore, DeviceAuthorization, TokenSet};
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -65,6 +67,7 @@ pub async fn handle_auth_command(
             )
             .await
         }
+        CloudAuthCommands::Switch { account } => switch(conn_mgr, profile, *account, output).await,
         CloudAuthCommands::Status { wait, timeout } => {
             status(conn_mgr, profile, *wait, *timeout, output).await
         }
@@ -155,12 +158,157 @@ async fn login(
             } else {
                 LoginFlow::Loopback
             },
-            account,
+            account: match account {
+                Some(id) => AccountChoice::Id(id),
+                None => AccountChoice::Current,
+            },
             allow_plaintext,
         },
     )
     .await?;
     emit_signed_in(&creds, &profile_name, output)
+}
+
+/// Switch the profile's key to another account, reusing the sign-in stored at login.
+///
+/// An API key is scoped to one account, so this mints a key for the chosen account and replaces
+/// the profile's current one. The refresh token saved at login stands in for the browser; minting
+/// itself cannot be avoided, because the key is per-account.
+async fn switch(
+    conn_mgr: &ConnectionManager,
+    profile: Option<&str>,
+    account: Option<u64>,
+    output: OutputFormat,
+) -> CliResult<()> {
+    let (profile_name, authenticator, auth_cfg) = prepare(conn_mgr, profile)?;
+
+    // Choosing from a list needs somewhere to ask. Checked before signing in, so a
+    // non-interactive caller fails immediately rather than after doing the work.
+    let interactive = std::io::stderr().is_terminal() && std::io::stdin().is_terminal();
+    if account.is_none() && !interactive {
+        return Err(RedisCtlError::Structured(Box::new(
+            StructuredError::account_required(
+                "there is no terminal to choose an account on; pass the id instead \
+                 (`redisctl cloud auth switch <ID>`). A completed login reports the accounts you \
+                 belong to in its `accounts` field.",
+            ),
+        )));
+    }
+
+    let store = CredentialStore::new();
+    let refresh_token = store
+        .get_credential(&format!("keyring:{profile_name}-okta-refresh"), None)
+        .map_err(|_| {
+            RedisCtlError::Structured(Box::new(StructuredError::not_authenticated(format!(
+                "there is no stored sign-in for profile '{profile_name}' to switch with \
+                 (credentials saved with --allow-plaintext cannot be reused this way). Run \
+                 `redisctl cloud auth login --account <ID>` instead."
+            ))))
+        })?;
+
+    // The browser is only ever needed to obtain a refresh token in the first place.
+    let tokens = authenticator.refresh(&refresh_token).await.map_err(|_| {
+        RedisCtlError::Structured(Box::new(StructuredError::not_authenticated(format!(
+            "the stored sign-in for profile '{profile_name}' is no longer usable — refresh tokens \
+             expire and are rotated. Run `redisctl cloud auth login --account <ID>`."
+        ))))
+    })?;
+
+    let creds = complete_and_persist(
+        conn_mgr,
+        &profile_name,
+        &authenticator,
+        &tokens,
+        auth_cfg,
+        LoginRun {
+            flow: LoginFlow::Loopback,
+            account: match account {
+                Some(id) => AccountChoice::Id(id),
+                None => AccountChoice::Prompt(Box::new(prompt_account)),
+            },
+            // A refresh token only exists on the keyring path, so this is never plaintext.
+            allow_plaintext: false,
+        },
+    )
+    .await?;
+
+    let which = creds
+        .account_id
+        .as_deref()
+        .and_then(|id| id.parse::<u64>().ok())
+        .and_then(|id| creds.accounts.iter().find(|a| a.id == id))
+        .map(LoginAccount::label)
+        .unwrap_or_else(|| "the selected account".to_string());
+    eprintln!("\n\u{2713} Profile '{profile_name}' now uses {which}.");
+    print_formatted_output(
+        serde_json::json!({
+            "status": "ok",
+            "profile": profile_name,
+            "account_id": creds.account_id,
+            "account_name": creds.account_name,
+            "email": creds.email,
+        }),
+        output,
+    )
+}
+
+/// Ask which account to switch to, listing them with the current one marked.
+///
+/// Only reached on a terminal (the caller checks). An error abandons the switch before anything
+/// is minted or written.
+fn prompt_account(accounts: &[LoginAccount], current: Option<u64>) -> Result<u64, AuthError> {
+    if accounts.len() < 2 {
+        return Err(AuthError::Protocol(
+            "this login belongs to a single Redis Cloud account, so there is nothing to switch to"
+                .into(),
+        ));
+    }
+    eprintln!("\nAccounts you belong to:");
+    for (i, a) in accounts.iter().enumerate() {
+        let marker = if Some(a.id) == current {
+            "  (current)"
+        } else {
+            ""
+        };
+        eprintln!("  {}) {}{}", i + 1, a.label(), marker);
+    }
+    eprint!("Switch to which? [1-{}]: ", accounts.len());
+    use std::io::Write;
+    let _ = std::io::stderr().flush();
+
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .map_err(|e| AuthError::Protocol(format!("could not read a choice: {e}")))?;
+    resolve_account_choice(accounts, &line)
+}
+
+/// Map what the user typed onto an account id. Split out from the prompt so the selection rules
+/// are testable without a terminal.
+fn resolve_account_choice(accounts: &[LoginAccount], input: &str) -> Result<u64, AuthError> {
+    let typed = input.trim();
+    // An id is accepted as well as a list position: it is what the listing shows, so typing one
+    // back is the obvious thing to try.
+    if let Ok(id) = typed.parse::<u64>()
+        && let Some(a) = accounts.iter().find(|a| a.id == id)
+    {
+        return Ok(a.id);
+    }
+    let choice: usize = typed.parse().map_err(|_| {
+        AuthError::Protocol(format!(
+            "'{typed}' is not one of 1-{} or an account id",
+            accounts.len()
+        ))
+    })?;
+    accounts
+        .get(choice.wrapping_sub(1))
+        .map(|a| a.id)
+        .ok_or_else(|| {
+            AuthError::Protocol(format!(
+                "{choice} is not one of 1-{} or an account id",
+                accounts.len()
+            ))
+        })
 }
 
 /// Sign-in instructions for the device flow. `verification_uri_complete` pre-fills the code on the
@@ -287,8 +435,8 @@ fn prompt_mfa_code(factors: &[String], attempt: u32) -> Result<Option<String>, A
 /// positional arguments.
 struct LoginRun {
     flow: LoginFlow,
-    /// `--account`: mint for this account rather than the session's current one.
-    account: Option<u64>,
+    /// Which account to mint for: the session's current one, an explicit id, or a picker.
+    account: AccountChoice,
     allow_plaintext: bool,
 }
 
@@ -429,7 +577,10 @@ async fn status(
                         flow: LoginFlow::Device,
                         // Whatever the initiating `login --device --account` asked for; `None`
                         // (no flag) keeps the session's current account.
-                        account: pending.account,
+                        account: match pending.account {
+                            Some(id) => AccountChoice::Id(id),
+                            None => AccountChoice::Current,
+                        },
                         allow_plaintext: pending.allow_plaintext,
                     },
                 )
@@ -635,4 +786,60 @@ fn open_browser(url: &str) -> std::io::Result<()> {
         .stderr(Stdio::null())
         .spawn()
         .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accounts() -> Vec<LoginAccount> {
+        vec![
+            LoginAccount {
+                id: 316941,
+                name: Some("Acme".to_string()),
+            },
+            LoginAccount {
+                id: 481022,
+                name: None,
+            },
+        ]
+    }
+
+    /// The listing shows both a position and an id, so both have to be accepted — and anything
+    /// else has to be refused rather than resolving to some account by accident.
+    #[test]
+    fn account_choice_accepts_a_position_or_an_id() {
+        assert_eq!(resolve_account_choice(&accounts(), "1").unwrap(), 316941);
+        assert_eq!(resolve_account_choice(&accounts(), " 2\n").unwrap(), 481022);
+        // An id the user copied out of the list.
+        assert_eq!(
+            resolve_account_choice(&accounts(), "481022").unwrap(),
+            481022
+        );
+    }
+
+    #[test]
+    fn account_choice_refuses_anything_else() {
+        for input in ["", "0", "3", "999999", "abc", "1.5", "-1"] {
+            assert!(
+                resolve_account_choice(&accounts(), input).is_err(),
+                "{input:?} should not resolve to an account"
+            );
+        }
+    }
+
+    /// A single-account user has nothing to switch to; saying so beats offering a list of one.
+    #[test]
+    fn prompt_refuses_when_there_is_only_one_account() {
+        let one = vec![LoginAccount {
+            id: 316941,
+            name: Some("Acme".to_string()),
+        }];
+        // Does not read stdin: it returns before prompting.
+        let err = prompt_account(&one, Some(316941)).unwrap_err();
+        assert!(
+            matches!(err, AuthError::Protocol(ref m) if m.contains("single Redis Cloud account")),
+            "got {err:?}"
+        );
+    }
 }

--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -1,4 +1,4 @@
-//! `redisctl cloud auth login | status | logout`
+//! `redisctl cloud auth login | switch | status | logout`
 //!
 //! `login` is a credential bootstrapper: it runs an OIDC flow, exchanges the tokens with the
 //! SM API to mint a CAPI key, and writes a normal cloud profile. Afterward every existing
@@ -37,6 +37,9 @@ const SCOPES: [&str; 4] = ["openid", "profile", "email", "offline_access"];
 /// Above this many `redisctl-*` CAPI keys on an account, `login` nudges the user to revoke
 /// unused ones (a normal user has 1–3; more suggests login/logout cycles without cleanup).
 const STALE_KEY_WARN_THRESHOLD: usize = 3;
+
+/// How many times `cloud auth switch` re-asks which account before giving up.
+const ACCOUNT_PROMPT_ATTEMPTS: u32 = 3;
 
 /// Wrap an OIDC/SM `AuthError` into the structured exit contract (stable code + exit code).
 fn auth_err(e: redisctl_core::AuthError) -> RedisCtlError {
@@ -163,6 +166,7 @@ async fn login(
                 None => AccountChoice::Current,
             },
             allow_plaintext,
+            make_default: true,
         },
     )
     .await?;
@@ -182,21 +186,39 @@ async fn switch(
 ) -> CliResult<()> {
     let (profile_name, authenticator, auth_cfg) = prepare(conn_mgr, profile)?;
 
+    // Which account this profile is on today, as recorded at the last login/switch.
+    let on_account = auth_cfg.account_id;
+
+    // Already there: minting another key for the same account would just add to the sprawl.
+    if let Some(want) = account
+        && on_account == Some(want)
+    {
+        eprintln!("\nProfile '{profile_name}' already uses account #{want}. Nothing to do.");
+        return print_formatted_output(
+            serde_json::json!({
+                "status": "ok",
+                "profile": profile_name,
+                // Numeric, like the mint path and like `accounts[].id`, so a caller can compare
+                // them without caring which path produced the output.
+                "account_id": want,
+                "changed": false,
+            }),
+            output,
+        );
+    }
+
     // Choosing from a list needs somewhere to ask. Checked before signing in, so a
     // non-interactive caller fails immediately rather than after doing the work.
     let interactive = std::io::stderr().is_terminal() && std::io::stdin().is_terminal();
     if account.is_none() && !interactive {
         return Err(RedisCtlError::Structured(Box::new(
-            StructuredError::account_required(
+            StructuredError::account_required(format!(
                 "there is no terminal to choose an account on; pass the id instead \
-                 (`redisctl cloud auth switch <ID>`). A completed login reports the accounts you \
-                 belong to in its `accounts` field.",
-            ),
+                 (`redisctl --profile {profile_name} cloud auth switch <ID>`). A completed login \
+                 reports the accounts you belong to in its `accounts` field."
+            )),
         )));
     }
-
-    // Which account this profile is on today, as recorded at the last login/switch.
-    let on_account = auth_cfg.account_id;
 
     let store = CredentialStore::new();
     let refresh_token = store
@@ -205,17 +227,28 @@ async fn switch(
             RedisCtlError::Structured(Box::new(StructuredError::not_authenticated(format!(
                 "there is no stored sign-in for profile '{profile_name}' to switch with \
                  (credentials saved with --allow-plaintext cannot be reused this way). Run \
-                 `redisctl cloud auth login --account <ID>` instead."
+                 `redisctl --profile {profile_name} cloud auth login --account <ID>` instead."
             ))))
         })?;
 
-    // The browser is only ever needed to obtain a refresh token in the first place.
-    let tokens = authenticator.refresh(&refresh_token).await.map_err(|_| {
-        RedisCtlError::Structured(Box::new(StructuredError::not_authenticated(format!(
-            "the stored sign-in for profile '{profile_name}' is no longer usable — refresh tokens \
-             expire and are rotated. Run `redisctl cloud auth login --account <ID>`."
-        ))))
-    })?;
+    // A refresh response that omits `refresh_token` leaves the stored one in place, which is
+    // correct: the identity provider only omits it when the existing token stays valid. With
+    // rotation on it always returns a new one, which replaces the stored value on persist.
+    //
+    // The browser is only ever needed to obtain a refresh token in the first place. Transport
+    // failures are relayed as-is: they are retryable, and calling them an expired sign-in would
+    // send the caller through a full browser login for a blip.
+    let tokens = authenticator
+        .refresh(&refresh_token)
+        .await
+        .map_err(|e| match e {
+            AuthError::Network(_) => auth_err(e),
+            _ => RedisCtlError::Structured(Box::new(StructuredError::not_authenticated(format!(
+                "the stored sign-in for profile '{profile_name}' is no longer usable — refresh \
+                 tokens expire and are rotated. Run `redisctl --profile {profile_name} cloud auth \
+                 login --account <ID>`."
+            )))),
+        })?;
 
     let creds = complete_and_persist(
         conn_mgr,
@@ -224,7 +257,8 @@ async fn switch(
         &tokens,
         auth_cfg,
         LoginRun {
-            flow: LoginFlow::Loopback,
+            // Not loopback: no browser is involved, and `utm_campaign` should say so.
+            flow: LoginFlow::Switch,
             account: match account {
                 Some(id) => AccountChoice::Id(id),
                 // `on_account` comes from the profile, not the session: `setcurrent` is
@@ -236,37 +270,59 @@ async fn switch(
             },
             // A refresh token only exists on the keyring path, so this is never plaintext.
             allow_plaintext: false,
+            // Changing an existing profile's account is not a reason to make it the default.
+            make_default: false,
         },
     )
     .await?;
 
-    let which = creds
-        .account_id
-        .as_deref()
-        .and_then(|id| id.parse::<u64>().ok())
-        .and_then(|id| creds.accounts.iter().find(|a| a.id == id))
-        .map(LoginAccount::label)
-        .unwrap_or_else(|| "the selected account".to_string());
-    eprintln!("\n\u{2713} Profile '{profile_name}' now uses {which}.");
+    // Any device authorization still awaiting approval for this profile is now stale: completing
+    // it later would overwrite the key we just minted with one for the account it recorded.
+    clear_pending(conn_mgr, &profile_name);
+
+    eprintln!(
+        "\n\u{2713} Profile '{profile_name}' now uses {}.",
+        creds.account_label()
+    );
+    warn_on_key_sprawl(&creds);
     print_formatted_output(
         serde_json::json!({
             "status": "ok",
             "profile": profile_name,
             "account_id": creds.account_id,
             "account_name": creds.account_name,
+            "accounts": creds.accounts.iter().map(|a| serde_json::json!({
+                "id": a.id,
+                "name": a.name,
+            })).collect::<Vec<_>>(),
             "email": creds.email,
+            "redisctl_key_count": creds.redisctl_key_count,
+            "changed": true,
         }),
         output,
     )
 }
 
+/// D5: every login *and* every switch mints a new `redisctl-*` CAPI key. Warn (don't delete)
+/// when they pile up — switching makes that happen faster than logging in does.
+fn warn_on_key_sprawl(creds: &MintedCredentials) {
+    let key_count = creds.redisctl_key_count;
+    if key_count > STALE_KEY_WARN_THRESHOLD {
+        eprintln!(
+            "  note: this account now has {key_count} redisctl-* API keys. Revoke unused ones \
+             in the Redis Cloud console (Access Management > API Keys)."
+        );
+    }
+}
+
 /// Ask which account to switch to, listing them with the current one marked.
 ///
-/// Only reached on a terminal (the caller checks). An error abandons the switch before anything
-/// is minted or written.
+/// Only reached on a terminal (the caller checks). Re-asks on a bad answer rather than aborting:
+/// giving up here would unwind the whole command, and re-running means another sign-in — and on an
+/// MFA account, another code. Returning an error abandons the switch before anything is minted.
 fn prompt_account(accounts: &[LoginAccount], current: Option<u64>) -> Result<u64, AuthError> {
     if accounts.len() < 2 {
-        return Err(AuthError::Protocol(
+        return Err(AuthError::AccountRequired(
             "this login belongs to a single Redis Cloud account, so there is nothing to switch to"
                 .into(),
         ));
@@ -283,43 +339,54 @@ fn prompt_account(accounts: &[LoginAccount], current: Option<u64>) -> Result<u64
     if current.is_none() {
         eprintln!("  (which one this profile is on is unknown — sign in again to record it)");
     }
-    eprint!("Switch to which? [1-{}]: ", accounts.len());
-    use std::io::Write;
-    let _ = std::io::stderr().flush();
 
-    let mut line = String::new();
-    std::io::stdin()
-        .read_line(&mut line)
-        .map_err(|e| AuthError::Protocol(format!("could not read a choice: {e}")))?;
-    resolve_account_choice(accounts, &line)
+    for attempt in 1..=ACCOUNT_PROMPT_ATTEMPTS {
+        eprint!("Switch to which? [1-{}]: ", accounts.len());
+        use std::io::Write;
+        let _ = std::io::stderr().flush();
+
+        let mut line = String::new();
+        let read = std::io::stdin()
+            .read_line(&mut line)
+            .map_err(|e| AuthError::Protocol(format!("could not read a choice: {e}")))?;
+        if read == 0 {
+            // EOF (Ctrl-D): the user is declining, not failing.
+            return Err(AuthError::AccountRequired(
+                "no account was chosen, so nothing was switched".into(),
+            ));
+        }
+        match resolve_account_choice(accounts, &line) {
+            Ok(id) => return Ok(id),
+            Err(e) if attempt < ACCOUNT_PROMPT_ATTEMPTS => eprintln!("  {e}"),
+            Err(e) => return Err(e),
+        }
+    }
+    unreachable!("loop returns on the final attempt")
 }
 
-/// Map what the user typed onto an account id. Split out from the prompt so the selection rules
-/// are testable without a terminal.
+/// Map what the user typed onto an account id.
+///
+/// A list position wins over an account id when the input could be either: the prompt asks for
+/// `[1-N]`, so that is what a bare small number means. Ids can be small in non-production
+/// environments, and resolving `2` to *account* 2 there would mint a key for the wrong account.
+/// Split out from the prompt so the rules are testable without a terminal.
 fn resolve_account_choice(accounts: &[LoginAccount], input: &str) -> Result<u64, AuthError> {
     let typed = input.trim();
-    // An id is accepted as well as a list position: it is what the listing shows, so typing one
-    // back is the obvious thing to try.
+    if let Ok(position) = typed.parse::<usize>()
+        && let Some(a) = accounts.get(position.wrapping_sub(1))
+    {
+        return Ok(a.id);
+    }
+    // Not a position — an id copied out of the listing is the other sensible thing to type.
     if let Ok(id) = typed.parse::<u64>()
         && let Some(a) = accounts.iter().find(|a| a.id == id)
     {
         return Ok(a.id);
     }
-    let choice: usize = typed.parse().map_err(|_| {
-        AuthError::Protocol(format!(
-            "'{typed}' is not one of 1-{} or an account id",
-            accounts.len()
-        ))
-    })?;
-    accounts
-        .get(choice.wrapping_sub(1))
-        .map(|a| a.id)
-        .ok_or_else(|| {
-            AuthError::Protocol(format!(
-                "{choice} is not one of 1-{} or an account id",
-                accounts.len()
-            ))
-        })
+    Err(AuthError::AccountRequired(format!(
+        "'{typed}' is not one of 1-{} or an account id from the list",
+        accounts.len()
+    )))
 }
 
 /// Sign-in instructions for the device flow. `verification_uri_complete` pre-fills the code on the
@@ -449,6 +516,9 @@ struct LoginRun {
     /// Which account to mint for: the session's current one, an explicit id, or a picker.
     account: AccountChoice,
     allow_plaintext: bool,
+    /// Whether to make this the default cloud profile. True when logging in (it bootstraps the
+    /// profile), false when only changing which account an existing profile targets.
+    make_default: bool,
 }
 
 /// Run the SM exchange, persist the profile + secrets, and return the minted credentials.
@@ -480,7 +550,13 @@ async fn complete_and_persist(
     // On the keyring path, a store failure means the OS secret service is unavailable (D4):
     // surface a distinct `keyring_unavailable` (exit 2) pointing at `--allow-plaintext`.
     config
-        .apply_cloud_login(&store, profile_name, &creds, Some(auth_cfg))
+        .apply_cloud_login(
+            &store,
+            profile_name,
+            &creds,
+            Some(auth_cfg),
+            run.make_default,
+        )
         .map_err(|e| {
             if run.allow_plaintext {
                 RedisCtlError::from(e)
@@ -536,14 +612,8 @@ fn emit_signed_in(
             "  To use another: redisctl --profile {profile_name} cloud auth login --account <id>"
         );
     }
-    // D5: each login mints a new redisctl-* CAPI key. Warn (don't delete) when they pile up.
+    warn_on_key_sprawl(creds);
     let key_count = creds.redisctl_key_count;
-    if key_count > STALE_KEY_WARN_THRESHOLD {
-        eprintln!(
-            "  note: this account now has {key_count} redisctl-* API keys. Revoke unused ones \
-             in the Redis Cloud console (Access Management > API Keys)."
-        );
-    }
     print_formatted_output(
         serde_json::json!({
             "status": "ok",
@@ -593,6 +663,7 @@ async fn status(
                             None => AccountChoice::Current,
                         },
                         allow_plaintext: pending.allow_plaintext,
+                        make_default: true,
                     },
                 )
                 .await?;
@@ -829,6 +900,39 @@ mod tests {
         );
     }
 
+    /// Small account ids exist outside production, so an input that is both a valid position and a
+    /// valid id must mean the position — that is what the prompt asks for. Resolving it to the id
+    /// would mint a key for a different account than the one the user pointed at.
+    #[test]
+    fn account_choice_prefers_a_position_over_an_id() {
+        let low = vec![
+            LoginAccount {
+                id: 2,
+                name: Some("Two".to_string()),
+            },
+            LoginAccount {
+                id: 5,
+                name: Some("Five".to_string()),
+            },
+        ];
+        // Row 2 is account #5, and "2" is also account #2's id: the row wins.
+        assert_eq!(resolve_account_choice(&low, "2").unwrap(), 5);
+        assert_eq!(resolve_account_choice(&low, "1").unwrap(), 2);
+        // An id that is not also a position still resolves.
+        assert_eq!(resolve_account_choice(&low, "5").unwrap(), 5);
+    }
+
+    /// Choice problems are the caller's to fix (exit 2), not backend failures (exit 1).
+    #[test]
+    fn account_choice_errors_are_preconditions() {
+        let err = resolve_account_choice(&accounts(), "nope").unwrap_err();
+        assert!(matches!(err, AuthError::AccountRequired(_)), "got {err:?}");
+        assert_eq!(
+            crate::structured_error::StructuredError::from(err).code,
+            "account_required"
+        );
+    }
+
     #[test]
     fn account_choice_refuses_anything_else() {
         for input in ["", "0", "3", "999999", "abc", "1.5", "-1"] {
@@ -849,7 +953,7 @@ mod tests {
         // Does not read stdin: it returns before prompting.
         let err = prompt_account(&one, Some(316941)).unwrap_err();
         assert!(
-            matches!(err, AuthError::Protocol(ref m) if m.contains("single Redis Cloud account")),
+            matches!(err, AuthError::AccountRequired(ref m) if m.contains("single Redis Cloud account")),
             "got {err:?}"
         );
     }

--- a/crates/redisctl/src/structured_error.rs
+++ b/crates/redisctl/src/structured_error.rs
@@ -192,6 +192,8 @@ impl From<AuthError> for StructuredError {
             // would leave the agent-facing message stale whenever the attribute is edited.
             AuthError::NotAccountOwner { .. } => Self::insufficient_permission(err.to_string()),
             AuthError::CapiDisabled => Self::capi_disabled(err.to_string()),
+            // A choice the caller has to make or correct, not a backend failure.
+            AuthError::AccountRequired(_) => Self::account_required(err.to_string()),
             // --account named an account the user is not in; the message lists the real ones.
             AuthError::UnknownAccount { .. } => Self::unknown_account(err.to_string()),
             AuthError::MigrationRequired => Self::migration_required(),

--- a/crates/redisctl/src/structured_error.rs
+++ b/crates/redisctl/src/structured_error.rs
@@ -79,6 +79,9 @@ impl StructuredError {
     pub fn insufficient_permission(message: impl Into<String>) -> Self {
         Self::new("insufficient_permission", 2, false, message)
     }
+    pub fn account_required(message: impl Into<String>) -> Self {
+        Self::new("account_required", 2, false, message)
+    }
     pub fn capi_disabled(message: impl Into<String>) -> Self {
         Self::new("capi_disabled", 2, false, message)
     }
@@ -218,6 +221,7 @@ mod tests {
             StructuredError::keyring_unavailable("x"),
             StructuredError::insufficient_permission("x"),
             StructuredError::capi_disabled("x"),
+            StructuredError::account_required("x"),
             StructuredError::unknown_account("x"),
             StructuredError::migration_required(),
             StructuredError::mfa_required(),

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -164,6 +164,15 @@ trip to the console. `account_id` and `accounts[].id` are both numbers, so they 
 redisctl cloud auth login -o json | jq -e '.account_id == 316941'
 ```
 
+### Password accounts need linking once
+
+Redis Cloud accounts that sign in with an email and password cannot be used by the CLI directly —
+the sign-in happens at the identity provider, which never held that password. Sign in to the
+[Redis Cloud console](https://app.redislabs.com) once with **Google or GitHub using the same email
+address** and accept the prompt to link the account; afterwards `cloud auth login` works normally.
+
+Until that's done, login exits `2` with `migration_required`.
+
 ## Switch Accounts
 
 ```bash
@@ -208,15 +217,6 @@ Two cases where a full `login` is needed instead:
 Without a terminal to prompt on, the account id is required — otherwise `switch` exits `2` with
 `account_required` rather than blocking. Accounts with MFA still prompt for a code, since that
 challenge happens on sign-in.
-
-### Password accounts need linking once
-
-Redis Cloud accounts that sign in with an email and password cannot be used by the CLI directly —
-the sign-in happens at the identity provider, which never held that password. Sign in to the
-[Redis Cloud console](https://app.redislabs.com) once with **Google or GitHub using the same email
-address** and accept the prompt to link the account; afterwards `cloud auth login` works normally.
-
-Until that's done, login exits `2` with `migration_required`.
 
 ## Status
 

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -188,6 +188,10 @@ Either a list position or an account id is accepted. Pass the id to skip the pro
 redisctl cloud auth switch 481022
 ```
 
+The account marked `(current)` is the one **this profile** is on, recorded when the key was minted.
+It is not read back from the server: switching is scoped to the sign-in session, so Redis Cloud
+still reports your usual default account and the console is unaffected by a CLI switch.
+
 !!! note "Switching replaces the profile's key"
     An API key is scoped to one account, so switching mints a key for the account you pick and
     replaces the profile's current one — the previous account is no longer usable through this

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -164,6 +164,47 @@ trip to the console. `account_id` and `accounts[].id` are both numbers, so they 
 redisctl cloud auth login -o json | jq -e '.account_id == 316941'
 ```
 
+## Switch Accounts
+
+```bash
+redisctl cloud auth switch
+```
+
+Changes which account the profile's key is for, **without opening a browser** — the sign-in stored
+at login is reused. With no argument it lists your accounts and asks:
+
+```
+Accounts you belong to:
+  1) Acme (#316941)  (current)
+  2) Contoso (#481022)
+Switch to which? [1-2]: 2
+
+✓ Profile 'cloud' now uses Contoso (#481022).
+```
+
+Either a list position or an account id is accepted. Pass the id to skip the prompt:
+
+```bash
+redisctl cloud auth switch 481022
+```
+
+!!! note "Switching replaces the profile's key"
+    An API key is scoped to one account, so switching mints a key for the account you pick and
+    replaces the profile's current one — the previous account is no longer usable through this
+    profile until you switch back. To use several accounts at once, keep one profile per account
+    and log in to each ([above](#which-account-the-key-belongs-to)).
+
+Two cases where a full `login` is needed instead:
+
+- **Credentials stored with `--allow-plaintext`.** Reusing a sign-in needs the refresh token, which
+  is only kept in the OS keyring, so there is nothing to reuse. Exits `2` with `not_authenticated`.
+- **The stored sign-in has expired.** Refresh tokens are rotated and eventually expire. Same code,
+  and the message says so.
+
+Without a terminal to prompt on, the account id is required — otherwise `switch` exits `2` with
+`account_required` rather than blocking. Accounts with MFA still prompt for a code, since that
+challenge happens on sign-in.
+
 ### Password accounts need linking once
 
 Redis Cloud accounts that sign in with an email and password cannot be used by the CLI directly —

--- a/docs/docs/reference/agent-error-codes.md
+++ b/docs/docs/reference/agent-error-codes.md
@@ -41,6 +41,7 @@ keeps today's `0` / `1` exit behavior.
 | `migration_required` | 2 | no | The account signs in with a password and must be linked to Google/GitHub once in the Redis Cloud console. |
 | `insufficient_permission` | 2 | no | Your role on the account does not permit programmatic access. The message names the role that does — in practice the account owner. |
 | `capi_disabled` | 2 | no | API access is switched off for the whole account, so no role can mint a key. Only Redis can re-enable it. |
+| `account_required` | 2 | no | `cloud auth switch` needs an account id when there is no terminal to choose on. Pass the id. |
 | `unknown_account` | 2 | no | `--account` named an account you don't belong to. The message lists the accounts you do have. |
 | `mfa_required` | 2 | no | The account requires multi-factor authentication and there was no terminal to prompt on. Re-run `cloud auth login` interactively. |
 | `mfa_invalid_code` | 2 | no | The multi-factor code was rejected. Start login again. |

--- a/docs/docs/reference/agent-error-codes.md
+++ b/docs/docs/reference/agent-error-codes.md
@@ -1,6 +1,6 @@
 # Agent Error Codes
 
-The agent-native surface — `cloud auth login | status | logout` and `cloud workflow
+The agent-native surface — `cloud auth login | switch | status | logout` and `cloud workflow
 quick-database | database-credentials` — reports failures in a **machine-branchable** form so
 scripts and agents can branch on a stable code instead of parsing prose.
 


### PR DESCRIPTION
Targeting a different Redis Cloud account meant a full `cloud auth login --account <id>`: a browser
round-trip, and an account id copied from somewhere else first. Neither is actually required.

## No browser

Login already stores an Okta refresh token — it was written on every login and read by nothing, so
the one thing it exists for was never wired up. `switch` trades it for fresh tokens and signs in to
Redis Cloud silently.

## No copying ids

The account list is already fetched during the exchange. With no argument, `switch` lists the
accounts and asks:

```
$ redisctl cloud auth switch

Accounts you belong to:
  1) Acme (#316941)  (current)
  2) Contoso (#481022)
Switch to which? [1-2]: 2

✓ Profile 'cloud' now uses Contoso (#481022).
```

Either a list position or an account id is accepted; a position wins when the input could be
either, since that is what the prompt asks for. Pass the id to skip the prompt:

```bash
redisctl cloud auth switch 481022
```

A bad answer re-asks rather than unwinding the command — giving up would mean another sign-in, and
on an MFA account another code.

## What `(current)` means, and what cannot be avoided

The marked account is the one **this profile** is on, recorded when its key was minted. It is not
read back from the server: `setCurrentAccount` only writes session attributes, so a fresh sign-in
reports the user's default account. That also means a CLI switch does not change what the web
console shows. An API key does not name its account either, so the account is now recorded on the
profile's `cloud_auth` entry — profiles predating this say the value is unknown rather than
marking the wrong row.

Minting cannot be avoided: a key is scoped to one account, so acquiring the target account's key is
what switching *is*. It replaces the profile's key, so one profile still reaches one account at a
time; several at once remains one profile per account. Because every switch mints, the existing
stale-key warning now fires on this path too and the output reports `redisctl_key_count`.

## Structure

A picker cannot run before the exchange: listing accounts needs a session, and acting on the answer
afterwards would mean a second sign-in and a second MFA challenge. So the account decision became
`AccountChoice` — `Current`, `Id`, or `Prompt`, the last a callback invoked mid-exchange on the one
session. `--account` maps to `Id`. Accounts are sorted by id at the projection boundary, so the
picker's numbering, the printed listing and the JSON `accounts` array agree between runs.

`LoginFlow` gained `Switch`, since reporting `utm_campaign=loopback` for a flow that opens no
browser would count these as interactive sign-ins.

## Declines rather than surprises

- No terminal and no id: `account_required` (exit 2), checked before signing in so a
  non-interactive caller fails immediately rather than after the work.
- Credentials stored with `--allow-plaintext`: the refresh token is keyring-only, so there is
  nothing to reuse. `not_authenticated`, naming the command to run.
- An expired or rotated-away refresh token: same code, saying so. Transport failures are relayed as
  the retryable class instead, so a blip does not send a caller through a browser login.
- Switching to the account the profile is already on: reports `changed: false` and mints nothing.
- Persisting deliberately does **not** claim the default cloud profile — only a login bootstraps
  one, and repointing the default is not implied by changing an existing profile's account.

## Testing

Verified end to end against a QA user belonging to two accounts: switching both ways with no
browser, the interactive picker, and account-scoped commands then reading the switched-to account.
The single-account refusal, the choice-parsing rules (including the position-over-id precedence),
the picker callback's ordering and its answer driving the mint, and the declined-picker path are
covered by tests.

Docs: a `Switch Accounts` section covering the command, what `(current)` means, the two cases that
need a full login, and the new error code in the agent error inventory.