### PR TITLE
fix(mcp): select a rustls crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,6 +2957,7 @@ dependencies = [
  "redis-cloud",
  "redis-enterprise",
  "redisctl-core",
+ "rustls",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ async-trait = "0.1"
 
 # HTTP and APIs
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "multipart"] }
+rustls = { version = "0.23.32", default-features = false, features = ["aws_lc_rs", "std"] }
 url = "2.5"
 base64 = "0.22"
 urlencoding = "2.1"

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -75,6 +75,7 @@ clap = { workspace = true }
 
 # HTTP middleware
 tower = { workspace = true }
+rustls = { workspace = true }
 
 [features]
 default = ["http", "cloud", "enterprise", "database", "secure-storage"]

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -151,6 +151,11 @@ fn resolve_policy_with_source_flags(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Mixed rustls features need a provider; preserve a host choice and ignore install races.
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+
     let args = Args::parse();
 
     // Resolve policy configuration (includes audit config)

--- a/crates/redisctl-mcp/tests/tls_crypto_provider.rs
+++ b/crates/redisctl-mcp/tests/tls_crypto_provider.rs
@@ -1,0 +1,162 @@
+use std::io::{Read, Write};
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+const PROCESS_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn wait_with_output_timeout(mut child: Child, timeout: Duration) -> (Output, bool) {
+    let mut child_stdout = child.stdout.take().expect("stdout should be piped");
+    let stdout_reader = thread::spawn(move || {
+        let mut stdout = Vec::new();
+        child_stdout
+            .read_to_end(&mut stdout)
+            .expect("stdout should be readable");
+        stdout
+    });
+
+    let mut child_stderr = child.stderr.take().expect("stderr should be piped");
+    let stderr_reader = thread::spawn(move || {
+        let mut stderr = Vec::new();
+        child_stderr
+            .read_to_end(&mut stderr)
+            .expect("stderr should be readable");
+        stderr
+    });
+
+    let deadline = Instant::now() + timeout;
+    let mut timed_out = false;
+    let status = loop {
+        match child.try_wait().expect("process status should be readable") {
+            Some(status) => break status,
+            None if Instant::now() < deadline => thread::sleep(Duration::from_millis(10)),
+            None => {
+                if let Err(kill_error) = child.kill() {
+                    match child.try_wait().expect("process status should be readable") {
+                        Some(status) => break status,
+                        None => panic!("failed to kill timed-out redisctl-mcp: {kill_error}"),
+                    }
+                }
+                timed_out = true;
+                break child.wait().expect("killed process should be waitable");
+            }
+        }
+    };
+
+    let stdout = stdout_reader
+        .join()
+        .expect("stdout reader should not panic");
+    let stderr = stderr_reader
+        .join()
+        .expect("stderr reader should not panic");
+
+    (
+        Output {
+            status,
+            stdout,
+            stderr,
+        },
+        timed_out,
+    )
+}
+
+#[test]
+fn tls_database_tool_returns_an_error_without_panicking() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_redisctl-mcp"))
+        .args([
+            "--database-url",
+            "rediss://default:test@localhost:1/0",
+            "--tools",
+            "database:keys",
+            "--log-level",
+            "error",
+        ])
+        .env_remove("REDISCTL_MCP_POLICY")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("redisctl-mcp should start");
+
+    let requests = [
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"tls-regression-test","version":"1.0.0"}}}"#,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+        r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"redis_type","arguments":{"key":"test"}}}"#,
+    ]
+    .join("\n");
+
+    child
+        .stdin
+        .take()
+        .expect("stdin should be piped")
+        .write_all(format!("{requests}\n").as_bytes())
+        .expect("MCP requests should be written");
+
+    let (output, timed_out) = wait_with_output_timeout(child, PROCESS_TIMEOUT);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    println!("stdout:\n{stdout}\nstderr:\n{stderr}");
+
+    assert!(
+        !timed_out,
+        "redisctl-mcp timed out after {PROCESS_TIMEOUT:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        output.status.success(),
+        "redisctl-mcp should report the connection error without crashing\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("CryptoProvider") && !stderr.contains("no process-level CryptoProvider"),
+        "redisctl-mcp should not panic while selecting a rustls crypto provider\nstderr:\n{stderr}"
+    );
+
+    let responses: Vec<Value> = stdout
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect();
+    let list_response = responses
+        .iter()
+        .find(|response| response.get("id") == Some(&Value::from(2)))
+        .expect("tools/list should return a response");
+    let tools = list_response
+        .pointer("/result/tools")
+        .and_then(Value::as_array)
+        .expect("tools/list should return a tools array");
+    assert!(
+        tools
+            .iter()
+            .any(|tool| tool.get("name") == Some(&Value::from("redis_type"))),
+        "database:keys should expose redis_type\nresponse:\n{list_response}"
+    );
+
+    let call_response = responses
+        .iter()
+        .find(|response| response.get("id") == Some(&Value::from(3)))
+        .expect("redis_type should return a response");
+    assert!(
+        call_response.get("error").is_none(),
+        "redis_type should reach the tool rather than return a JSON-RPC protocol error\nresponse:\n{call_response}"
+    );
+    assert_eq!(
+        call_response.pointer("/result/isError"),
+        Some(&Value::Bool(true)),
+        "redis_type should report the expected connection failure\nresponse:\n{call_response}"
+    );
+    let error_text = call_response
+        .pointer("/result/content")
+        .and_then(Value::as_array)
+        .expect("tool error should contain MCP content")
+        .iter()
+        .filter_map(|content| content.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .to_lowercase();
+    assert!(
+        error_text.contains("connection") || error_text.contains("connect"),
+        "redis_type should report an ordinary connection failure\nresponse:\n{call_response}"
+    );
+}


### PR DESCRIPTION
## Summary

- select the `aws-lc-rs` rustls `CryptoProvider` before the MCP server creates TLS clients
- preserve a provider already installed by an embedding host and tolerate the install race
- add a bounded subprocess regression test that initializes MCP, verifies `redis_type` is registered, and exercises a real `rediss://` tool call

## Why

The default `redisctl-mcp` feature graph enables two rustls providers: reqwest 0.13 brings `aws-lc-rs`, while the Redis client brings `ring`. Rustls 0.23 cannot choose between them automatically, so the first Redis TLS data-plane call panics with:

```text
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

The server initializes and lists tools successfully before that point, which makes the failure appear command-specific even though any Redis command over TLS can trigger it.

## Compatibility

This is a safety correction. It does not add, remove, or rename MCP tools, change their schemas, or alter CLI output/contracts. The catalog baseline is unchanged.

## Tests

- RED without the startup selection: the test initializes MCP and lists `redis_type`, then the TLS tool call reproduces the CryptoProvider panic
- GREEN with the fix: the same call returns a normal MCP `isError: true` connection failure and the process exits cleanly
- the subprocess has a 10-second cross-platform timeout, drains stdout/stderr concurrently, and is killed/reaped on timeout
- `cargo fmt --all -- --check`
- `cargo clippy -p redisctl-mcp --all-targets --all-features -- -D warnings`
- `cargo test -p redisctl-mcp --test tls_crypto_provider --all-features -- --nocapture`
- `cargo test -p redisctl-mcp --all-features catalog_contract::mcp_catalog_matches_1_0_baseline`

The repository workflows were created with `action_required` because this is a first-time fork contribution. A maintainer needs to approve them before the full workspace CI gate can run.