### PR TITLE
fix(core): make redisctl-core compile with its own default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Check redisctl-core with default features
+        run: cargo check -p redisctl-core
+
   # Unit tests for each package in parallel
   test-unit:
     name: Unit Tests - ${{ matrix.package }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,6 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 oauth2 = { version = "5", default-features = false, features = ["reqwest", "rustls-tls"] }
 url = "2.5"
 base64 = "0.22"
-sha2 = "0.10"
-getrandom = "0.3"
 urlencoding = "2.1"
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/crates/redisctl-core/src/config/credential.rs
+++ b/crates/redisctl-core/src/config/credential.rs
@@ -72,8 +72,15 @@ impl CredentialStore {
     /// Create a store that always uses plaintext (no keyring). Useful for tests and for the
     /// explicit `--allow-plaintext` opt-in when no keyring is available.
     pub fn plaintext() -> Self {
-        Self {
-            storage: CredentialStorage::Plaintext,
+        #[cfg(feature = "secure-storage")]
+        {
+            Self {
+                storage: CredentialStorage::Plaintext,
+            }
+        }
+        #[cfg(not(feature = "secure-storage"))]
+        {
+            Self {}
         }
     }
 


### PR DESCRIPTION
`cargo check -p redisctl-core` failed:

```
error[E0560]: struct `CredentialStore` has no field named `storage`
  --> crates/redisctl-core/src/config/credential.rs:76:13
```

`CredentialStore::plaintext()` assigned `storage`, which only exists under `secure-storage`, while
the constructor itself was not gated. The crate's default features are empty, so it did not build
on its own — but every workspace build passes, because the binary turns the feature on. That is the
build an embedder gets, and the crate now ships a 1.0 compatibility policy and an embedding API, so
it needs to work.

`plaintext()` now handles both configurations the way `new()` already did. It stays available
either way rather than being gated away, so the API does not change shape with features.

CI only ever built the workspace, so it could not catch this. Added a `cargo check -p redisctl-core`
step to the quick-checks job.

Also dropped `sha2` and `getrandom` from `[workspace.dependencies]`: both were added with this work
and neither is referenced by any crate. `Cargo.lock` is unaffected, since nothing pulled them in.

## Verification

| Check | Result |
|---|---|
| `cargo check -p redisctl-core` | exit 0 (was 101) |
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets --all-features` | 0 |
| `cargo test --workspace --all-features` | 23 suites / 1152 tests |