### PR TITLE
fix: stop losing the device code, the profile's other settings, and file privacy

### DIFF
--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -4,7 +4,7 @@
 //! Returns [`MintedCredentials`] for the caller to persist (see
 //! `config::Config::apply_cloud_login`). Persistence lives in the config layer so this stays
 //! free of file/keyring I/O and easy to test. The flow itself (device polling with progress,
-//! or loopback with a browser) is driven by the CLI using [`CloudAuthenticator::device_flow`]
+//! or loopback with a browser) is driven by the CLI using [`CloudAuthenticator::device`]
 //! / [`CloudAuthenticator::loopback`].
 
 use url::Url;

--- a/crates/redisctl-core/src/auth/device_flow.rs
+++ b/crates/redisctl-core/src/auth/device_flow.rs
@@ -11,8 +11,8 @@
 //! prints/persists the returned [`DeviceAuthorization`] (which is `serde`-serializable), and
 //! returns. A later `status --wait` — possibly a *different* process — rebuilds the client from
 //! the issuer + client id, deserializes the [`DeviceAuthorization`], and calls
-//! [`poll`](DeviceFlowClient::poll). Refreshing a token is flow-agnostic and lives in
-//! [`super::oidc::refresh`].
+//! [`poll`](DeviceFlowClient::poll). Refreshing a token is flow-agnostic and lives on
+//! [`CloudAuthenticator::refresh`](super::authenticator::CloudAuthenticator::refresh).
 
 use std::time::Duration;
 

--- a/crates/redisctl-core/src/config/config.rs
+++ b/crates/redisctl-core/src/config/config.rs
@@ -633,6 +633,21 @@ impl Config {
         Ok(())
     }
 
+    /// Save to `config_path` with owner-only permissions, for callers that just put a secret in it.
+    pub fn save_to_path_owner_only(&self, config_path: &Path) -> Result<()> {
+        if let Some(parent) = config_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| ConfigError::SaveError {
+                path: parent.display().to_string(),
+                source: e,
+            })?;
+        }
+        let content = toml::to_string_pretty(self)?;
+        write_owner_only(config_path, content.as_bytes()).map_err(|e| ConfigError::SaveError {
+            path: config_path.display().to_string(),
+            source: e,
+        })
+    }
+
     /// Set or update a profile
     pub fn set_profile(&mut self, name: String, profile: Profile) {
         self.profiles.insert(name, profile);
@@ -674,6 +689,7 @@ impl Config {
             // Reference is implicit (looked up by the well-known key on refresh); ignore it.
             let _ = store.store_credential(&format!("{profile_name}-okta-refresh"), refresh)?;
         }
+        let existing = self.profiles.get(profile_name);
         let profile = Profile {
             deployment_type: DeploymentType::Cloud,
             credentials: ProfileCredentials::Cloud {
@@ -681,8 +697,8 @@ impl Config {
                 api_secret,
                 api_url: creds.api_url.clone(),
             },
-            files_api_key: None,
-            tags: Vec::new(),
+            files_api_key: existing.and_then(|p| p.files_api_key.clone()),
+            tags: existing.map(|p| p.tags.clone()).unwrap_or_default(),
         };
         self.profiles.insert(profile_name.to_string(), profile);
         if let Some(mut auth) = cloud_auth {
@@ -786,6 +802,25 @@ impl Config {
 
 fn default_cloud_url() -> String {
     "https://api.redislabs.com/v1".to_string()
+}
+
+#[cfg(unix)]
+fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+    let mut f = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    f.write_all(bytes)?;
+    f.set_permissions(std::fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    fs::write(path, bytes)
 }
 
 #[cfg(test)]

--- a/crates/redisctl-core/tests/cloud_auth_config.rs
+++ b/crates/redisctl-core/tests/cloud_auth_config.rs
@@ -93,11 +93,8 @@ fn resolve_cloud_auth_falls_back_to_prod_defaults() {
     assert_eq!(resolved.sm_api_url, "https://cloud.redis.io/api/v1");
 }
 
-#[test]
-fn apply_cloud_login_writes_profile_default_and_endpoints() {
-    let mut config = Config::default();
-    let store = CredentialStore::plaintext(); // never touches the keyring
-    let creds = MintedCredentials {
+fn minted() -> MintedCredentials {
+    MintedCredentials {
         account_id: Some(112117),
         email: Some("u@e.com".to_string()),
         api_key: "ACCT-KEY".to_string(),
@@ -111,7 +108,14 @@ fn apply_cloud_login_writes_profile_default_and_endpoints() {
             id: 112117,
             name: None,
         }],
-    };
+    }
+}
+
+#[test]
+fn apply_cloud_login_writes_profile_default_and_endpoints() {
+    let mut config = Config::default();
+    let store = CredentialStore::plaintext();
+    let creds = minted();
 
     config
         .apply_cloud_login(&store, "qa", &creds, Some(qa_cloud_auth()), true)
@@ -161,4 +165,90 @@ fn logout_removes_profile_but_preserves_cloud_auth_endpoints() {
     let auth = loaded.resolve_cloud_auth("qa");
     assert!(auth.is_complete());
     assert_eq!(auth.okta_client_id, "test-client-id");
+}
+
+/// A login rewrites the profile, but must not discard settings it does not own.
+#[test]
+fn apply_cloud_login_preserves_files_api_key_and_tags() {
+    let mut config = Config::default();
+    config.set_profile(
+        "qa".to_string(),
+        Profile {
+            deployment_type: DeploymentType::Cloud,
+            credentials: ProfileCredentials::Cloud {
+                api_key: "OLD".to_string(),
+                api_secret: "OLD".to_string(),
+                api_url: "https://api.example.com/v1".to_string(),
+            },
+            files_api_key: Some("FILES-KEY".to_string()),
+            tags: vec!["team-a".to_string(), "prod".to_string()],
+        },
+    );
+
+    config
+        .apply_cloud_login(
+            &CredentialStore::plaintext(),
+            "qa",
+            &minted(),
+            Some(qa_cloud_auth()),
+            true,
+        )
+        .unwrap();
+
+    let profile = &config.profiles["qa"];
+    assert_eq!(profile.files_api_key.as_deref(), Some("FILES-KEY"));
+    assert_eq!(profile.tags, vec!["team-a", "prod"]);
+    let (key, _, _) = profile.cloud_credentials().unwrap();
+    assert_eq!(key, "ACCT-KEY", "the credentials themselves are replaced");
+}
+
+/// A first login has no profile to merge with, so the fields are simply absent.
+#[test]
+fn apply_cloud_login_on_a_fresh_profile_has_no_extras() {
+    let mut config = Config::default();
+    config
+        .apply_cloud_login(
+            &CredentialStore::plaintext(),
+            "qa",
+            &minted(),
+            Some(qa_cloud_auth()),
+            true,
+        )
+        .unwrap();
+    let profile = &config.profiles["qa"];
+    assert!(profile.files_api_key.is_none());
+    assert!(profile.tags.is_empty());
+}
+
+/// The plaintext path puts the CAPI secret in this file, so that save must not be readable by
+/// other users. The ordinary save is left as it is, to keep every other command's behaviour.
+#[cfg(unix)]
+#[test]
+fn owner_only_save_is_0600_and_tightens_an_existing_file() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("nested").join("config.toml");
+
+    let mut config = Config::default();
+    config
+        .apply_cloud_login(
+            &CredentialStore::plaintext(),
+            "qa",
+            &minted(),
+            Some(qa_cloud_auth()),
+            true,
+        )
+        .unwrap();
+    config.save_to_path_owner_only(&path).unwrap();
+
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "got {mode:o}");
+
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+    config.save_to_path_owner_only(&path).unwrap();
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "an existing loose file is tightened, got {mode:o}"
+    );
 }

--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -544,7 +544,17 @@ async fn complete_and_persist(
     let store = if run.allow_plaintext {
         CredentialStore::plaintext()
     } else {
-        CredentialStore::new()
+        let store = CredentialStore::new();
+        if store.storage_backend() != "keyring" {
+            return Err(RedisCtlError::Structured(Box::new(
+                StructuredError::keyring_unavailable(
+                    "no OS keyring is available to store the credentials, and storing them in \
+                     the config file has to be asked for. Re-run with `--allow-plaintext` to \
+                     store them there (0600) instead.",
+                ),
+            )));
+        }
+        store
     };
     let mut config = conn_mgr.config.clone();
     // On the keyring path, a store failure means the OS secret service is unavailable (D4):
@@ -564,11 +574,11 @@ async fn complete_and_persist(
                 RedisCtlError::Structured(Box::new(StructuredError::keyring_unavailable(format!(
                     "failed to store credentials in the OS keyring ({e}). Re-run \
                      `redisctl cloud auth login --allow-plaintext` to store them in the config \
-                     file instead."
+                     file (0600) instead."
                 ))))
             }
         })?;
-    save_config(conn_mgr, &config)?;
+    save_config_for_store(conn_mgr, &config, &store)?;
     Ok(creds)
 }
 
@@ -811,6 +821,9 @@ fn clear_pending(conn_mgr: &ConnectionManager, profile: &str) {
 fn write_private(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
     use std::io::Write as _;
     use std::os::unix::fs::OpenOptionsExt;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     let mut f = std::fs::OpenOptions::new()
         .write(true)
         .create(true)
@@ -822,6 +835,9 @@ fn write_private(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
 
 #[cfg(not(unix))]
 fn write_private(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     std::fs::write(path, bytes)
 }
 
@@ -835,6 +851,24 @@ fn save_config(conn_mgr: &ConnectionManager, config: &Config) -> CliResult<()> {
         Some(path) => config.save_to_path(path)?,
         None => config.save()?,
     }
+    Ok(())
+}
+
+/// Save after a login. A plaintext store has just put the CAPI secret in this file, so it is
+/// written owner-only; the keyring path leaves permissions alone.
+fn save_config_for_store(
+    conn_mgr: &ConnectionManager,
+    config: &Config,
+    store: &CredentialStore,
+) -> CliResult<()> {
+    if store.storage_backend() == "keyring" {
+        return save_config(conn_mgr, config);
+    }
+    let path = match &conn_mgr.config_path {
+        Some(path) => path.clone(),
+        None => Config::config_path()?,
+    };
+    config.save_to_path_owner_only(&path)?;
     Ok(())
 }
 
@@ -885,6 +919,33 @@ mod tests {
                 name: None,
             },
         ]
+    }
+
+    /// The pending record lands next to the config, in a directory that does not exist on a
+    /// machine that has never run redisctl. Writing used to fail there with ENOENT *after* the
+    /// IdP had already issued a code, losing the code the user needs.
+    #[test]
+    fn write_private_creates_missing_parents() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir
+            .path()
+            .join("no")
+            .join("such")
+            .join("dir")
+            .join("p.json");
+        write_private(&path, b"{}").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"{}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_private_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("p.json");
+        write_private(&path, b"{}").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "got {mode:o}");
     }
 
     /// The listing shows both a position and an id, so both have to be accepted — and anything

--- a/crates/redisctl/src/workflows/cloud/quick_database.rs
+++ b/crates/redisctl/src/workflows/cloud/quick_database.rs
@@ -2,7 +2,8 @@
 //! [`redisctl_core::cloud::quick_database`].
 //!
 //! This layer owns only CLI concerns: clap arg parsing, the terminal spinner, and wrapping
-//! the [`QuickDatabaseReport`] into a [`WorkflowResult`]. The provisioning logic itself lives
+//! the [`QuickDatabaseReport`](redisctl_core::cloud::quick_database::QuickDatabaseReport) into a
+//! [`WorkflowResult`]. The provisioning logic itself lives
 //! in `redisctl-core` so the MCP server reuses it directly. Error → exit-code mapping lives
 //! in [`crate::structured_error`].
 

--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -39,7 +39,7 @@ redisctl cloud auth login --allow-plaintext
 |------|-------------|
 | `--device` | Use the device-authorization flow (print a URL + code) instead of opening a browser. |
 | `--wait` | With `--device`: block until approved (one-shot). Without it, `login --device` returns immediately and `auth status --wait` completes the login. |
-| `--allow-plaintext` | Store credentials in the config file when no OS keyring is available. |
+| `--allow-plaintext` | Store credentials in the config file (`0600`) when no OS keyring is available. Required when there is no keyring: without it, login refuses rather than writing them there silently. |
 | `--account <ID>` | Mint the key for this Redis Cloud account id. Defaults to your current account. Carried through the device flow, so `login --device --account <id>` still applies when `auth status --wait` completes it. |
 
 ### Browser (loopback) flow


### PR DESCRIPTION
Four defects around persisting a login, from a local review and the CSTOPS-2260 security audit.

## The device code was lost on a first run

`write_private` opened the pending record without creating its parent, and that parent is the
config directory — which does not exist on a machine that has never run redisctl. The IdP had
already issued a code by then, so `login --device` died and threw the code away unprinted:

```
code   : configuration
message: could not save pending login: No such file or directory (os error 2)
```

Device flow is selected automatically whenever stderr is not a TTY, so this was the agent path, in
a container, on first use.

## Credentials could be written in cleartext without asking

`CredentialStore::new()` falls back to plaintext when no keyring is available, so without
`--allow-plaintext` the CAPI secret went into `config.toml` anyway and the documented
`keyring_unavailable` could never fire. Login now refuses instead, naming the flag.

**This is a visible behaviour change:** where no keyring exists, a login that used to succeed
quietly now fails until the flag is passed. It is what the docs have always promised. Affected
machines are narrower than they look — Linux uses the kernel keyring (`linux-keyutils`) rather than
D-Bus, so headless boxes and plain containers do have one; it comes down to `keyctl` blocked by
seccomp, a kernel without `CONFIG_KEYS`, or some WSL setups.

## Cleartext credentials were world-readable

With a typical umask of 022 the config landed `0644`, so on a shared host or CI runner any local
user could read a plaintext CAPI secret, an Enterprise password or a Files.com key.

The login path now writes it `0600` when — and only when — the plaintext store is in use, i.e. when
it has just put a secret in that file, tightening an existing loose file. **`save_to_path` itself is
untouched**, so `profile set` and every other command keep their current behaviour rather than
having permissions changed out from under them by an auth fix.

`afd6ca6` removed the `0600` promise from the docs and the error message rather than implementing
it. Both say it again now, and it is true.

## Re-login discarded unrelated profile settings

`apply_cloud_login` built a fresh `Profile`, dropping `files_api_key` and any tags on every login
and every switch, while the profile-update path preserved them.

## Verification

| Check | Result |
|---|---|
| `cargo clippy --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo fmt --all --check` | clean |
| `cargo test --workspace --all-features` | 23 suites / 1157 tests (5 new) |
| `mkdocs build --strict` | exit 0 |

New tests cover field preservation, the fresh-profile case, owner-only saves including tightening
an existing `0644` file, and `write_private` creating parents.

## Not addressed here

Config saves still materialize `${ENV}` placeholders. Expansion happens on the raw TOML before
parsing, so the struct only ever holds expanded values; fixing it means expanding at use rather
than at load, which touches every credential consumer.

The keyring refusal has no test — it depends on the absence of an OS keyring, which neither a dev
machine nor CI provides. Verified by reading.

Separately worth knowing, and not a defect in this change: on Linux the kernel keyring is
documented as "a secure cache" that "will not persist across reboots", with the persistent keyring
expiring after "a few days". A stored key can therefore vanish, and how redisctl behaves when the
entry is gone has not been established.